### PR TITLE
Add `regexp/prefer-quantifier` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-useless-two-nums-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-two-nums-quantifier.html) | disallow unnecessary `{n,m}` quantifier | :star: |
 | [regexp/prefer-d](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-d.html) | enforce using `\d` | :star::wrench: |
 | [regexp/prefer-plus-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-plus-quantifier.html) | enforce using `+` quantifier | :star::wrench: |
+| [regexp/prefer-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-quantifier.html) | enforce using quantifier | :wrench: |
 | [regexp/prefer-question-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-question-quantifier.html) | enforce using `?` quantifier | :star::wrench: |
 | [regexp/prefer-star-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-star-quantifier.html) | enforce using `*` quantifier | :star::wrench: |
 | [regexp/prefer-t](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-t.html) | enforce using `\t` | :star::wrench: |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -24,6 +24,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-useless-two-nums-quantifier](./no-useless-two-nums-quantifier.md) | disallow unnecessary `{n,m}` quantifier | :star: |
 | [regexp/prefer-d](./prefer-d.md) | enforce using `\d` | :star::wrench: |
 | [regexp/prefer-plus-quantifier](./prefer-plus-quantifier.md) | enforce using `+` quantifier | :star::wrench: |
+| [regexp/prefer-quantifier](./prefer-quantifier.md) | enforce using quantifier | :wrench: |
 | [regexp/prefer-question-quantifier](./prefer-question-quantifier.md) | enforce using `?` quantifier | :star::wrench: |
 | [regexp/prefer-star-quantifier](./prefer-star-quantifier.md) | enforce using `*` quantifier | :star::wrench: |
 | [regexp/prefer-t](./prefer-t.md) | enforce using `\t` | :star::wrench: |

--- a/docs/rules/prefer-quantifier.md
+++ b/docs/rules/prefer-quantifier.md
@@ -1,0 +1,39 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "regexp/prefer-quantifier"
+description: "enforce using quantifier"
+---
+# regexp/prefer-quantifier
+
+> enforce using quantifier
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule is aimed to use quantifiers instead of consecutive characters in regular expressions.
+
+<eslint-code-block fix>
+
+```js
+/* eslint regexp/prefer-quantifier: "error" */
+
+/* ✓ GOOD */
+var foo = /\d{4}-\d{2}-\d{2}/;
+
+/* ✗ BAD */
+var foo = /\d\d\d\d-\d\d-\d\d/;
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/lib/rules/prefer-quantifier.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/tests/lib/rules/prefer-quantifier.ts)

--- a/lib/rules/match-any.ts
+++ b/lib/rules/match-any.ts
@@ -65,6 +65,7 @@ export default createRule("match-any", {
                         minItems: 1,
                     },
                 },
+                additionalProperties: false,
             },
         ],
         messages: {

--- a/lib/rules/prefer-quantifier.ts
+++ b/lib/rules/prefer-quantifier.ts
@@ -1,0 +1,207 @@
+import type { Expression } from "estree"
+import type { RegExpVisitor } from "regexpp/visitor"
+import type { Character, CharacterSet, Quantifier } from "regexpp/ast"
+import { createRule, defineRegexpVisitor, getRegexpRange } from "../utils"
+
+class CharBuffer {
+    public target: CharacterSet | Character
+
+    public min: number
+
+    public max: number
+
+    public elements: (CharacterSet | Character | Quantifier)[]
+
+    public equalChar: (element: CharacterSet | Character) => boolean
+
+    public constructor(
+        element: CharacterSet | Character | Quantifier,
+        target: CharacterSet | Character,
+    ) {
+        this.target = target
+        this.elements = [element]
+
+        if (element.type === "Quantifier") {
+            this.min = element.min
+            this.max = element.max
+        } else {
+            this.min = 1
+            this.max = 1
+        }
+        if (target.type === "CharacterSet") {
+            if (target.kind === "any") {
+                this.equalChar = (e) =>
+                    e.type === "CharacterSet" && e.kind === "any"
+            } else if (target.kind === "property") {
+                this.equalChar = (e) =>
+                    e.type === "CharacterSet" &&
+                    e.kind === "property" &&
+                    e.key === target.key &&
+                    e.value === target.value &&
+                    e.negate === target.negate
+            } else {
+                // Escape
+                this.equalChar = (e) =>
+                    e.type === "CharacterSet" &&
+                    e.kind === target.kind &&
+                    e.negate === target.negate
+            }
+        } else {
+            this.equalChar = (e) =>
+                e.type === "Character" && e.value === target.value
+        }
+    }
+
+    public addElement(element: CharacterSet | Character | Quantifier) {
+        this.elements.push(element)
+        if (element.type === "Quantifier") {
+            this.min += element.min
+            this.max += element.max
+        } else {
+            this.min += 1
+            this.max += 1
+        }
+    }
+
+    public getQuantifier(): string {
+        if (this.min === 0 && this.max === Number.POSITIVE_INFINITY) {
+            return "*"
+        } else if (this.min === 1 && this.max === Number.POSITIVE_INFINITY) {
+            return "+"
+        } else if (this.min === 0 && this.max === 1) {
+            return "?"
+        } else if (this.min === this.max) {
+            return `{${this.min}}`
+        } else if (this.max === Number.POSITIVE_INFINITY) {
+            return `{${this.min},}`
+        }
+        return `{${this.min},${this.max}}`
+    }
+}
+
+export default createRule("prefer-quantifier", {
+    meta: {
+        docs: {
+            description: "enforce using quantifier",
+            // TODO In the major version, it will be changed to "recommended".
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [],
+        messages: {
+            unexpected:
+                'Unexpected consecutive same {{type}}. Use "{{quantifier}}" instead.',
+        },
+        type: "suggestion", // "problem",
+    },
+    create(context) {
+        const sourceCode = context.getSourceCode()
+
+        /**
+         * Create visitor
+         * @param node
+         */
+        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+            return {
+                onAlternativeEnter(aNode) {
+                    let charBuffer: CharBuffer | null = null
+                    for (const element of aNode.elements) {
+                        let target: CharacterSet | Character
+                        if (
+                            element.type === "CharacterSet" ||
+                            element.type === "Character"
+                        ) {
+                            target = element
+                        } else if (element.type === "Quantifier") {
+                            if (
+                                element.element.type === "CharacterSet" ||
+                                element.element.type === "Character"
+                            ) {
+                                target = element.element
+                            } else {
+                                if (charBuffer) {
+                                    validateBuffer(charBuffer)
+                                    charBuffer = null
+                                }
+                                continue
+                            }
+                        } else {
+                            if (charBuffer) {
+                                validateBuffer(charBuffer)
+                                charBuffer = null
+                            }
+                            continue
+                        }
+                        if (charBuffer) {
+                            if (charBuffer.equalChar(target)) {
+                                charBuffer.addElement(element)
+                                continue
+                            }
+                            validateBuffer(charBuffer)
+                        }
+                        charBuffer = new CharBuffer(element, target)
+                    }
+                    if (charBuffer) {
+                        validateBuffer(charBuffer)
+                        charBuffer = null
+                    }
+
+                    /**
+                     * Validate
+                     */
+                    function validateBuffer(buffer: CharBuffer) {
+                        if (buffer.elements.length < 2) {
+                            return
+                        }
+                        const firstRange = getRegexpRange(
+                            sourceCode,
+                            node,
+                            buffer.elements[0],
+                        )
+                        const lastRange = getRegexpRange(
+                            sourceCode,
+                            node,
+                            buffer.elements[buffer.elements.length - 1],
+                        )
+                        let range: [number, number] | null = null
+                        if (firstRange && lastRange) {
+                            range = [firstRange[0], lastRange[1]]
+                        }
+                        context.report({
+                            node,
+                            loc: range
+                                ? {
+                                      start: sourceCode.getLocFromIndex(
+                                          range[0],
+                                      ),
+                                      end: sourceCode.getLocFromIndex(range[1]),
+                                  }
+                                : undefined,
+                            messageId: "unexpected",
+                            data: {
+                                type:
+                                    buffer.target.type === "Character"
+                                        ? "characters"
+                                        : "character sets",
+                                quantifier: buffer.getQuantifier(),
+                            },
+                            fix(fixer) {
+                                if (range == null) {
+                                    return null
+                                }
+                                return fixer.replaceTextRange(
+                                    range,
+                                    buffer.target.raw + buffer.getQuantifier(),
+                                )
+                            },
+                        })
+                    }
+                },
+            }
+        }
+
+        return defineRegexpVisitor(context, {
+            createVisitor,
+        })
+    },
+})

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -12,6 +12,7 @@ import noUselessExactlyQuantifier from "../rules/no-useless-exactly-quantifier"
 import noUselessTwoNumsQuantifier from "../rules/no-useless-two-nums-quantifier"
 import preferD from "../rules/prefer-d"
 import preferPlusQuantifier from "../rules/prefer-plus-quantifier"
+import preferQuantifier from "../rules/prefer-quantifier"
 import preferQuestionQuantifier from "../rules/prefer-question-quantifier"
 import preferStarQuantifier from "../rules/prefer-star-quantifier"
 import preferT from "../rules/prefer-t"
@@ -31,6 +32,7 @@ export const rules = [
     noUselessTwoNumsQuantifier,
     preferD,
     preferPlusQuantifier,
+    preferQuantifier,
     preferQuestionQuantifier,
     preferStarQuantifier,
     preferT,

--- a/lib/utils/unicode.ts
+++ b/lib/utils/unicode.ts
@@ -80,6 +80,17 @@ function isCodePointInRange(
 export function isDigit(codePoint: number): boolean {
     return isCodePointInRange(codePoint, CP_RANGE_DIGIT)
 }
+/**
+ * Checks if the given code point is letter.
+ * @param codePoint The code point to check
+ * @returns {boolean} `true` if the given code point is letter.
+ */
+export function isLetter(codePoint: number): boolean {
+    return (
+        isCodePointInRange(codePoint, CP_RANGE_SMALL_LETTER) ||
+        isCodePointInRange(codePoint, CP_RANGE_CAPITAL_LETTER)
+    )
+}
 
 /**
  * Checks if the given code point is space.

--- a/tests/lib/rules/prefer-quantifier.ts
+++ b/tests/lib/rules/prefer-quantifier.ts
@@ -1,0 +1,76 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/prefer-quantifier"
+
+const tester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+})
+
+tester.run("prefer-quantifier", rule as any, {
+    valid: [`/regexp/`, `/\\d_\\d/`],
+    invalid: [
+        {
+            code: `/\\d\\d/`,
+            output: `/\\d{2}/`,
+            errors: [
+                {
+                    message:
+                        'Unexpected consecutive same character sets. Use "{2}" instead.',
+                    line: 1,
+                    column: 2,
+                    endColumn: 6,
+                },
+            ],
+        },
+        {
+            code: `/aa/`,
+            output: `/a{2}/`,
+            errors: [
+                {
+                    message:
+                        'Unexpected consecutive same characters. Use "{2}" instead.',
+                    line: 1,
+                    column: 2,
+                    endColumn: 4,
+                },
+            ],
+        },
+        {
+            code: `/\\d\\d?/`,
+            output: `/\\d{1,2}/`,
+            errors: [
+                {
+                    message:
+                        'Unexpected consecutive same character sets. Use "{1,2}" instead.',
+                    line: 1,
+                    column: 2,
+                    endColumn: 7,
+                },
+            ],
+        },
+        {
+            code: `/(\\d\\d\\d*)/`,
+            output: `/(\\d{2,})/`,
+            errors: [
+                {
+                    message:
+                        'Unexpected consecutive same character sets. Use "{2,}" instead.',
+                    line: 1,
+                    column: 3,
+                    endColumn: 10,
+                },
+            ],
+        },
+        {
+            code: String.raw`/\d\d\d\d-\d\d-\d\d/`,
+            output: String.raw`/\d{4}-\d{2}-\d{2}/`,
+            errors: [
+                'Unexpected consecutive same character sets. Use "{4}" instead.',
+                'Unexpected consecutive same character sets. Use "{2}" instead.',
+                'Unexpected consecutive same character sets. Use "{2}" instead.',
+            ],
+        },
+    ],
+})

--- a/tests/lib/rules/prefer-quantifier.ts
+++ b/tests/lib/rules/prefer-quantifier.ts
@@ -9,7 +9,7 @@ const tester = new RuleTester({
 })
 
 tester.run("prefer-quantifier", rule as any, {
-    valid: [`/regexp/`, `/\\d_\\d/`],
+    valid: [`/regexp/`, `/\\d_\\d/`, `/Google/`, `/2000/`],
     invalid: [
         {
             code: `/\\d\\d/`,
@@ -25,8 +25,8 @@ tester.run("prefer-quantifier", rule as any, {
             ],
         },
         {
-            code: `/aa/`,
-            output: `/a{2}/`,
+            code: `/__/`,
+            output: `/_{2}/`,
             errors: [
                 {
                     message:
@@ -73,8 +73,8 @@ tester.run("prefer-quantifier", rule as any, {
             ],
         },
         {
-            code: String.raw`/aa..\s\s\S\S\p{ASCII}\p{ASCII}/u`,
-            output: String.raw`/a{2}..\s{2}\S\S\p{ASCII}{2}/u`,
+            code: String.raw`/__..\s\s\S\S\p{ASCII}\p{ASCII}/u`,
+            output: String.raw`/_{2}..\s{2}\S\S\p{ASCII}{2}/u`,
             errors: [
                 'Unexpected consecutive same characters. Use "{2}" instead.',
                 'Unexpected consecutive same character sets. Use "{2}" instead.',

--- a/tests/lib/rules/prefer-quantifier.ts
+++ b/tests/lib/rules/prefer-quantifier.ts
@@ -72,5 +72,62 @@ tester.run("prefer-quantifier", rule as any, {
                 'Unexpected consecutive same character sets. Use "{2}" instead.',
             ],
         },
+        {
+            code: String.raw`/aa..\s\s\S\S\p{ASCII}\p{ASCII}/u`,
+            output: String.raw`/a{2}..\s{2}\S\S\p{ASCII}{2}/u`,
+            errors: [
+                'Unexpected consecutive same characters. Use "{2}" instead.',
+                'Unexpected consecutive same character sets. Use "{2}" instead.',
+                'Unexpected consecutive same character sets. Use "{2}" instead.',
+                'Unexpected consecutive same character sets. Use "{2}" instead.',
+                'Unexpected consecutive same character sets. Use "{2}" instead.',
+            ],
+        },
+        {
+            code: `/aaaa(aaa)/u`,
+            output: `/a{4}(a{3})/u`,
+            errors: [
+                'Unexpected consecutive same characters. Use "{4}" instead.',
+                'Unexpected consecutive same characters. Use "{3}" instead.',
+            ],
+        },
+        {
+            code: `/(b)?aaaa(b)?/u`,
+            output: `/(b)?a{4}(b)?/u`,
+            errors: [
+                'Unexpected consecutive same characters. Use "{4}" instead.',
+            ],
+        },
+        {
+            code: `
+            const s = "\\\\d\\\\d"
+            new RegExp(s)
+            `,
+            output: null,
+            errors: [
+                'Unexpected consecutive same character sets. Use "{2}" instead.',
+            ],
+        },
+        {
+            code: `/aa*/`,
+            output: `/a+/`,
+            errors: [
+                'Unexpected consecutive same characters. Use "+" instead.',
+            ],
+        },
+        {
+            code: `/a*a*/`,
+            output: `/a*/`,
+            errors: [
+                'Unexpected consecutive same characters. Use "*" instead.',
+            ],
+        },
+        {
+            code: `/a?a?a?/`,
+            output: `/a{0,3}/`,
+            errors: [
+                'Unexpected consecutive same characters. Use "{0,3}" instead.',
+            ],
+        },
     ],
 })

--- a/tools/new-rule.ts
+++ b/tools/new-rule.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import fs from "fs"
+import cp from "child_process"
 const logger = console
 
 // main
@@ -129,4 +130,8 @@ This rule reports ???.
 
 `,
     )
+
+    cp.execSync(`code "${ruleFile}"`)
+    cp.execSync(`code "${testFile}"`)
+    cp.execSync(`code "${docFile}"`)
 })(process.argv[2])


### PR DESCRIPTION
This PR adds `regexp/prefer-quantifier` rule.
`regexp/prefer-quantifier` rule is aimed to use quantifiers instead of consecutive characters in regular expressions.