### PR TITLE
Use `npm ci` instead of `npm install`

### DIFF
--- a/.github/workflows/GHPages.yml
+++ b/.github/workflows/GHPages.yml
@@ -11,7 +11,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
             - name: Install Packages
-              run: npm install
+              run: npm ci
             - name: Build docs
               run: npm run docs:build
             - name: Deploy

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -46,7 +46,7 @@ jobs:
               run: |+
                   npm i -D eslint@6 mocha@7 @typescript-eslint/parser@3
                   npx rimraf node_modules
-                  npm ci
+                  npm install
             - name: Test
               run: npm test
     test-and-coverage:

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -15,7 +15,7 @@ jobs:
               with:
                   node-version: 14
             - name: Install Packages
-              run: npm install
+              run: npm ci
             - name: Build
               run: npm run build
             - name: Lint
@@ -32,7 +32,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Install Packages
-              run: npm install
+              run: npm ci
             - name: Test
               run: npm test
     test-with-eslint6:
@@ -46,7 +46,7 @@ jobs:
               run: |+
                   npm i -D eslint@6 mocha@7 @typescript-eslint/parser@3
                   npx rimraf node_modules
-                  npm install
+                  npm ci
             - name: Test
               run: npm test
     test-and-coverage:
@@ -55,7 +55,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
             - name: Install Packages
-              run: npm install
+              run: npm ci
             - name: Test
               run: npm run test:nyc
             - name: Coveralls GitHub Action

--- a/.github/workflows/NpmPublish.yml
+++ b/.github/workflows/NpmPublish.yml
@@ -15,7 +15,7 @@ jobs:
               with:
                   registry-url: "https://registry.npmjs.org"
             - name: Install Packages
-              run: npm install
+              run: npm ci
             - name: test
               run: npm run test
             - name: check can npm-publish


### PR DESCRIPTION
Since we now have a package-lock, we might as well use it :)

This replaces all CI commands using `npm install` with [`npm ci`](https://docs.npmjs.com/cli/v7/commands/npm-ci/). This will guarantee that the CI installs the package specified in package-lock and is significantly faster than `npm install`.