### PR TITLE
Changed `no-octal` to report more octal escapes

### DIFF
--- a/lib/rules/no-octal.ts
+++ b/lib/rules/no-octal.ts
@@ -24,7 +24,26 @@ export default createRule("no-octal", {
         function createVisitor(node: Expression): RegExpVisitor.Handlers {
             return {
                 onCharacterEnter(cNode) {
-                    if (cNode.raw.startsWith("\\0") && cNode.raw !== "\\0") {
+                    if (cNode.raw === "\\0") {
+                        // \0 looks like a octal escape but is allowed
+                        return
+                    }
+                    if (!/^\\[0-7]+$/.test(cNode.raw)) {
+                        // not an octal escape
+                        return
+                    }
+
+                    const report =
+                        // always report octal escapes that look like \0
+                        cNode.raw.startsWith("\\0") ||
+                        // don't report octal escapes inside character classes
+                        // (e.g. [\4-\6]).
+                        !(
+                            cNode.parent.type === "CharacterClass" ||
+                            cNode.parent.type === "CharacterClassRange"
+                        )
+
+                    if (report) {
                         context.report({
                             node,
                             loc: getRegexpLocation(sourceCode, node, cNode),

--- a/tests/lib/rules/no-octal.ts
+++ b/tests/lib/rules/no-octal.ts
@@ -9,7 +9,7 @@ const tester = new RuleTester({
 })
 
 tester.run("no-octal", rule as any, {
-    valid: ["/\\0/", "/\\7/"],
+    valid: ["/\\0/", "/[\\7]/", "/[\\1-\\4]/"],
     invalid: [
         {
             code: "/\\07/",
@@ -32,6 +32,10 @@ tester.run("no-octal", rule as any, {
             ],
         },
         {
+            code: "/[\\077]/",
+            errors: [{ message: 'Unexpected octal escape sequence "\\077".' }],
+        },
+        {
             code: "/\\0777/",
             errors: [
                 {
@@ -40,6 +44,21 @@ tester.run("no-octal", rule as any, {
                     endColumn: 6,
                 },
             ],
+        },
+        {
+            code: "/\\7/",
+            errors: [{ message: 'Unexpected octal escape sequence "\\7".' }],
+        },
+        {
+            code: "/\\1\\2/",
+            errors: [
+                { message: 'Unexpected octal escape sequence "\\1".' },
+                { message: 'Unexpected octal escape sequence "\\2".' },
+            ],
+        },
+        {
+            code: "/()\\1\\2/",
+            errors: [{ message: 'Unexpected octal escape sequence "\\2".' }],
         },
     ],
 })


### PR DESCRIPTION
I changed `no-octal` to report all octal escapes outside of character classes and only octal escapes starting with `\0` inside character classes.

The `no-octal` rule is now even stricter than `clean-regex/no-octal-escape`. (That's good :) )

---

This resolves #102.

