### PR TITLE
`no-empty-lookarounds-assertion`: Better detection

### DIFF
--- a/docs/rules/no-empty-lookarounds-assertion.md
+++ b/docs/rules/no-empty-lookarounds-assertion.md
@@ -15,6 +15,25 @@ since: "v0.1.0"
 
 This rule reports empty lookahead assertion or empty lookbehind assertion.
 
+### What are _empty lookarounds_?
+
+An empty lookaround is a lookaround for which at least one path in the lookaround expression contains only elements that do not consume characters and do not assert characters. This means that the lookaround expression will trivially accept any input string.
+
+**Examples:**
+
+-   `(?=)`: One of simplest empty lookarounds.
+-   `(?=a*)`: It is possible for `a*` to not consume characters, therefore the lookahead is _empty_.
+-   `(?=a|b*)`: Only one path has to not consume characters. Since it is possible for `b*` to not consume characters, the lookahead is _empty_.
+-   `(?=a|$)`: This is **not** an empty lookaround. `$` does not _consume_ characters but it does _assert_ characters. Similarly, all other standard assertions (`\b`, `\B`, `^`) are also not empty.
+
+### Why are empty lookarounds a problem?
+
+Because empty lookarounds accept the empty string, they are essentially non-functional. They will always trivially reject/accept.
+
+E.g. `(?=b?)\w` will match `a` just fine. `(?=b?)` will always trivially accept no matter the input string. The same also happens for negated lookarounds but they will trivially reject. E.g. `(?!b?)\w` won't match any input strings.
+
+The only way to fix empty lookarounds is to either remove them or to rewrite the lookaround expression to be non-empty.
+
 <eslint-code-block>
 
 ```js
@@ -31,6 +50,8 @@ var foo = /x(?=)/;
 var foo = /x(?!)/;
 var foo = /(?<=)x/;
 var foo = /(?<!)x/;
+var foo = /(?=b?)\w/;
+var foo = /(?!b?)\w/;
 ```
 
 </eslint-code-block>

--- a/lib/rules/no-empty-lookarounds-assertion.ts
+++ b/lib/rules/no-empty-lookarounds-assertion.ts
@@ -1,4 +1,5 @@
 import type { Expression } from "estree"
+import { isPotentiallyEmpty } from "regexp-ast-analysis"
 import type { RegExpVisitor } from "regexpp/visitor"
 import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
 
@@ -11,8 +12,8 @@ export default createRule("no-empty-lookarounds-assertion", {
         },
         schema: [],
         messages: {
-            unexpectedLookahead: "Unexpected empty lookahead.",
-            unexpectedLookbehind: "Unexpected empty lookbehind.",
+            unexpected:
+                "Unexpected empty {{kind}}. It will trivially {{result}} all inputs.",
         },
         type: "suggestion",
     },
@@ -32,18 +33,16 @@ export default createRule("no-empty-lookarounds-assertion", {
                     ) {
                         return
                     }
-                    if (
-                        aNode.alternatives.every(
-                            (alt) => alt.elements.length === 0,
-                        )
-                    ) {
+
+                    if (isPotentiallyEmpty(aNode.alternatives)) {
                         context.report({
                             node,
                             loc: getRegexpLocation(sourceCode, node, aNode),
-                            messageId:
-                                aNode.kind === "lookahead"
-                                    ? "unexpectedLookahead"
-                                    : "unexpectedLookbehind",
+                            messageId: "unexpected",
+                            data: {
+                                kind: aNode.kind,
+                                result: aNode.negate ? "reject" : "accept",
+                            },
                         })
                     }
                 },

--- a/tests/lib/rules/no-empty-lookarounds-assertion.ts
+++ b/tests/lib/rules/no-empty-lookarounds-assertion.ts
@@ -14,19 +14,20 @@ tester.run("no-empty-lookarounds-assertion", rule as any, {
         "/x(?!y)/",
         "/(?<=y)x/",
         "/(?<!y)x/",
-        "/x(?=y|)/",
-        "/x(?!y|)/",
-        "/(?<=y|)x/",
-        "/(?<!y|)x/",
         "/(^)x/",
         "/x($)/",
+        "/(?=(?=.).*)/",
+        "/(?=$|a)/",
+        "/(?=\\ba*\\b)/",
+        '/b?r(#*)"(?:[^"]|"(?!\\1))*"\\1/',
     ],
     invalid: [
         {
             code: "/x(?=)/",
             errors: [
                 {
-                    message: "Unexpected empty lookahead.",
+                    message:
+                        "Unexpected empty lookahead. It will trivially accept all inputs.",
                     column: 3,
                     endColumn: 7,
                 },
@@ -36,7 +37,8 @@ tester.run("no-empty-lookarounds-assertion", rule as any, {
             code: "/x(?!)/",
             errors: [
                 {
-                    message: "Unexpected empty lookahead.",
+                    message:
+                        "Unexpected empty lookahead. It will trivially reject all inputs.",
                     column: 3,
                     endColumn: 7,
                 },
@@ -46,7 +48,8 @@ tester.run("no-empty-lookarounds-assertion", rule as any, {
             code: "/(?<=)x/",
             errors: [
                 {
-                    message: "Unexpected empty lookbehind.",
+                    message:
+                        "Unexpected empty lookbehind. It will trivially accept all inputs.",
                     column: 2,
                     endColumn: 7,
                 },
@@ -56,7 +59,8 @@ tester.run("no-empty-lookarounds-assertion", rule as any, {
             code: "/(?<!)x/",
             errors: [
                 {
-                    message: "Unexpected empty lookbehind.",
+                    message:
+                        "Unexpected empty lookbehind. It will trivially reject all inputs.",
                     column: 2,
                     endColumn: 7,
                 },
@@ -66,7 +70,8 @@ tester.run("no-empty-lookarounds-assertion", rule as any, {
             code: "/x(?=|)/",
             errors: [
                 {
-                    message: "Unexpected empty lookahead.",
+                    message:
+                        "Unexpected empty lookahead. It will trivially accept all inputs.",
                     column: 3,
                     endColumn: 8,
                 },
@@ -76,7 +81,8 @@ tester.run("no-empty-lookarounds-assertion", rule as any, {
             code: "/x(?!|)/",
             errors: [
                 {
-                    message: "Unexpected empty lookahead.",
+                    message:
+                        "Unexpected empty lookahead. It will trivially reject all inputs.",
                     column: 3,
                     endColumn: 8,
                 },
@@ -86,7 +92,8 @@ tester.run("no-empty-lookarounds-assertion", rule as any, {
             code: "/(?<=|)x/",
             errors: [
                 {
-                    message: "Unexpected empty lookbehind.",
+                    message:
+                        "Unexpected empty lookbehind. It will trivially accept all inputs.",
                     column: 2,
                     endColumn: 8,
                 },
@@ -96,9 +103,74 @@ tester.run("no-empty-lookarounds-assertion", rule as any, {
             code: "/(?<!|)x/",
             errors: [
                 {
-                    message: "Unexpected empty lookbehind.",
+                    message:
+                        "Unexpected empty lookbehind. It will trivially reject all inputs.",
                     column: 2,
                     endColumn: 8,
+                },
+            ],
+        },
+
+        {
+            code: "/x(?=y|)/",
+            errors: [
+                {
+                    message:
+                        "Unexpected empty lookahead. It will trivially accept all inputs.",
+                    column: 3,
+                    endColumn: 9,
+                },
+            ],
+        },
+        {
+            code: "/x(?!y|)/",
+            errors: [
+                {
+                    message:
+                        "Unexpected empty lookahead. It will trivially reject all inputs.",
+                    column: 3,
+                    endColumn: 9,
+                },
+            ],
+        },
+        {
+            code: "/(?<=y|)x/",
+            errors: [
+                {
+                    message:
+                        "Unexpected empty lookbehind. It will trivially accept all inputs.",
+                    column: 2,
+                    endColumn: 9,
+                },
+            ],
+        },
+        {
+            code: "/(?<!y|)x/",
+            errors: [
+                {
+                    message:
+                        "Unexpected empty lookbehind. It will trivially reject all inputs.",
+                    column: 2,
+                    endColumn: 9,
+                },
+            ],
+        },
+
+        {
+            code: "/(?=a*)/",
+            errors: [
+                {
+                    message:
+                        "Unexpected empty lookahead. It will trivially accept all inputs.",
+                },
+            ],
+        },
+        {
+            code: "/(?=a|b*)/",
+            errors: [
+                {
+                    message:
+                        "Unexpected empty lookahead. It will trivially accept all inputs.",
                 },
             ],
         },


### PR DESCRIPTION
It now uses the same detection method as `clean-regex/no-empty-lookaround`. 

I also made the error messages a little longer and added more docs as to why empty lookarounds are a problem.