### PR TITLE
Fix false positives for character classes with no matching characters in `regexp/match-any` rule.

### DIFF
--- a/lib/rules/match-any.ts
+++ b/lib/rules/match-any.ts
@@ -160,7 +160,11 @@ export default createRule("match-any", {
                         }
                         return
                     }
-                    if (characterClassData && !characterClassData.reported) {
+                    if (
+                        characterClassData &&
+                        !characterClassData.reported &&
+                        !characterClassData.node.negate
+                    ) {
                         const key = getCharacterSetKey(csNode)
                         const alreadyCharSet = characterClassData.charSets.get(
                             key,
@@ -213,7 +217,8 @@ export default createRule("match-any", {
                     ) {
                         if (
                             characterClassData &&
-                            !characterClassData.reported
+                            !characterClassData.reported &&
+                            !characterClassData.node.negate
                         ) {
                             const ccNode = characterClassData.node
                             context.report({

--- a/tests/lib/rules/match-any.ts
+++ b/tests/lib/rules/match-any.ts
@@ -28,6 +28,19 @@ tester.run("match-any", rule as any, {
             code: "/[\\s\\S][\\S\\s][^]./s",
             options: [{ allows: ["[\\s\\S]", "[\\S\\s]", "[^]", "dotAll"] }],
         },
+        "/[^\\S\\s]/",
+        {
+            code: "/[^\\s\\S]/",
+            options: [{ allows: ["[^]"] }],
+        },
+        "/[^\\d\\D]/",
+        "/[^\\D\\d]/",
+        "/[^\\w\\W]/",
+        "/[^\\W\\w]/",
+        "/[^\\0-\\uFFFF]/",
+        "/[^\\p{ASCII}\\P{ASCII}]/u",
+        "/[^\\P{ASCII}\\p{ASCII}]/u",
+        "/[^\\s\\S\\0-\\uFFFF]/",
     ],
     invalid: [
         {
@@ -133,11 +146,6 @@ tester.run("match-any", rule as any, {
                 'Unexpected using "[\\S\\s]" to match any character.',
                 'Unexpected using "." to match any character.',
             ],
-        },
-        {
-            code: "/[^\\s\\S]/",
-            output: "/[\\s\\S]/",
-            errors: ['Unexpected using "[^\\s\\S]" to match any character.'],
         },
         {
             code: "/[\\p{ASCII}\\P{ASCII}]/u",


### PR DESCRIPTION
fixes #85