### PR TITLE
Fixed `match-any` false negatives and improved fixer

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -17,6 +17,7 @@ import {
 import type { Rule, AST, SourceCode } from "eslint"
 import { parseStringTokens } from "./string-literal-parser"
 import { findVariable } from "./ast-utils"
+import type { ReadonlyFlags } from "regexp-ast-analysis"
 export * from "./unicode"
 
 type RegexpRule = {
@@ -41,6 +42,28 @@ export const FLAG_IGNORECASE = "i"
 export const FLAG_MULTILINE = "m"
 export const FLAG_STICKY = "y"
 export const FLAG_UNICODE = "u"
+
+const flagsCache = new Map<string, ReadonlyFlags>()
+/**
+ * Given some flags, this will return a parsed flags object.
+ *
+ * Non-standard flags will be ignored.
+ */
+export function parseFlags(flags: string): ReadonlyFlags {
+    let cached = flagsCache.get(flags)
+    if (cached === undefined) {
+        cached = {
+            dotAll: flags.includes(FLAG_DOTALL),
+            global: flags.includes(FLAG_GLOBAL),
+            ignoreCase: flags.includes(FLAG_IGNORECASE),
+            multiline: flags.includes(FLAG_MULTILINE),
+            sticky: flags.includes(FLAG_STICKY),
+            unicode: flags.includes(FLAG_UNICODE),
+        }
+        flagsCache.set(flags, cached)
+    }
+    return cached
+}
 
 /**
  * Define the rule.

--- a/tests/lib/rules/match-any.ts
+++ b/tests/lib/rules/match-any.ts
@@ -109,8 +109,8 @@ tester.run("match-any", rule as any, {
             ],
         },
         {
-            code: "/[\\s\\S][\\S\\s][^]./s",
-            output: null,
+            code: "/[\\s\\S] [\\S\\s] [^] ./s",
+            output: "/. . . ./s",
             options: [{ allows: ["dotAll"] }],
             errors: [
                 'Unexpected using "[\\s\\S]" to match any character.',
@@ -166,6 +166,18 @@ tester.run("match-any", rule as any, {
             output: "/[\\s\\S]/",
             errors: [
                 'Unexpected using "[\\s\\S\\0-\\uFFFF]" to match any character.',
+            ],
+        },
+        {
+            code: "/[\\w\\D]/",
+            output: "/[\\s\\S]/",
+            errors: ['Unexpected using "[\\w\\D]" to match any character.'],
+        },
+        {
+            code: "/[\\P{ASCII}\\w\\0-AZ-\\xFF]/u",
+            output: "/[\\s\\S]/u",
+            errors: [
+                'Unexpected using "[\\P{ASCII}\\w\\0-AZ-\\xFF]" to match any character.',
             ],
         },
     ],


### PR DESCRIPTION
- The rule now uses `matchesAllCharacters` for detection
- The fixer can now fix `dotAll` as well.
- New `parseFlags` function.