### PR TITLE
Fixed `update` script

### DIFF
--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -62,3 +62,18 @@ jobs:
               uses: coverallsapp/github-action@v1.1.2
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+    update:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+            - name: Install Packages
+              run: npm ci
+            - name: Update
+              run: npm run update
+            - name: Check changes
+              run: |
+                  git add --all && \
+                  git diff-index --cached HEAD --stat --exit-code

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -71,6 +71,8 @@ jobs:
                   node-version: 14
             - name: Install Packages
               run: npm ci
+            - name: Build
+              run: npm run build
             - name: Update
               run: npm run update
             - name: Check changes

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Please use GitHub's Issues/PRs.
 
 <!--DOCS_IGNORE_END-->
 
+<!--INSERT_SETTINGS_SECTION-->
+
 ## :lock: License
 
 See the [LICENSE](LICENSE) file for license rights and limitations (MIT).

--- a/tools/update-readme.ts
+++ b/tools/update-readme.ts
@@ -38,5 +38,13 @@ fs.writeFileSync(
             /\(https:\/\/ota-meshi.github.io\/eslint-plugin-regexp/gu,
             "(.",
         )
+        .replace(
+            /<!--INSERT_SETTINGS_SECTION-->/g,
+            `
+## :gear: Settings
+
+See [Settings](./settings/README.md).
+`,
+        )
         .replace(/\n{3,}/gu, "\n\n"),
 )


### PR DESCRIPTION
@ota-meshi You probably also noticed, that I broke the `update` script in #122.

This PR 1) fixes the update script so that it no longer removes the "Settings" section and 2) adds a CI job to verify that `npm run update` doesn't change any files.