### PR TITLE
Updated `regexp/no-dupe-characters-character-class` rule using `regexp-ast-analysis`.

### DIFF
--- a/lib/rules/no-dupe-characters-character-class.ts
+++ b/lib/rules/no-dupe-characters-character-class.ts
@@ -305,14 +305,23 @@ export default createRule("no-dupe-characters-character-class", {
                                 if (
                                     intersection.has(range.min.value) ||
                                     intersection.has(range.max.value)
-                                )
+                                ) {
+                                    const reportRanges = intersection.ranges.filter(
+                                        ({ min, max }) => {
+                                            return (
+                                                min === range.min.value ||
+                                                max === range.max.value
+                                            )
+                                        },
+                                    )
                                     reportIntersect(
                                         node,
                                         [range, ...dupeRanges],
                                         other,
-                                        intersection,
+                                        intersection.intersect(reportRanges),
                                         flags,
                                     )
+                                }
                             }
                         }
                     }
@@ -320,10 +329,9 @@ export default createRule("no-dupe-characters-character-class", {
                         if (dupeSets.length) {
                             reportDuplicates(node, [set, ...dupeSets])
                         }
-                        for (const [other] of [
-                            ...characterSets.filter(([o]) => o !== set),
-                            ...characterClassRanges,
-                        ]) {
+                        for (const [other] of characterSets.filter(
+                            ([o]) => o !== set,
+                        )) {
                             if (isElementInElementReported(set, other)) {
                                 continue
                             }

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -248,15 +248,15 @@ function buildRegexpVisitor(
             }
             const flags = parseFlags(node.regex.flags)
             verify(node.regex.pattern, flags, function* (helpers) {
+                const regexpContext: RegExpContextForLiteral = {
+                    node,
+                    pattern: node.regex.pattern,
+                    flags,
+                    regexpNode: node,
+                    ...helpers,
+                }
                 for (const rule of rules) {
                     if (rule.createLiteralVisitor) {
-                        const regexpContext: RegExpContextForLiteral = {
-                            node,
-                            pattern: node.regex.pattern,
-                            flags,
-                            regexpNode: node,
-                            ...helpers,
-                        }
                         yield rule.createLiteralVisitor(
                             node,
                             node.regex.pattern,
@@ -353,14 +353,14 @@ function buildRegexpVisitor(
                     }
                     const flags = parseFlags(flagsStr || "")
                     verify(pattern, flags, function* (helpers) {
+                        const regexpContext: RegExpContextForSource = {
+                            node: verifyPatternNode,
+                            pattern,
+                            flags,
+                            regexpNode: newOrCall,
+                            ...helpers,
+                        }
                         for (const rule of rules) {
-                            const regexpContext: RegExpContextForSource = {
-                                node: verifyPatternNode,
-                                pattern,
-                                flags,
-                                regexpNode: newOrCall,
-                                ...helpers,
-                            }
                             if (rule.createSourceVisitor) {
                                 yield rule.createSourceVisitor(
                                     verifyPatternNode,

--- a/lib/utils/unicode.ts
+++ b/lib/utils/unicode.ts
@@ -1,3 +1,5 @@
+import { Chars } from "regexp-ast-analysis"
+
 export const CP_BACKSPACE = 8
 export const CP_TAB = 9
 export const CP_LF = 10
@@ -52,34 +54,8 @@ export const CP_CAPITAL_A = "A".codePointAt(0)!
 export const CP_CAPITAL_Z = "Z".codePointAt(0)!
 export const CP_LOW_LINE = "_".codePointAt(0)!
 
-export const CPS_SINGLE_SPACES = new Set<number>([
-    CP_SPACE,
-    CP_TAB,
-    CP_CR,
-    CP_LF,
-    CP_VT,
-    CP_FF,
-    CP_NBSP,
-    CP_OGHAM_SPACE_MARK,
-    CP_MONGOLIAN_VOWEL_SEPARATOR,
-    CP_LINE_SEPARATOR,
-    CP_PARAGRAPH_SEPARATOR,
-    CP_NNBSP,
-    CP_MMSP,
-    CP_IDEOGRAPHIC_SPACE,
-    CP_BOM,
-])
-
-export const CP_RANGE_DIGIT = [CP_DIGIT_ZERO, CP_DIGIT_NINE] as const
 export const CP_RANGE_SMALL_LETTER = [CP_SMALL_A, CP_SMALL_Z] as const
 export const CP_RANGE_CAPITAL_LETTER = [CP_CAPITAL_A, CP_CAPITAL_Z] as const
-export const CP_RANGE_SPACES = [CP_EN_QUAD, CP_HAIR_SPACE] as const
-
-export const CP_RANGES_WORDS = [
-    CP_RANGE_SMALL_LETTER,
-    CP_RANGE_CAPITAL_LETTER,
-    CP_RANGE_DIGIT,
-]
 
 /**
  * Checks if the given code point is within the code point range.
@@ -100,7 +76,7 @@ function isCodePointInRange(
  * @returns {boolean} `true` if the given code point is digit.
  */
 export function isDigit(codePoint: number): boolean {
-    return isCodePointInRange(codePoint, CP_RANGE_DIGIT)
+    return Chars.digit({}).has(codePoint)
 }
 /**
  * Checks if the given code point is lowercase.
@@ -168,10 +144,7 @@ export function isSymbol(codePoint: number): boolean {
  * @returns {boolean} `true` if the given code point is space.
  */
 export function isSpace(codePoint: number): boolean {
-    return (
-        CPS_SINGLE_SPACES.has(codePoint) ||
-        isCodePointInRange(codePoint, CP_RANGE_SPACES)
-    )
+    return Chars.space({}).has(codePoint)
 }
 
 /**
@@ -180,10 +153,7 @@ export function isSpace(codePoint: number): boolean {
  * @returns {boolean} `true` if the given code point is word.
  */
 export function isWord(codePoint: number): boolean {
-    return (
-        CP_RANGES_WORDS.some((range) => isCodePointInRange(codePoint, range)) ||
-        CP_LOW_LINE === codePoint
-    )
+    return Chars.word({}).has(codePoint)
 }
 
 /**
@@ -196,6 +166,7 @@ export function isInvisible(codePoint: number): boolean {
         return true
     }
     return (
+        codePoint === CP_MONGOLIAN_VOWEL_SEPARATOR ||
         codePoint === CP_NEL ||
         codePoint === CP_ZWSP ||
         codePoint === CP_ZWNJ ||

--- a/lib/utils/unicode.ts
+++ b/lib/utils/unicode.ts
@@ -61,7 +61,7 @@ export const CP_RANGE_CAPITAL_LETTER = [CP_CAPITAL_A, CP_CAPITAL_Z] as const
  * Checks if the given code point is within the code point range.
  * @param codePoint The code point to check.
  * @param range The range of code points of the range.
- * @returns {boolean} `true` if the given character is within the character class range.
+ * @returns `true` if the given character is within the character class range.
  */
 function isCodePointInRange(
     codePoint: number,
@@ -73,7 +73,7 @@ function isCodePointInRange(
 /**
  * Checks if the given code point is digit.
  * @param codePoint The code point to check
- * @returns {boolean} `true` if the given code point is digit.
+ * @returns `true` if the given code point is digit.
  */
 export function isDigit(codePoint: number): boolean {
     return Chars.digit({}).has(codePoint)
@@ -81,7 +81,7 @@ export function isDigit(codePoint: number): boolean {
 /**
  * Checks if the given code point is lowercase.
  * @param codePoint The code point to check
- * @returns {boolean} `true` if the given code point is lowercase.
+ * @returns `true` if the given code point is lowercase.
  */
 export function isLowercaseLetter(codePoint: number): boolean {
     return isCodePointInRange(codePoint, CP_RANGE_SMALL_LETTER)
@@ -89,7 +89,7 @@ export function isLowercaseLetter(codePoint: number): boolean {
 /**
  * Checks if the given code point is uppercase.
  * @param codePoint The code point to check
- * @returns {boolean} `true` if the given code point is uppercase.
+ * @returns `true` if the given code point is uppercase.
  */
 export function isUppercaseLetter(codePoint: number): boolean {
     return isCodePointInRange(codePoint, CP_RANGE_CAPITAL_LETTER)
@@ -97,7 +97,7 @@ export function isUppercaseLetter(codePoint: number): boolean {
 /**
  * Checks if the given code point is letter.
  * @param codePoint The code point to check
- * @returns {boolean} `true` if the given code point is letter.
+ * @returns `true` if the given code point is letter.
  */
 export function isLetter(codePoint: number): boolean {
     return isLowercaseLetter(codePoint) || isUppercaseLetter(codePoint)
@@ -105,7 +105,7 @@ export function isLetter(codePoint: number): boolean {
 /**
  * Convert the given character to lowercase.
  * @param codePoint The code point to convert.
- * @returns {number} Converted code point.
+ * @returns Converted code point.
  */
 export function toLowerCodePoint(codePoint: number): number {
     if (isUppercaseLetter(codePoint)) {
@@ -116,7 +116,7 @@ export function toLowerCodePoint(codePoint: number): number {
 /**
  * Convert the given character to uppercase.
  * @param codePoint The code point to convert.
- * @returns {number} Converted code point.
+ * @returns Converted code point.
  */
 export function toUpperCodePoint(codePoint: number): number {
     if (isLowercaseLetter(codePoint)) {
@@ -127,7 +127,7 @@ export function toUpperCodePoint(codePoint: number): number {
 /**
  * Checks if the given code point is symbol.
  * @param codePoint The code point to check
- * @returns {boolean} `true` if the given code point is symbol.
+ * @returns `true` if the given code point is symbol.
  */
 export function isSymbol(codePoint: number): boolean {
     return (
@@ -141,7 +141,7 @@ export function isSymbol(codePoint: number): boolean {
 /**
  * Checks if the given code point is space.
  * @param codePoint The code point to check
- * @returns {boolean} `true` if the given code point is space.
+ * @returns `true` if the given code point is space.
  */
 export function isSpace(codePoint: number): boolean {
     return Chars.space({}).has(codePoint)
@@ -150,7 +150,7 @@ export function isSpace(codePoint: number): boolean {
 /**
  * Checks if the given code point is word.
  * @param codePoint The code point to check
- * @returns {boolean} `true` if the given code point is word.
+ * @returns `true` if the given code point is word.
  */
 export function isWord(codePoint: number): boolean {
     return Chars.word({}).has(codePoint)
@@ -159,7 +159,7 @@ export function isWord(codePoint: number): boolean {
 /**
  * Checks if the given code point is invisible character.
  * @param codePoint The code point to check
- * @returns {boolean} `true` if the given code point is invisible character.
+ * @returns `true` if the given code point is invisible character.
  */
 export function isInvisible(codePoint: number): boolean {
     if (isSpace(codePoint)) {

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -293,11 +293,19 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             code: "/[\\W\\W\\w \\d\\d\\D]/",
             errors: [
                 { message: "Unexpected element '\\W' duplication.", column: 3 },
+                {
+                    message: "The '\\W' is included in '\\D'.",
+                    column: 3,
+                },
                 { message: "Unexpected element '\\W' duplication.", column: 5 },
                 { message: "The ' ' is included in '\\W'.", column: 9 },
                 { message: "The ' ' is included in '\\D'.", column: 9 },
                 {
                     message: "Unexpected element '\\d' duplication.",
+                    column: 10,
+                },
+                {
+                    message: "The '\\d' is included in '\\w'.",
                     column: 10,
                 },
                 {
@@ -316,7 +324,17 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 },
                 {
                     message:
+                        "The '\\p{ASCII}' is included in '\\P{Script=Hiragana}'.",
+                    column: 3,
+                },
+                {
+                    message:
                         "Unexpected element '\\p{Script=Hiragana}' duplication.",
+                    column: 21,
+                },
+                {
+                    message:
+                        "The '\\p{Script=Hiragana}' is included in '\\P{ASCII}'.",
                     column: 21,
                 },
                 {
@@ -442,6 +460,34 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 {
                     message: "The 'a' is included in '\\S'.",
                     column: 5,
+                },
+            ],
+        },
+        {
+            code: "/[a-z\\p{L}]/u",
+            errors: [
+                {
+                    message:
+                        "Unexpected intersection of 'a-z' and '\\p{L}' was found 'a-z'.",
+                    column: 3,
+                },
+            ],
+        },
+        {
+            code: "/[\\d\\p{ASCII}]/u",
+            errors: [
+                {
+                    message: "The '\\d' is included in '\\p{ASCII}'.",
+                    column: 3,
+                },
+            ],
+        },
+        {
+            code: "/[\\t\\s]/",
+            errors: [
+                {
+                    message: "The '\\t' is included in '\\s'.",
+                    column: 3,
                 },
             ],
         },

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -61,8 +61,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             code: "/[0-9\\d]/",
             errors: [
                 {
-                    message: "The '\\d' is included in '0-9'.",
-                    column: 6,
+                    message: "The '0-9' is included in '\\d'.",
+                    column: 3,
                 },
             ],
         },
@@ -89,8 +89,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 { message: "The '\\u00a0' is included in '\\s'.", column: 16 },
                 { message: "The '\\u1680' is included in '\\s'.", column: 22 },
                 {
-                    message:
-                        "Unexpected intersection of '\\u2000-\\u200a' and '\\s' was found '\\u2000-\\u200a'.",
+                    message: "The '\\u2000-\\u200a' is included in '\\s'.",
                     column: 34,
                 },
                 { message: "The '\\u2028' is included in '\\s'.", column: 47 },
@@ -116,18 +115,15 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             code: "/[\\wA-Za-z0-9_]/",
             errors: [
                 {
-                    message:
-                        "Unexpected intersection of 'A-Z' and '\\w' was found 'A-Z'.",
+                    message: "The 'A-Z' is included in '\\w'.",
                     column: 5,
                 },
                 {
-                    message:
-                        "Unexpected intersection of 'a-z' and '\\w' was found 'a-z'.",
+                    message: "The 'a-z' is included in '\\w'.",
                     column: 8,
                 },
                 {
-                    message:
-                        "Unexpected intersection of '0-9' and '\\w' was found '0-9'.",
+                    message: "The '0-9' is included in '\\w'.",
                     column: 11,
                 },
                 { message: "The '_' is included in '\\w'.", column: 14 },
@@ -175,11 +171,6 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 },
                 {
                     message:
-                        "Unexpected intersection of 'a-d' and 'c-d' was found 'c-d'.",
-                    column: 3,
-                },
-                {
-                    message:
                         "Unexpected intersection of 'e-h' and 'd-e' was found 'e'.",
                     column: 7,
                 },
@@ -199,8 +190,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                     column: 11,
                 },
                 {
-                    message:
-                        "Unexpected intersection of 'c-d' and 'a-d' was found 'c-d'.",
+                    message: "The 'c-d' is included in 'a-d'.",
                     column: 15,
                 },
                 {
@@ -269,24 +259,18 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             code: "/[\\d 0-9_!-z]/",
             errors: [
                 {
-                    message: "The '\\d' is included in '0-9'.",
-                    column: 3,
-                },
-                {
                     message: "The '\\d' is included in '!-z'.",
                     column: 3,
                 },
                 {
-                    message:
-                        "Unexpected intersection of '0-9' and '!-z' was found '0-9'.",
+                    message: "The '0-9' is included in '!-z'.",
+                    column: 6,
+                },
+                {
+                    message: "The '0-9' is included in '\\d'.",
                     column: 6,
                 },
                 { message: "The '_' is included in '!-z'.", column: 9 },
-                {
-                    message:
-                        "Unexpected intersection of '!-z' and '0-9' was found '0-9'.",
-                    column: 10,
-                },
             ],
         },
         {
@@ -298,6 +282,10 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                     column: 3,
                 },
                 { message: "Unexpected element '\\W' duplication.", column: 5 },
+                {
+                    message: "The '\\W' is included in '\\D'.",
+                    column: 5,
+                },
                 { message: "The ' ' is included in '\\W'.", column: 9 },
                 { message: "The ' ' is included in '\\D'.", column: 9 },
                 {
@@ -310,6 +298,10 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 },
                 {
                     message: "Unexpected element '\\d' duplication.",
+                    column: 12,
+                },
+                {
+                    message: "The '\\d' is included in '\\w'.",
                     column: 12,
                 },
             ],
@@ -343,7 +335,17 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 },
                 {
                     message:
+                        "The '\\p{ASCII}' is included in '\\P{Script=Hiragana}'.",
+                    column: 59,
+                },
+                {
+                    message:
                         "Unexpected element '\\p{Script=Hiragana}' duplication.",
+                    column: 68,
+                },
+                {
+                    message:
+                        "The '\\p{Script=Hiragana}' is included in '\\P{ASCII}'.",
                     column: 68,
                 },
             ],
@@ -467,8 +469,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             code: "/[a-z\\p{L}]/u",
             errors: [
                 {
-                    message:
-                        "Unexpected intersection of 'a-z' and '\\p{L}' was found 'a-z'.",
+                    message: "The 'a-z' is included in '\\p{L}'.",
                     column: 3,
                 },
             ],
@@ -487,6 +488,15 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message: "The '\\t' is included in '\\s'.",
+                    column: 3,
+                },
+            ],
+        },
+        {
+            code: String.raw`/[A-Z a-\uFFFF]/i`,
+            errors: [
+                {
+                    message: "The 'A-Z' is included in 'a-\\uFFFF'.",
                     column: 3,
                 },
             ],

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -14,8 +14,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         "/[abc]/",
         "/[a][a][a]/",
         "/[0-9\\D]/",
-        "/[\\S \\f\\n\\r\\t\\v\\u00a0\\u1680\\u180e\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff]/",
-        "/\\s \\f\\n\\r\\t\\v\\u00a0\\u1680\\u180e\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff/",
+        "/[\\S \\f\\n\\r\\t\\v\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff]/",
+        "/\\s \\f\\n\\r\\t\\v\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff/",
         "/[\\WA-Za-z0-9_]/",
         "/[\\w \\/-:]/",
         // dont check
@@ -61,9 +61,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             code: "/[0-9\\d]/",
             errors: [
                 {
-                    message:
-                        "Unexpected intersection of '0-9' and '\\d' was found '0-9'.",
-                    column: 3,
+                    message: "The '\\d' is included in '0-9'.",
+                    column: 6,
                 },
             ],
         },
@@ -89,7 +88,6 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 { message: "The '\\v' is included in '\\s'.", column: 14 },
                 { message: "The '\\u00a0' is included in '\\s'.", column: 16 },
                 { message: "The '\\u1680' is included in '\\s'.", column: 22 },
-                { message: "The '\\u180e' is included in '\\s'.", column: 28 },
                 {
                     message:
                         "Unexpected intersection of '\\u2000-\\u200a' and '\\s' was found '\\u2000-\\u200a'.",
@@ -271,24 +269,22 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             code: "/[\\d 0-9_!-z]/",
             errors: [
                 {
-                    message:
-                        "Unexpected intersection of '0-9' and '!-z' was found '0-9'.",
-                    column: 6,
+                    message: "The '\\d' is included in '0-9'.",
+                    column: 3,
+                },
+                {
+                    message: "The '\\d' is included in '!-z'.",
+                    column: 3,
                 },
                 {
                     message:
-                        "Unexpected intersection of '0-9' and '\\d' was found '0-9'.",
+                        "Unexpected intersection of '0-9' and '!-z' was found '0-9'.",
                     column: 6,
                 },
                 { message: "The '_' is included in '!-z'.", column: 9 },
                 {
                     message:
                         "Unexpected intersection of '!-z' and '0-9' was found '0-9'.",
-                    column: 10,
-                },
-                {
-                    message:
-                        "Unexpected intersection of '!-z' and '\\d' was found '0-9'.",
                     column: 10,
                 },
             ],
@@ -332,6 +328,38 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                         "Unexpected element '\\p{Script=Hiragana}' duplication.",
                     column: 68,
                 },
+                {
+                    message: "The ' ' is included in '\\p{ASCII}'.",
+                    column: 87,
+                },
+                {
+                    message: "The ' ' is included in '\\P{Script=Hiragana}'.",
+                    column: 87,
+                },
+                {
+                    message: "The 'a' is included in '\\p{ASCII}'.",
+                    column: 88,
+                },
+                {
+                    message: "The 'a' is included in '\\P{Script=Hiragana}'.",
+                    column: 88,
+                },
+                {
+                    message: "The 'b' is included in '\\p{ASCII}'.",
+                    column: 89,
+                },
+                {
+                    message: "The 'b' is included in '\\P{Script=Hiragana}'.",
+                    column: 89,
+                },
+                {
+                    message: "The 'c' is included in '\\p{ASCII}'.",
+                    column: 90,
+                },
+                {
+                    message: "The 'c' is included in '\\P{Script=Hiragana}'.",
+                    column: 90,
+                },
             ],
         },
         {
@@ -364,12 +392,12 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected intersection of 'A-_' and '\\w' was found 'A-Z'.",
+                        "Unexpected intersection of 'A-_' and '\\w' was found '_'.",
                     column: 5,
                 },
                 {
                     message:
-                        "Unexpected intersection of 'A-_' and '\\w' was found '_'.",
+                        "Unexpected intersection of 'A-_' and '\\w' was found 'A-Z'.",
                     column: 5,
                 },
             ],
@@ -395,6 +423,15 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                     column: 12,
                     endLine: 1,
                     endColumn: 14,
+                },
+            ],
+        },
+        {
+            code: "/[\\Sa]/",
+            errors: [
+                {
+                    message: "The 'a' is included in '\\S'.",
+                    column: 5,
                 },
             ],
         },

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -18,7 +18,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         "/\\s \\f\\n\\r\\t\\v\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff/",
         "/[\\WA-Za-z0-9_]/",
         "/[\\w \\/-:]/",
-        // dont check
+        "/[\\w\\p{L}]/u",
         "/\\p{ASCII}abc/u",
         // error
         "var r = new RegExp('[\\\\wA-Za-z0-9_][invalid');",

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -20,6 +20,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         "/[\\w \\/-:]/",
         "/[\\w\\p{L}]/u",
         "/\\p{ASCII}abc/u",
+        String.raw`/[\u1fff-\u2020\s]/`,
         // error
         "var r = new RegExp('[\\\\wA-Za-z0-9_][invalid');",
     ],
@@ -492,6 +493,26 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message: "The 'A-Z' is included in 'a-\\uFFFF'.",
+                    column: 3,
+                },
+            ],
+        },
+        {
+            code: String.raw`/[\xA0-\uFFFF\s]/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected intersection of '\\xA0-\\uFFFF' and '\\s' was found '\\xa0'.",
+                    column: 3,
+                },
+            ],
+        },
+        {
+            code: String.raw`/[\u1fff-\u2005\s]/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected intersection of '\\u1fff-\\u2005' and '\\s' was found '[\\u2000-\\u2005]'.",
                     column: 3,
                 },
             ],

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -308,7 +308,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         },
         {
             code:
-                "/[\\p{ASCII}\\P{ASCII}\\p{Script=Hiragana}\\P{Script=Hiragana}\\p{ASCII}\\p{Script=Hiragana} abc]/u",
+                "/[\\p{ASCII}\\P{ASCII}\\p{Script=Hiragana}\\P{Script=Hiragana}\\p{ASCII}\\p{Script=Hiragana}]/u",
             errors: [
                 {
                     message: "Unexpected element '\\p{ASCII}' duplication.",
@@ -328,37 +328,47 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                         "Unexpected element '\\p{Script=Hiragana}' duplication.",
                     column: 68,
                 },
+            ],
+        },
+        {
+            code: "/[\\p{ASCII} abc\\P{ASCII}]/u",
+            errors: [
                 {
                     message: "The ' ' is included in '\\p{ASCII}'.",
-                    column: 87,
-                },
-                {
-                    message: "The ' ' is included in '\\P{Script=Hiragana}'.",
-                    column: 87,
+                    column: 12,
                 },
                 {
                     message: "The 'a' is included in '\\p{ASCII}'.",
-                    column: 88,
-                },
-                {
-                    message: "The 'a' is included in '\\P{Script=Hiragana}'.",
-                    column: 88,
+                    column: 13,
                 },
                 {
                     message: "The 'b' is included in '\\p{ASCII}'.",
-                    column: 89,
-                },
-                {
-                    message: "The 'b' is included in '\\P{Script=Hiragana}'.",
-                    column: 89,
+                    column: 14,
                 },
                 {
                     message: "The 'c' is included in '\\p{ASCII}'.",
-                    column: 90,
+                    column: 15,
+                },
+            ],
+        },
+        {
+            code: "/[\\P{Script=Hiragana} abc\\p{Script=Hiragana}]/u",
+            errors: [
+                {
+                    message: "The ' ' is included in '\\P{Script=Hiragana}'.",
+                    column: 22,
+                },
+                {
+                    message: "The 'a' is included in '\\P{Script=Hiragana}'.",
+                    column: 23,
+                },
+                {
+                    message: "The 'b' is included in '\\P{Script=Hiragana}'.",
+                    column: 24,
                 },
                 {
                     message: "The 'c' is included in '\\P{Script=Hiragana}'.",
-                    column: 90,
+                    column: 25,
                 },
             ],
         },

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -206,33 +206,33 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 { message: "Unexpected element '3-6' duplication.", column: 3 },
                 {
                     message:
-                        "Unexpected intersection of '3-6' and '2-4' was found '3-4'.",
+                        "Unexpected intersection of '3-6' and '2-4' was found '[34]'.",
                     column: 3,
                 },
                 {
                     message:
-                        "Unexpected intersection of '3-6' and '5-7' was found '5-6'.",
+                        "Unexpected intersection of '3-6' and '5-7' was found '[56]'.",
                     column: 3,
                 },
                 { message: "Unexpected element '3-6' duplication.", column: 7 },
                 {
                     message:
-                        "Unexpected intersection of '3-6' and '2-4' was found '3-4'.",
+                        "Unexpected intersection of '3-6' and '2-4' was found '[34]'.",
                     column: 7,
                 },
                 {
                     message:
-                        "Unexpected intersection of '3-6' and '5-7' was found '5-6'.",
+                        "Unexpected intersection of '3-6' and '5-7' was found '[56]'.",
                     column: 7,
                 },
                 {
                     message:
-                        "Unexpected intersection of '2-4' and '3-6' was found '3-4'.",
+                        "Unexpected intersection of '2-4' and '3-6' was found '[34]'.",
                     column: 11,
                 },
                 {
                     message:
-                        "Unexpected intersection of '5-7' and '3-6' was found '5-6'.",
+                        "Unexpected intersection of '5-7' and '3-6' was found '[56]'.",
                     column: 15,
                 },
             ],
@@ -397,12 +397,12 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected intersection of '/-7' and '\\w' was found '0-7'.",
+                        "Unexpected intersection of '/-7' and '\\w' was found '[0-7]'.",
                     column: 6,
                 },
                 {
                     message:
-                        "Unexpected intersection of '8-:' and '\\w' was found '8-9'.",
+                        "Unexpected intersection of '8-:' and '\\w' was found '[89]'.",
                     column: 10,
                 },
             ],
@@ -422,12 +422,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected intersection of 'A-_' and '\\w' was found '_'.",
-                    column: 5,
-                },
-                {
-                    message:
-                        "Unexpected intersection of 'A-_' and '\\w' was found 'A-Z'.",
+                        "Unexpected intersection of 'A-_' and '\\w' was found '[A-Z_]'.",
                     column: 5,
                 },
             ],

--- a/tests/lib/utils/unicode.ts
+++ b/tests/lib/utils/unicode.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../lib/utils/unicode"
 
 const SPACES =
-    " \f\n\r\t\v\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000\ufeff"
+    " \f\n\r\t\v\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000\ufeff"
 
 describe("isSpace", () => {
     for (const c of SPACES) {

--- a/tools/new-rule.ts
+++ b/tools/new-rule.ts
@@ -45,9 +45,14 @@ export default createRule("${ruleId}", {
 
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor(
+            _node: Expression,
+            _pattern: string,
+            _flagsStr: string,
+            _regexpNode: Expression,
+            regexpContext: RegExpContext
+        ): RegExpVisitor.Handlers {
         }
         return defineRegexpVisitor(context, {
             createVisitor,


### PR DESCRIPTION
This PR contains the following changes:

- Fix false negatives for `[\s\u180e]` in `regexp/no-dupe-characters-character-class` rule.  
  (The document (Japanese MDN) I checked, `\s` contained `\u180e`, which was incorrect.)
- Fixed false negatives for `i` flag  in `regexp/no-dupe-characters-character-class` rule.  
- Add supports for unicode property to `regexp/no-dupe-characters-character-class` rule.
- Add supports for negative escape character class to `regexp/no-dupe-characters-character-class` rule.
- Update `regexp/no-dupe-characters-character-class` rule to report that escape character class include escape character class.
- Improved reporting of `regexp/no-dupe-characters-character-class` rule when fully including elements.

related to #92


