### PR TITLE
Fixed TODO in `optimal-lookaround-quantifier`

### DIFF
--- a/lib/rules/optimal-lookaround-quantifier.ts
+++ b/lib/rules/optimal-lookaround-quantifier.ts
@@ -2,6 +2,7 @@ import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { Alternative, LookaroundAssertion, Quantifier } from "regexpp/ast"
 import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import { hasSomeDescendant } from "regexp-ast-analysis"
 
 /**
  * Extract invalid quantifiers for lookarounds
@@ -17,8 +18,17 @@ function* extractInvalidQuantifiers(
             switch (last.type) {
                 case "Quantifier":
                     if (last.min !== last.max) {
-                        // TODO: last might contain a capturing group in which cause, we can't change the quantifier
-                        yield last
+                        if (
+                            hasSomeDescendant(
+                                last.element,
+                                (d) => d.type === "CapturingGroup",
+                            )
+                        ) {
+                            // we can't change the quantifier because it might
+                            // affect the capturing group
+                        } else {
+                            yield last
+                        }
                     }
                     break
 
@@ -54,9 +64,9 @@ export default createRule("optimal-lookaround-quantifier", {
         schema: [],
         messages: {
             remove:
-                "The quantified expression {{expr}} at the {{endOrStart}} of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
+                "The quantified expression '{{expr}}' at the {{endOrStart}} of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
             replacedWith:
-                "The quantified expression {{expr}} at the {{endOrStart}} of the expression tree should only be matched a constant number of times. The expression can be replaced with {{replacer}} without affecting the lookaround.",
+                "The quantified expression '{{expr}}' at the {{endOrStart}} of the expression tree should only be matched a constant number of times. The expression can be replaced with {{replacer}} without affecting the lookaround.",
         },
         type: "problem",
     },
@@ -85,8 +95,8 @@ export default createRule("optimal-lookaround-quantifier", {
                                 q.min === 0
                                     ? ""
                                     : q.min === 1
-                                    ? `${q.element.raw} (no quantifier)`
-                                    : `${q.element.raw}{${q.min}}`
+                                    ? `'${q.element.raw}' (no quantifier)`
+                                    : `'${q.element.raw}{${q.min}}'`
 
                             context.report({
                                 node,

--- a/tests/lib/rules/optimal-lookaround-quantifier.ts
+++ b/tests/lib/rules/optimal-lookaround-quantifier.ts
@@ -9,14 +9,14 @@ const tester = new RuleTester({
 })
 
 tester.run("optimal-lookaround-quantifier", rule as any, {
-    valid: [String.raw`/(?=(a*))\w+\1/`, `/(?<=a{4})/`],
+    valid: [String.raw`/(?=(a*))\w+\1/`, `/(?<=a{4})/`, `/(?=a(?:(a)|b)*)/`],
     invalid: [
         {
             code: `/(?=ba*)/`,
             errors: [
                 {
                     message:
-                        "The quantified expression a* at the end of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
+                        "The quantified expression 'a*' at the end of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
                     line: 1,
                     column: 6,
                 },
@@ -27,7 +27,7 @@ tester.run("optimal-lookaround-quantifier", rule as any, {
             errors: [
                 {
                     message:
-                        "The quantified expression c* at the end of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
+                        "The quantified expression 'c*' at the end of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
                     line: 1,
                     column: 14,
                 },
@@ -38,7 +38,7 @@ tester.run("optimal-lookaround-quantifier", rule as any, {
             errors: [
                 {
                     message:
-                        "The quantified expression c+ at the end of the expression tree should only be matched a constant number of times. The expression can be replaced with c (no quantifier) without affecting the lookaround.",
+                        "The quantified expression 'c+' at the end of the expression tree should only be matched a constant number of times. The expression can be replaced with 'c' (no quantifier) without affecting the lookaround.",
                     line: 1,
                     column: 14,
                 },
@@ -49,7 +49,7 @@ tester.run("optimal-lookaround-quantifier", rule as any, {
             errors: [
                 {
                     message:
-                        "The quantified expression c{4,9} at the end of the expression tree should only be matched a constant number of times. The expression can be replaced with c{4} without affecting the lookaround.",
+                        "The quantified expression 'c{4,9}' at the end of the expression tree should only be matched a constant number of times. The expression can be replaced with 'c{4}' without affecting the lookaround.",
                     line: 1,
                     column: 14,
                 },
@@ -60,18 +60,18 @@ tester.run("optimal-lookaround-quantifier", rule as any, {
             errors: [
                 {
                     message:
-                        "The quantified expression [a-c]* at the start of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
+                        "The quantified expression '[a-c]*' at the start of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
                     line: 1,
                     column: 6,
                 },
             ],
         },
         {
-            code: `/(?<=(c)*ab)/`,
+            code: `/(?<=(?:d|c)*ab)/`,
             errors: [
                 {
                     message:
-                        "The quantified expression (c)* at the start of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
+                        "The quantified expression '(?:d|c)*' at the start of the expression tree should only be matched a constant number of times. The expression can be removed without affecting the lookaround.",
                     line: 1,
                     column: 6,
                 },


### PR DESCRIPTION
This fixes the TODO in `optimal-lookaround-quantifier` and makes the message formatting consistent with other rules.