### PR TITLE
Fix wrong autofix for non-RegExp arguments in `regexp/prefer-regexp-test` rule

### DIFF
--- a/lib/rules/prefer-regexp-test.ts
+++ b/lib/rules/prefer-regexp-test.ts
@@ -43,6 +43,7 @@ export default createRule("prefer-regexp-test", {
                     }
                     const arg = node.arguments[0]
                     const evaluated = getStaticValue(arg, context.getScope())
+                    let argIsRegExp = true
                     if (evaluated && evaluated.value instanceof RegExp) {
                         if (evaluated.value.flags.includes("g")) {
                             return
@@ -50,8 +51,8 @@ export default createRule("prefer-regexp-test", {
                     } else if (!typeTracer.isRegExp(arg)) {
                         // Not RegExp
                         // String.prototype.match function allows non-RegExp arguments
-                        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#a_non-regexp_object_as_the_parameter
-                        return
+                        // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#a_non-regexp_object_as_the_parameter
+                        argIsRegExp = false
                     }
 
                     const memberExpr = node.callee
@@ -60,6 +61,13 @@ export default createRule("prefer-regexp-test", {
                         messageId: "disallow",
                         data: { target: "String#match" },
                         fix(fixer) {
+                            if (!argIsRegExp) {
+                                // If the argument is not RegExp, it will not be autofix.
+                                // Must use `new RegExp()` before fixing it.
+                                // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#a_non-regexp_object_as_the_parameter
+                                // When the regexp parameter is a string or a number, it is implicitly converted to a RegExp by using new RegExp(regexp).
+                                return null
+                            }
                             if (
                                 node.arguments.length !== 1 ||
                                 hasSideEffect(memberExpr, sourceCode) ||

--- a/lib/rules/prefer-regexp-test.ts
+++ b/lib/rules/prefer-regexp-test.ts
@@ -43,11 +43,14 @@ export default createRule("prefer-regexp-test", {
                     }
                     const arg = node.arguments[0]
                     const evaluated = getStaticValue(arg, context.getScope())
-                    if (
-                        evaluated &&
-                        evaluated.value instanceof RegExp &&
-                        evaluated.value.flags.includes("g")
-                    ) {
+                    if (evaluated && evaluated.value instanceof RegExp) {
+                        if (evaluated.value.flags.includes("g")) {
+                            return
+                        }
+                    } else if (!typeTracer.isRegExp(arg)) {
+                        // Not RegExp
+                        // String.prototype.match function allows non-RegExp arguments
+                        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#a_non-regexp_object_as_the_parameter
                         return
                     }
 

--- a/tests/lib/rules/prefer-regexp-test.ts
+++ b/tests/lib/rules/prefer-regexp-test.ts
@@ -33,19 +33,6 @@ tester.run("prefer-regexp-test", rule as any, {
         const a = pattern.exec(text)
         const b = text.match(pattern)
         `,
-        `
-        const text = 'something';
-        if (text.match()) {}
-        const pattern1 = 'some';
-        if (text.match(pattern1)) {}
-        const pattern2 = Infinity;
-        if (text.match(pattern2)) {}
-        `,
-        `
-        const text = 'something';
-        const pattern = getPattern();
-        if (text.match(pattern)) {}
-        `,
     ],
     invalid: [
         {
@@ -154,6 +141,32 @@ tester.run("prefer-regexp-test", rule as any, {
             errors: [
                 "Use the `RegExp#test()` method instead of `RegExp#exec`, if you need a boolean.",
                 "Use the `RegExp#test()` method instead of `RegExp#exec`, if you need a boolean.",
+            ],
+        },
+        {
+            code: `
+            const text = 'something';
+            if (text.match()) {}
+            const pattern1 = 'some';
+            if (text.match(pattern1)) {}
+            const pattern2 = Infinity;
+            if (text.match(pattern2)) {}
+            `,
+            output: null,
+            errors: [
+                "Use the `RegExp#test()` method instead of `String#match`, if you need a boolean.",
+                "Use the `RegExp#test()` method instead of `String#match`, if you need a boolean.",
+            ],
+        },
+        {
+            code: `
+            const text = 'something';
+            const pattern = getPattern();
+            if (text.match(pattern)) {}
+            `,
+            output: null,
+            errors: [
+                "Use the `RegExp#test()` method instead of `String#match`, if you need a boolean.",
             ],
         },
         {

--- a/tests/lib/rules/prefer-regexp-test.ts
+++ b/tests/lib/rules/prefer-regexp-test.ts
@@ -33,6 +33,19 @@ tester.run("prefer-regexp-test", rule as any, {
         const a = pattern.exec(text)
         const b = text.match(pattern)
         `,
+        `
+        const text = 'something';
+        if (text.match()) {}
+        const pattern1 = 'some';
+        if (text.match(pattern1)) {}
+        const pattern2 = Infinity;
+        if (text.match(pattern2)) {}
+        `,
+        `
+        const text = 'something';
+        const pattern = getPattern();
+        if (text.match(pattern)) {}
+        `,
     ],
     invalid: [
         {
@@ -141,6 +154,23 @@ tester.run("prefer-regexp-test", rule as any, {
             errors: [
                 "Use the `RegExp#test()` method instead of `RegExp#exec`, if you need a boolean.",
                 "Use the `RegExp#test()` method instead of `RegExp#exec`, if you need a boolean.",
+            ],
+        },
+        {
+            code: `
+            const text = 'something';
+            /** @type {RegExp} */
+            const pattern = getPattern();
+            if (text.match(pattern)) {}
+            `,
+            output: `
+            const text = 'something';
+            /** @type {RegExp} */
+            const pattern = getPattern();
+            if (pattern.test(text)) {}
+            `,
+            errors: [
+                "Use the `RegExp#test()` method instead of `String#match`, if you need a boolean.",
             ],
         },
     ],


### PR DESCRIPTION
Fixed #119