### PR TITLE
Fixed escaping

### DIFF
--- a/tests/lib/rules/no-useless-range.ts
+++ b/tests/lib/rules/no-useless-range.ts
@@ -88,17 +88,26 @@ tester.run("no-useless-range", rule as any, {
         {
             code: `
             /[,--b]/;
+            /[a-a-z]/;
+            /[a-a--z]/;
             /[\\c-d]/;
             /[\\x6-7]/;
             /[\\u002-3]/;
+            /[A-\\u004-5]/;
             `,
             output: `
             /[,\\-b]/;
+            /[a\\-z]/;
+            /[a\\--z]/;
             /[\\c-d]/;
             /[\\x6-7]/;
             /[\\u002-3]/;
+            /[A-\\u004-5]/;
             `,
             errors: [
+                "Unexpected unnecessary range of characters by using a hyphen.",
+                "Unexpected unnecessary range of characters by using a hyphen.",
+                "Unexpected unnecessary range of characters by using a hyphen.",
                 "Unexpected unnecessary range of characters by using a hyphen.",
                 "Unexpected unnecessary range of characters by using a hyphen.",
                 "Unexpected unnecessary range of characters by using a hyphen.",
@@ -110,15 +119,21 @@ tester.run("no-useless-range", rule as any, {
             /[,-\\-b]/;
             /[c-d]/;
             /[x6-7]/;
+            /[\\x 6-7]/;
             /[u002-3]/;
+            /[\\u 002-3]/;
             `,
             output: `
             /[,\\-b]/;
             /[cd]/;
             /[x67]/;
+            /[\\x 67]/;
             /[u0023]/;
+            /[\\u 0023]/;
             `,
             errors: [
+                "Unexpected unnecessary range of characters by using a hyphen.",
+                "Unexpected unnecessary range of characters by using a hyphen.",
                 "Unexpected unnecessary range of characters by using a hyphen.",
                 "Unexpected unnecessary range of characters by using a hyphen.",
                 "Unexpected unnecessary range of characters by using a hyphen.",


### PR DESCRIPTION
The fix in #126 was still wrong for some edge cases.

The problem we are trying to solve is that some characters get re-interpreted. I.e. in `[A-B-C]`, transforming it to `[AB-C]` will cause the second `-` to become a range operator. We are dealing with a parser problem.

To fix this problem, I only look at the raw source code around the range I'm trying to fix. This makes detect these cases where characters get interpreted as something else way easier. The general idea is still the same as in #126.