### PR TITLE
New CI job to check for changes after `update`

### DIFF
--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -62,3 +62,20 @@ jobs:
               uses: coverallsapp/github-action@v1.1.2
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+    update:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+            - name: Install Packages
+              run: npm ci
+            - name: Build
+              run: npm run build
+            - name: Update
+              run: npm run update
+            - name: Check changes
+              run: |
+                  git add --all && \
+                  git diff-index --cached HEAD --stat --exit-code


### PR DESCRIPTION
As promised, here is the CI job from #141.

This job is quite useful because it means that we can never forget to run `npm run update` again.