### PR TITLE
Added `regexp/no-trivially-nested-assertion` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-lazy-ends](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-lazy-ends.html) | disallow lazy quantifiers at the end of an expression |  |
 | [regexp/no-legacy-features](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-legacy-features.html) | disallow legacy RegExp features |  |
 | [regexp/no-octal](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-octal.html) | disallow octal escape sequence | :star: |
-| [regexp/no-trivially-nested-assertion](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-trivially-nested-assertion.html) | disallow trivially nested assertions | :star::wrench: |
+| [regexp/no-trivially-nested-assertion](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-trivially-nested-assertion.html) | disallow trivially nested assertions | :wrench: |
 | [regexp/no-unused-capturing-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-unused-capturing-group.html) | disallow unused capturing group |  |
 | [regexp/no-useless-backreference](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-backreference.html) | disallow useless backreferences in regular expressions |  |
 | [regexp/no-useless-character-class](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-character-class.html) | disallow character class with one character | :wrench: |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-lazy-ends](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-lazy-ends.html) | disallow lazy quantifiers at the end of an expression |  |
 | [regexp/no-legacy-features](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-legacy-features.html) | disallow legacy RegExp features |  |
 | [regexp/no-octal](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-octal.html) | disallow octal escape sequence | :star: |
+| [regexp/no-trivially-nested-assertion](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-trivially-nested-assertion.html) | disallow trivially nested assertions | :star::wrench: |
 | [regexp/no-unused-capturing-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-unused-capturing-group.html) | disallow unused capturing group |  |
 | [regexp/no-useless-backreference](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-backreference.html) | disallow useless backreferences in regular expressions |  |
 | [regexp/no-useless-character-class](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-character-class.html) | disallow character class with one character | :wrench: |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -26,7 +26,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-lazy-ends](./no-lazy-ends.md) | disallow lazy quantifiers at the end of an expression |  |
 | [regexp/no-legacy-features](./no-legacy-features.md) | disallow legacy RegExp features |  |
 | [regexp/no-octal](./no-octal.md) | disallow octal escape sequence | :star: |
-| [regexp/no-trivially-nested-assertion](./no-trivially-nested-assertion.md) | disallow trivially nested assertions | :star::wrench: |
+| [regexp/no-trivially-nested-assertion](./no-trivially-nested-assertion.md) | disallow trivially nested assertions | :wrench: |
 | [regexp/no-unused-capturing-group](./no-unused-capturing-group.md) | disallow unused capturing group |  |
 | [regexp/no-useless-backreference](./no-useless-backreference.md) | disallow useless backreferences in regular expressions |  |
 | [regexp/no-useless-character-class](./no-useless-character-class.md) | disallow character class with one character | :wrench: |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -26,6 +26,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-lazy-ends](./no-lazy-ends.md) | disallow lazy quantifiers at the end of an expression |  |
 | [regexp/no-legacy-features](./no-legacy-features.md) | disallow legacy RegExp features |  |
 | [regexp/no-octal](./no-octal.md) | disallow octal escape sequence | :star: |
+| [regexp/no-trivially-nested-assertion](./no-trivially-nested-assertion.md) | disallow trivially nested assertions | :star::wrench: |
 | [regexp/no-unused-capturing-group](./no-unused-capturing-group.md) | disallow unused capturing group |  |
 | [regexp/no-useless-backreference](./no-useless-backreference.md) | disallow useless backreferences in regular expressions |  |
 | [regexp/no-useless-character-class](./no-useless-character-class.md) | disallow character class with one character | :wrench: |

--- a/docs/rules/no-trivially-nested-assertion.md
+++ b/docs/rules/no-trivially-nested-assertion.md
@@ -9,7 +9,6 @@ description: "disallow trivially nested assertions"
 > disallow trivially nested assertions
 
 - :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
-- :gear: This rule is included in `"plugin:regexp/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details

--- a/docs/rules/no-trivially-nested-assertion.md
+++ b/docs/rules/no-trivially-nested-assertion.md
@@ -1,0 +1,42 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "regexp/no-trivially-nested-assertion"
+description: "disallow trivially nested assertions"
+---
+# regexp/no-trivially-nested-assertion
+
+> disallow trivially nested assertions
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :gear: This rule is included in `"plugin:regexp/recommended"`.
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+Lookaround assertions that only contain another assertion can be simplified.
+
+<eslint-code-block fix>
+
+```js
+/* eslint regexp/no-trivially-nested-assertion: "error" */
+
+/* ✓ GOOD */
+var foo = /a(?=b)/;
+var foo = /a(?!$)/;
+
+/* ✗ BAD */
+var foo = /a(?=$)/;
+var foo = /a(?=(?!a))/;
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/lib/rules/no-trivially-nested-assertion.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/tests/lib/rules/no-trivially-nested-assertion.ts)

--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -23,7 +23,6 @@ export = {
         "regexp/no-escape-backspace": "error",
         "regexp/no-invisible-character": "error",
         "regexp/no-octal": "error",
-        "regexp/no-trivially-nested-assertion": "error",
         "regexp/no-useless-exactly-quantifier": "error",
         "regexp/no-useless-two-nums-quantifier": "error",
         "regexp/prefer-d": "error",

--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -23,6 +23,7 @@ export = {
         "regexp/no-escape-backspace": "error",
         "regexp/no-invisible-character": "error",
         "regexp/no-octal": "error",
+        "regexp/no-trivially-nested-assertion": "error",
         "regexp/no-useless-exactly-quantifier": "error",
         "regexp/no-useless-two-nums-quantifier": "error",
         "regexp/prefer-d": "error",

--- a/lib/rules/no-trivially-nested-assertion.ts
+++ b/lib/rules/no-trivially-nested-assertion.ts
@@ -62,7 +62,9 @@ export default createRule("no-trivially-nested-assertion", {
     meta: {
         docs: {
             description: "disallow trivially nested assertions",
-            recommended: true,
+            // TODO Switch to recommended in the major version.
+            // recommended: true,
+            recommended: false,
         },
         fixable: "code",
         schema: [],

--- a/lib/rules/no-trivially-nested-assertion.ts
+++ b/lib/rules/no-trivially-nested-assertion.ts
@@ -1,0 +1,139 @@
+import type { Expression } from "estree"
+import type { RegExpVisitor } from "regexpp/visitor"
+import type {
+    Node as RegExpNode,
+    Assertion,
+    LookaroundAssertion,
+} from "regexpp/ast"
+import {
+    createRule,
+    defineRegexpVisitor,
+    fixReplaceNode,
+    getRegexpLocation,
+} from "../utils"
+import { hasSomeDescendant } from "regexp-ast-analysis"
+
+/**
+ * Returns whether the given node is a lookaround.
+ */
+function isLookaround(node: RegExpNode): node is LookaroundAssertion {
+    return (
+        node.type === "Assertion" &&
+        (node.kind === "lookahead" || node.kind === "lookbehind")
+    )
+}
+
+/**
+ * If the given lookaround only contains a single assertion, then this
+ * assertion will be returned.
+ */
+function getTriviallyNestedAssertion(
+    node: LookaroundAssertion,
+): Assertion | null {
+    const alternatives = node.alternatives
+    if (alternatives.length === 1) {
+        const elements = alternatives[0].elements
+        if (elements.length === 1) {
+            const element = elements[0]
+            if (element.type === "Assertion") {
+                return element
+            }
+        }
+    }
+
+    return null
+}
+
+/**
+ * Returns the raw of an assertion that is the negation of the given assertion.
+ */
+function getNegatedRaw(assertion: Assertion): string | null {
+    if (assertion.kind === "word") {
+        return assertion.negate ? "\\b" : "\\B"
+    } else if (assertion.kind === "lookahead") {
+        return `(?${assertion.negate ? "=" : "!"}${assertion.raw.slice(3)}`
+    } else if (assertion.kind === "lookbehind") {
+        return `(?<${assertion.negate ? "=" : "!"}${assertion.raw.slice(4)}`
+    }
+    return null
+}
+
+export default createRule("no-trivially-nested-assertion", {
+    meta: {
+        docs: {
+            description: "disallow trivially nested assertions",
+            recommended: true,
+        },
+        fixable: "code",
+        schema: [],
+        messages: {
+            unexpected: "Unexpected trivially nested assertion.",
+        },
+        type: "suggestion", // "problem",
+    },
+    create(context) {
+        const sourceCode = context.getSourceCode()
+
+        /**
+         * Create visitor
+         * @param node
+         */
+        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+            return {
+                onAssertionEnter(aNode) {
+                    if (aNode.parent.type === "Quantifier") {
+                        // Not all quantifiers are allowed to be the element
+                        // of a quantifier, so we don't even try
+                        return
+                    }
+
+                    if (!isLookaround(aNode)) {
+                        // there can be no nesting in predefined assertions
+                        return
+                    }
+
+                    const nested = getTriviallyNestedAssertion(aNode)
+                    if (nested === null) {
+                        return
+                    }
+
+                    if (
+                        aNode.negate &&
+                        isLookaround(nested) &&
+                        nested.negate &&
+                        hasSomeDescendant(
+                            nested,
+                            (d) => d.type === "CapturingGroup",
+                        )
+                    ) {
+                        // e.g. /(?!(?!(a)))\1/ != /(?=(a))\1/
+                        return
+                    }
+
+                    const replacement = aNode.negate
+                        ? getNegatedRaw(nested)
+                        : nested.raw
+                    if (replacement === null) {
+                        return
+                    }
+
+                    context.report({
+                        node,
+                        loc: getRegexpLocation(sourceCode, node, aNode),
+                        messageId: "unexpected",
+                        fix: fixReplaceNode(
+                            sourceCode,
+                            node,
+                            aNode,
+                            replacement,
+                        ),
+                    })
+                },
+            }
+        }
+
+        return defineRegexpVisitor(context, {
+            createVisitor,
+        })
+    },
+})

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -14,6 +14,7 @@ import noInvisibleCharacter from "../rules/no-invisible-character"
 import noLazyEnds from "../rules/no-lazy-ends"
 import noLegacyFeatures from "../rules/no-legacy-features"
 import noOctal from "../rules/no-octal"
+import noTriviallyNestedAssertion from "../rules/no-trivially-nested-assertion"
 import noUnusedCapturingGroup from "../rules/no-unused-capturing-group"
 import noUselessBackreference from "../rules/no-useless-backreference"
 import noUselessCharacterClass from "../rules/no-useless-character-class"
@@ -56,6 +57,7 @@ export const rules = [
     noLazyEnds,
     noLegacyFeatures,
     noOctal,
+    noTriviallyNestedAssertion,
     noUnusedCapturingGroup,
     noUselessBackreference,
     noUselessCharacterClass,

--- a/tests/lib/rules/no-trivially-nested-assertion.ts
+++ b/tests/lib/rules/no-trivially-nested-assertion.ts
@@ -1,0 +1,151 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-trivially-nested-assertion"
+
+const tester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+})
+
+tester.run("no-trivially-nested-assertion", rule as any, {
+    valid: [
+        `/(?=(?=a)b)/`,
+
+        // these anchors cannot be negated, so they have to be allowed
+        `/(?!$)/`,
+        `/(?<!$)/`,
+        `/(?!^)/`,
+        `/(?<!^)/`,
+
+        // the text of capturing groups inside negated lookarounds is
+        // guaranteed to be reset, so we can't transform them into one
+        // non-negated lookaround
+        `/(?!(?!(a)))/`,
+    ],
+    invalid: [
+        {
+            code: String(/(?=$)/),
+            output: String(/$/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?=^)/),
+            output: String(/^/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<=$)/),
+            output: String(/$/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<=^)/),
+            output: String(/^/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?=\b)/),
+            output: String(/\b/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?!\b)/),
+            output: String(/\B/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<=\b)/),
+            output: String(/\b/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<!\b)/),
+            output: String(/\B/),
+            errors: [{ messageId: "unexpected" }],
+        },
+
+        // all trivially nested lookarounds can be written as one lookaround
+        // Note: The inner lookaround has to be negated if the outer one is negative.
+        {
+            code: String(/(?=(?=a))/),
+            output: String(/(?=a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?=(?!a))/),
+            output: String(/(?!a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?=(?<=a))/),
+            output: String(/(?<=a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?=(?<!a))/),
+            output: String(/(?<!a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?!(?=a))/),
+            output: String(/(?!a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?!(?!a))/),
+            output: String(/(?=a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?!(?<=a))/),
+            output: String(/(?<!a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?!(?<!a))/),
+            output: String(/(?<=a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<=(?=a))/),
+            output: String(/(?=a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<=(?!a))/),
+            output: String(/(?!a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<=(?<=a))/),
+            output: String(/(?<=a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<=(?<!a))/),
+            output: String(/(?<!a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<!(?=a))/),
+            output: String(/(?!a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<!(?!a))/),
+            output: String(/(?=a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<!(?<=a))/),
+            output: String(/(?<!a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+        {
+            code: String(/(?<!(?<!a))/),
+            output: String(/(?<=a)/),
+            errors: [{ messageId: "unexpected" }],
+        },
+    ],
+})


### PR DESCRIPTION
This is the `clean-regex/no-trivially-nested-lookaround` rule but with a different name and [this bug](https://github.com/ota-meshi/eslint-plugin-regexp/issues/91#issuecomment-817773291) fixed.

I renamed it because the "trivially nested assertion" is the inner assertion (e.g. in `/(?=(?!a))/`, the trivially nested assertion is `(?!a)`). Since the inner assertion can be any assertion and not just a lookaround, I renamed the rule.