### PR TITLE
Extracted common fix logic into functions

### DIFF
--- a/lib/rules/letter-case.ts
+++ b/lib/rules/letter-case.ts
@@ -4,9 +4,8 @@ import type { Character, CharacterClassRange } from "regexpp/ast"
 import {
     createRule,
     defineRegexpVisitor,
-    fixerApplyEscape,
+    fixReplaceNode,
     getRegexpLocation,
-    getRegexpRange,
     isLetter,
     isLowercaseLetter,
     isUppercaseLetter,
@@ -107,17 +106,9 @@ export default createRule("letter-case", {
                     char: reportNode.raw,
                     case: letterCase,
                 },
-                fix(fixer) {
-                    const range = getRegexpRange(sourceCode, node, reportNode)
-                    if (range == null) {
-                        return null
-                    }
-                    const newText = convertText(CONVERTER[letterCase])
-                    return fixer.replaceTextRange(
-                        range,
-                        fixerApplyEscape(newText, node),
-                    )
-                },
+                fix: fixReplaceNode(sourceCode, node, reportNode, () =>
+                    convertText(CONVERTER[letterCase]),
+                ),
             })
         }
 

--- a/lib/rules/negation.ts
+++ b/lib/rules/negation.ts
@@ -7,9 +7,8 @@ import type { RegExpVisitor } from "regexpp/visitor"
 import {
     createRule,
     defineRegexpVisitor,
-    fixerApplyEscape,
+    fixReplaceNode,
     getRegexpLocation,
-    getRegexpRange,
 } from "../utils"
 
 export default createRule("negation", {
@@ -49,20 +48,12 @@ export default createRule("negation", {
                             loc: getRegexpLocation(sourceCode, node, ccNode),
                             messageId: "unexpected",
                             data: { negatedCharSet },
-                            fix(fixer) {
-                                const range = getRegexpRange(
-                                    sourceCode,
-                                    node,
-                                    ccNode,
-                                )
-                                if (range == null) {
-                                    return null
-                                }
-                                return fixer.replaceTextRange(
-                                    range,
-                                    fixerApplyEscape(negatedCharSet, node),
-                                )
-                            },
+                            fix: fixReplaceNode(
+                                sourceCode,
+                                node,
+                                ccNode,
+                                negatedCharSet,
+                            ),
                         })
                     }
                 },

--- a/lib/rules/no-useless-character-class.ts
+++ b/lib/rules/no-useless-character-class.ts
@@ -4,9 +4,8 @@ import {
     canUnwrapped,
     createRule,
     defineRegexpVisitor,
-    fixerApplyEscape,
+    fixReplaceNode,
     getRegexpLocation,
-    getRegexpRange,
 } from "../utils"
 
 export default createRule("no-useless-character-class", {
@@ -113,15 +112,7 @@ export default createRule("no-useless-character-class", {
                                     ? " and range"
                                     : "",
                         },
-                        fix(fixer) {
-                            const range = getRegexpRange(
-                                sourceCode,
-                                node,
-                                ccNode,
-                            )
-                            if (range == null) {
-                                return null
-                            }
+                        fix: fixReplaceNode(sourceCode, node, ccNode, () => {
                             let text: string =
                                 element.type === "CharacterClassRange"
                                     ? element.min.raw
@@ -137,11 +128,8 @@ export default createRule("no-useless-character-class", {
                                     text = `\\${text}`
                                 }
                             }
-                            return fixer.replaceTextRange(
-                                range,
-                                fixerApplyEscape(text, node),
-                            )
-                        },
+                            return text
+                        }),
                     })
                 },
             }

--- a/lib/rules/no-useless-range.ts
+++ b/lib/rules/no-useless-range.ts
@@ -3,9 +3,8 @@ import type { RegExpVisitor } from "regexpp/visitor"
 import {
     createRule,
     defineRegexpVisitor,
-    fixerApplyEscape,
+    fixReplaceNode,
     getRegexpLocation,
-    getRegexpRange,
 } from "../utils"
 
 export default createRule("no-useless-range", {
@@ -44,15 +43,7 @@ export default createRule("no-useless-range", {
                         node,
                         loc: getRegexpLocation(sourceCode, node, ccrNode),
                         messageId: "unexpected",
-                        fix(fixer) {
-                            const range = getRegexpRange(
-                                sourceCode,
-                                node,
-                                ccrNode,
-                            )
-                            if (range == null) {
-                                return null
-                            }
+                        fix: fixReplaceNode(sourceCode, node, ccrNode, () => {
                             let text =
                                 ccrNode.min.value < ccrNode.max.value
                                     ? ccrNode.min.raw + ccrNode.max.raw
@@ -68,10 +59,10 @@ export default createRule("no-useless-range", {
                                 next.type === "Character" &&
                                 next.raw === "-"
                             ) {
-                                text += fixerApplyEscape("\\", node)
+                                text += "\\"
                             }
-                            return fixer.replaceTextRange(range, text)
-                        },
+                            return text
+                        }),
                     })
                 },
             }

--- a/lib/rules/prefer-d.ts
+++ b/lib/rules/prefer-d.ts
@@ -7,8 +7,7 @@ import {
     CP_DIGIT_ZERO,
     CP_DIGIT_NINE,
     getRegexpLocation,
-    getRegexpRange,
-    fixerApplyEscape,
+    fixReplaceNode,
 } from "../utils"
 
 export default createRule("prefer-d", {
@@ -65,20 +64,12 @@ export default createRule("prefer-d", {
                                 expr: reportNode.raw,
                                 instead,
                             },
-                            fix(fixer) {
-                                const range = getRegexpRange(
-                                    sourceCode,
-                                    node,
-                                    reportNode,
-                                )
-                                if (range == null) {
-                                    return null
-                                }
-                                return fixer.replaceTextRange(
-                                    range,
-                                    fixerApplyEscape(instead, node),
-                                )
-                            },
+                            fix: fixReplaceNode(
+                                sourceCode,
+                                node,
+                                reportNode,
+                                instead,
+                            ),
                         })
                     }
                 },

--- a/lib/rules/prefer-plus-quantifier.ts
+++ b/lib/rules/prefer-plus-quantifier.ts
@@ -4,8 +4,8 @@ import {
     createRule,
     defineRegexpVisitor,
     getRegexpLocation,
-    getRegexpRange,
     getQuantifierOffsets,
+    fixReplaceQuant,
 } from "../utils"
 
 export default createRule("prefer-plus-quantifier", {
@@ -49,23 +49,12 @@ export default createRule("prefer-plus-quantifier", {
                                 data: {
                                     expr: text,
                                 },
-                                fix(fixer) {
-                                    const range = getRegexpRange(
-                                        sourceCode,
-                                        node,
-                                        qNode,
-                                    )
-                                    if (range == null) {
-                                        return null
-                                    }
-                                    return fixer.replaceTextRange(
-                                        [
-                                            range[0] + startOffset,
-                                            range[0] + endOffset,
-                                        ],
-                                        "+",
-                                    )
-                                },
+                                fix: fixReplaceQuant(
+                                    sourceCode,
+                                    node,
+                                    qNode,
+                                    "+",
+                                ),
                             })
                         }
                     }

--- a/lib/rules/prefer-question-quantifier.ts
+++ b/lib/rules/prefer-question-quantifier.ts
@@ -6,8 +6,8 @@ import {
     defineRegexpVisitor,
     getRegexpLocation,
     getQuantifierOffsets,
-    getRegexpRange,
-    fixerApplyEscape,
+    fixReplaceQuant,
+    fixReplaceNode,
 } from "../utils"
 
 export default createRule("prefer-question-quantifier", {
@@ -53,23 +53,12 @@ export default createRule("prefer-question-quantifier", {
                                 data: {
                                     expr: text,
                                 },
-                                fix(fixer) {
-                                    const range = getRegexpRange(
-                                        sourceCode,
-                                        node,
-                                        qNode,
-                                    )
-                                    if (range == null) {
-                                        return null
-                                    }
-                                    return fixer.replaceTextRange(
-                                        [
-                                            range[0] + startOffset,
-                                            range[0] + endOffset,
-                                        ],
-                                        "?",
-                                    )
-                                },
+                                fix: fixReplaceQuant(
+                                    sourceCode,
+                                    node,
+                                    qNode,
+                                    "?",
+                                ),
                             })
                         }
                     }
@@ -125,20 +114,12 @@ export default createRule("prefer-question-quantifier", {
                                 expr: reportNode.raw,
                                 instead,
                             },
-                            fix(fixer) {
-                                const range = getRegexpRange(
-                                    sourceCode,
-                                    node,
-                                    reportNode,
-                                )
-                                if (range == null) {
-                                    return null
-                                }
-                                return fixer.replaceTextRange(
-                                    range,
-                                    fixerApplyEscape(instead, node),
-                                )
-                            },
+                            fix: fixReplaceNode(
+                                sourceCode,
+                                node,
+                                reportNode,
+                                instead,
+                            ),
                         })
                     }
                 },

--- a/lib/rules/prefer-star-quantifier.ts
+++ b/lib/rules/prefer-star-quantifier.ts
@@ -4,8 +4,8 @@ import {
     createRule,
     defineRegexpVisitor,
     getRegexpLocation,
-    getRegexpRange,
     getQuantifierOffsets,
+    fixReplaceQuant,
 } from "../utils"
 
 export default createRule("prefer-star-quantifier", {
@@ -49,23 +49,12 @@ export default createRule("prefer-star-quantifier", {
                                 data: {
                                     expr: text,
                                 },
-                                fix(fixer) {
-                                    const range = getRegexpRange(
-                                        sourceCode,
-                                        node,
-                                        qNode,
-                                    )
-                                    if (range == null) {
-                                        return null
-                                    }
-                                    return fixer.replaceTextRange(
-                                        [
-                                            range[0] + startOffset,
-                                            range[0] + endOffset,
-                                        ],
-                                        "*",
-                                    )
-                                },
+                                fix: fixReplaceQuant(
+                                    sourceCode,
+                                    node,
+                                    qNode,
+                                    "*",
+                                ),
                             })
                         }
                     }

--- a/lib/rules/prefer-t.ts
+++ b/lib/rules/prefer-t.ts
@@ -4,9 +4,8 @@ import {
     createRule,
     defineRegexpVisitor,
     getRegexpLocation,
-    getRegexpRange,
     CP_TAB,
-    fixerApplyEscape,
+    fixReplaceNode,
 } from "../utils"
 
 export default createRule("prefer-t", {
@@ -47,20 +46,7 @@ export default createRule("prefer-t", {
                             data: {
                                 expr: cNode.raw,
                             },
-                            fix(fixer) {
-                                const range = getRegexpRange(
-                                    sourceCode,
-                                    node,
-                                    cNode,
-                                )
-                                if (range == null) {
-                                    return null
-                                }
-                                return fixer.replaceTextRange(
-                                    range,
-                                    fixerApplyEscape("\\t", node),
-                                )
-                            },
+                            fix: fixReplaceNode(sourceCode, node, cNode, "\\t"),
                         })
                     }
                 },

--- a/lib/rules/prefer-unicode-codepoint-escapes.ts
+++ b/lib/rules/prefer-unicode-codepoint-escapes.ts
@@ -3,9 +3,8 @@ import type { RegExpVisitor } from "regexpp/visitor"
 import {
     createRule,
     defineRegexpVisitor,
-    fixerApplyEscape,
+    fixReplaceNode,
     getRegexpLocation,
-    getRegexpRange,
 } from "../utils"
 
 export default createRule("prefer-unicode-codepoint-escapes", {
@@ -46,26 +45,22 @@ export default createRule("prefer-unicode-codepoint-escapes", {
                                 node,
                                 loc: getRegexpLocation(sourceCode, node, cNode),
                                 messageId: "disallowSurrogatePair",
-                                fix(fixer) {
-                                    const range = getRegexpRange(
-                                        sourceCode,
-                                        node,
-                                        cNode,
-                                    )
-                                    if (range == null) {
-                                        return null
-                                    }
-                                    let text = String.fromCodePoint(cNode.value)
-                                        .codePointAt(0)!
-                                        .toString(16)
-                                    if (/[A-F]/.test(cNode.raw)) {
-                                        text = text.toUpperCase()
-                                    }
-                                    return fixer.replaceTextRange(
-                                        range,
-                                        fixerApplyEscape(`\\u{${text}}`, node),
-                                    )
-                                },
+                                fix: fixReplaceNode(
+                                    sourceCode,
+                                    node,
+                                    cNode,
+                                    () => {
+                                        let text = String.fromCodePoint(
+                                            cNode.value,
+                                        )
+                                            .codePointAt(0)!
+                                            .toString(16)
+                                        if (/[A-F]/.test(cNode.raw)) {
+                                            text = text.toUpperCase()
+                                        }
+                                        return `\\u{${text}}`
+                                    },
+                                ),
                             })
                         }
                     }

--- a/lib/rules/prefer-w.ts
+++ b/lib/rules/prefer-w.ts
@@ -16,6 +16,7 @@ import {
     CP_LOW_LINE,
     FLAG_IGNORECASE,
     fixerApplyEscape,
+    fixReplaceNode,
 } from "../utils"
 
 /**
@@ -146,20 +147,12 @@ export default createRule("prefer-w", {
                                     expr: ccNode.raw,
                                     instead,
                                 },
-                                fix(fixer: Rule.RuleFixer) {
-                                    const range = getRegexpRange(
-                                        sourceCode,
-                                        node,
-                                        ccNode,
-                                    )
-                                    if (range == null) {
-                                        return null
-                                    }
-                                    return fixer.replaceTextRange(
-                                        range,
-                                        fixerApplyEscape(instead, node),
-                                    )
-                                },
+                                fix: fixReplaceNode(
+                                    sourceCode,
+                                    node,
+                                    ccNode,
+                                    instead,
+                                ),
                             })
                         } else {
                             context.report({


### PR DESCRIPTION
I noticed that many fix functions share a lot of code, so I extracted the shared logic into two functions: `fixReplaceNode` and `fixReplaceQuant`.

The new functions could also be used in `match-any` but I haven't used them there yet to avoid conflicts with #103. I will add this after #103.