### PR TITLE
Made `no-useless-two-nums-quantifier` fixable

### DIFF
--- a/lib/rules/no-useless-two-nums-quantifier.ts
+++ b/lib/rules/no-useless-two-nums-quantifier.ts
@@ -5,6 +5,7 @@ import {
     defineRegexpVisitor,
     getRegexpLocation,
     getQuantifierOffsets,
+    fixReplaceQuant,
 } from "../utils"
 
 export default createRule("no-useless-two-nums-quantifier", {
@@ -13,6 +14,7 @@ export default createRule("no-useless-two-nums-quantifier", {
             description: "disallow unnecessary `{n,m}` quantifier",
             recommended: true,
         },
+        fixable: "code",
         schema: [],
         messages: {
             unexpected: 'Unexpected quantifier "{{expr}}".',
@@ -47,6 +49,12 @@ export default createRule("no-useless-two-nums-quantifier", {
                             data: {
                                 expr: text,
                             },
+                            fix: fixReplaceQuant(
+                                sourceCode,
+                                node,
+                                qNode,
+                                `{${qNode.min}}`,
+                            ),
                         })
                     }
                 },

--- a/tests/lib/rules/no-useless-two-nums-quantifier.ts
+++ b/tests/lib/rules/no-useless-two-nums-quantifier.ts
@@ -13,6 +13,7 @@ tester.run("no-useless-two-nums-quantifier", rule as any, {
     invalid: [
         {
             code: "/a{1,1}/",
+            output: "/a{1}/",
             errors: [
                 {
                     message: 'Unexpected quantifier "{1,1}".',
@@ -23,11 +24,23 @@ tester.run("no-useless-two-nums-quantifier", rule as any, {
         },
         {
             code: "/a{42,42}/",
+            output: "/a{42}/",
             errors: ['Unexpected quantifier "{42,42}".'],
         },
         {
             code: "/a{042,42}/",
+            output: "/a{42}/",
             errors: ['Unexpected quantifier "{042,42}".'],
+        },
+        {
+            code: "/a{042,042}/",
+            output: "/a{42}/",
+            errors: ['Unexpected quantifier "{042,042}".'],
+        },
+        {
+            code: "/a{100,100}?/",
+            output: "/a{100}?/",
+            errors: ['Unexpected quantifier "{100,100}".'],
         },
     ],
 })


### PR DESCRIPTION
This makes `no-useless-two-nums-quantifier` compatible with `clean-regex/simple-constant-quantifier`.