### PR TITLE
Refactor `defineRegexpVisitor`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,21 @@ module.exports = {
         "no-shadow": "off", // ts bug?
         "@typescript-eslint/no-shadow": "error",
 
+        // Rules for implementing this plugin.
+        "no-restricted-imports": [
+            "error",
+            {
+                paths: [
+                    {
+                        name: "regexp-ast-analysis",
+                        importNames: ["toCharSet"],
+                        message:
+                            "Please use toCharSet from RegExpContext instead.",
+                    },
+                ],
+            },
+        ],
+
         // https://github.com/ota-meshi/eslint-plugin-regexp/pull/49
         "no-empty-character-class": "error",
         "regexp/negation": "error",

--- a/lib/rules/confusing-quantifier.ts
+++ b/lib/rules/confusing-quantifier.ts
@@ -1,10 +1,9 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
+import type { RegExpContext } from "../utils"
 import {
     createRule,
     defineRegexpVisitor,
     getQuantifierOffsets,
-    getRegexpLocation,
     quantToString,
 } from "../utils"
 import { isPotentiallyEmpty } from "regexp-ast-analysis"
@@ -26,13 +25,13 @@ export default createRule("confusing-quantifier", {
         type: "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onQuantifierEnter(qNode) {
                     if (qNode.min > 0 && isPotentiallyEmpty(qNode.element)) {
@@ -40,8 +39,6 @@ export default createRule("confusing-quantifier", {
                         context.report({
                             node,
                             loc: getRegexpLocation(
-                                sourceCode,
-                                node,
                                 qNode,
                                 getQuantifierOffsets(qNode),
                             ),

--- a/lib/rules/negation.ts
+++ b/lib/rules/negation.ts
@@ -1,15 +1,10 @@
-import type { Expression } from "estree"
 import type {
     EscapeCharacterSet,
     UnicodePropertyCharacterSet,
 } from "regexpp/ast"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    createRule,
-    defineRegexpVisitor,
-    fixReplaceNode,
-    getRegexpLocation,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("negation", {
     meta: {
@@ -28,13 +23,14 @@ export default createRule("negation", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+            fixReplaceNode,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCharacterClassEnter(ccNode) {
                     if (!ccNode.negate || ccNode.elements.length !== 1) {
@@ -45,15 +41,10 @@ export default createRule("negation", {
                         const negatedCharSet = getNegationText(element)
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, ccNode),
+                            loc: getRegexpLocation(ccNode),
                             messageId: "unexpected",
                             data: { negatedCharSet },
-                            fix: fixReplaceNode(
-                                sourceCode,
-                                node,
-                                ccNode,
-                                negatedCharSet,
-                            ),
+                            fix: fixReplaceNode(ccNode, negatedCharSet),
                         })
                     }
                 },

--- a/lib/rules/no-assertion-capturing-group.ts
+++ b/lib/rules/no-assertion-capturing-group.ts
@@ -1,6 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("no-assertion-capturing-group", {
     meta: {
@@ -15,13 +15,13 @@ export default createRule("no-assertion-capturing-group", {
         type: "suggestion",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCapturingGroupEnter(cgNode) {
                     if (
@@ -31,7 +31,7 @@ export default createRule("no-assertion-capturing-group", {
                     ) {
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, cgNode),
+                            loc: getRegexpLocation(cgNode),
                             messageId: "unexpected",
                         })
                     }

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -1,4 +1,3 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type {
     CapturingGroup,
@@ -7,7 +6,8 @@ import type {
     Pattern,
     Quantifier,
 } from "regexpp/ast"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 import { isCoveredNode, isEqualNodes } from "../utils/regexp-ast"
 
 export default createRule("no-dupe-disjunctions", {
@@ -38,7 +38,6 @@ export default createRule("no-dupe-disjunctions", {
         const disallowNeverMatch = Boolean(
             context.options[0]?.disallowNeverMatch,
         )
-        const sourceCode = context.getSourceCode()
 
         /**
          * Check has after pattern
@@ -74,13 +73,12 @@ export default createRule("no-dupe-disjunctions", {
 
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(
-            node: Expression,
-            _p: string,
-            flags: string,
-        ): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            flags,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             /** Verify group node */
             function verify(
                 regexpNode:
@@ -111,7 +109,7 @@ export default createRule("no-dupe-disjunctions", {
                     if (dupeAlt) {
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, alt),
+                            loc: getRegexpLocation(alt),
                             messageId:
                                 disallowNeverMatch &&
                                 !isEqualNodes(dupeAlt, alt)

--- a/lib/rules/no-empty-alternative.ts
+++ b/lib/rules/no-empty-alternative.ts
@@ -1,7 +1,7 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { CapturingGroup, Group, Pattern } from "regexpp/ast"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("no-empty-alternative", {
     meta: {
@@ -19,13 +19,13 @@ export default createRule("no-empty-alternative", {
         type: "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             /**
              * Verify alternatives
              */
@@ -40,7 +40,7 @@ export default createRule("no-empty-alternative", {
                         if (alt.elements.length === 0) {
                             context.report({
                                 node,
-                                loc: getRegexpLocation(sourceCode, node, alt),
+                                loc: getRegexpLocation(alt),
                                 messageId: "empty",
                             })
                             // don't report the same node multiple times

--- a/lib/rules/no-empty-group.ts
+++ b/lib/rules/no-empty-group.ts
@@ -1,7 +1,7 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { Group, CapturingGroup } from "regexpp/ast"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("no-empty-group", {
     meta: {
@@ -16,16 +16,17 @@ export default createRule("no-empty-group", {
         type: "suggestion",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * verify group node
          */
-        function verifyGroup(node: Expression, gNode: Group | CapturingGroup) {
+        function verifyGroup(
+            { node, getRegexpLocation }: RegExpContext,
+            gNode: Group | CapturingGroup,
+        ) {
             if (gNode.alternatives.every((alt) => alt.elements.length === 0)) {
                 context.report({
                     node,
-                    loc: getRegexpLocation(sourceCode, node, gNode),
+                    loc: getRegexpLocation(gNode),
                     messageId: "unexpected",
                 })
             }
@@ -33,15 +34,16 @@ export default createRule("no-empty-group", {
 
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor(
+            regexpContext: RegExpContext,
+        ): RegExpVisitor.Handlers {
             return {
                 onGroupEnter(gNode) {
-                    verifyGroup(node, gNode)
+                    verifyGroup(regexpContext, gNode)
                 },
                 onCapturingGroupEnter(cgNode) {
-                    verifyGroup(node, cgNode)
+                    verifyGroup(regexpContext, cgNode)
                 },
             }
         }

--- a/lib/rules/no-empty-lookarounds-assertion.ts
+++ b/lib/rules/no-empty-lookarounds-assertion.ts
@@ -1,7 +1,7 @@
-import type { Expression } from "estree"
 import { isPotentiallyEmpty } from "regexp-ast-analysis"
 import type { RegExpVisitor } from "regexpp/visitor"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("no-empty-lookarounds-assertion", {
     meta: {
@@ -18,13 +18,13 @@ export default createRule("no-empty-lookarounds-assertion", {
         type: "suggestion",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onAssertionEnter(aNode) {
                     if (
@@ -37,7 +37,7 @@ export default createRule("no-empty-lookarounds-assertion", {
                     if (isPotentiallyEmpty(aNode.alternatives)) {
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, aNode),
+                            loc: getRegexpLocation(aNode),
                             messageId: "unexpected",
                             data: {
                                 kind: aNode.kind,

--- a/lib/rules/no-escape-backspace.ts
+++ b/lib/rules/no-escape-backspace.ts
@@ -1,11 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    CP_BACKSPACE,
-    createRule,
-    defineRegexpVisitor,
-    getRegexpLocation,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { CP_BACKSPACE, createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("no-escape-backspace", {
     meta: {
@@ -20,19 +15,19 @@ export default createRule("no-escape-backspace", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCharacterEnter(cNode) {
                     if (cNode.value === CP_BACKSPACE && cNode.raw === "\\b") {
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, cNode),
+                            loc: getRegexpLocation(cNode),
                             messageId: "unexpected",
                         })
                     }

--- a/lib/rules/no-lazy-ends.ts
+++ b/lib/rules/no-lazy-ends.ts
@@ -1,7 +1,7 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { Alternative, Quantifier } from "regexpp/ast"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 
 /**
  * Extract lazy end quantifiers
@@ -63,13 +63,13 @@ export default createRule("no-lazy-ends", {
         type: "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onPatternEnter(pNode) {
                     for (const lazy of extractLazyEndQuantifiers(
@@ -78,19 +78,19 @@ export default createRule("no-lazy-ends", {
                         if (lazy.min === 0) {
                             context.report({
                                 node,
-                                loc: getRegexpLocation(sourceCode, node, lazy),
+                                loc: getRegexpLocation(lazy),
                                 messageId: "uselessElement",
                             })
                         } else if (lazy.min === 1) {
                             context.report({
                                 node,
-                                loc: getRegexpLocation(sourceCode, node, lazy),
+                                loc: getRegexpLocation(lazy),
                                 messageId: "uselessQuantifier",
                             })
                         } else {
                             context.report({
                                 node,
-                                loc: getRegexpLocation(sourceCode, node, lazy),
+                                loc: getRegexpLocation(lazy),
                                 messageId: "uselessRange",
                                 data: {
                                     min: String(lazy.min),

--- a/lib/rules/no-obscure-range.ts
+++ b/lib/rules/no-obscure-range.ts
@@ -1,14 +1,13 @@
-import type { Expression } from "estree"
 import {
     getAllowedCharRanges,
     inRange,
     getAllowedCharValueSchema,
 } from "../utils/char-ranges"
 import type { RegExpVisitor } from "regexpp/visitor"
+import type { RegExpContext } from "../utils"
 import {
     createRule,
     defineRegexpVisitor,
-    getRegexpLocation,
     isControlEscape,
     isEscapeSequence,
     isHexadecimalEscape,
@@ -43,13 +42,14 @@ export default createRule("no-obscure-range", {
             context.options[0]?.allowed,
             context,
         )
-        const sourceCode = context.getSourceCode()
 
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCharacterClassRangeEnter(rNode) {
                     const { min, max } = rNode
@@ -88,7 +88,7 @@ export default createRule("no-obscure-range", {
 
                     context.report({
                         node,
-                        loc: getRegexpLocation(sourceCode, node, rNode),
+                        loc: getRegexpLocation(rNode),
                         messageId: "unexpected",
                         data: {
                             range: rNode.raw,

--- a/lib/rules/no-optional-assertion.ts
+++ b/lib/rules/no-optional-assertion.ts
@@ -1,4 +1,3 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type {
     Alternative,
@@ -7,7 +6,8 @@ import type {
     Group,
     Quantifier,
 } from "regexpp/ast"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 import { isZeroLength } from "regexp-ast-analysis"
 
 type ZeroQuantifier = Quantifier & { min: 0 }
@@ -83,13 +83,13 @@ export default createRule("no-optional-assertion", {
         type: "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             // The closest quantifier with a minimum of 0 is stored at index = 0.
             const zeroQuantifierStack: ZeroQuantifier[] = []
             return {
@@ -109,7 +109,7 @@ export default createRule("no-optional-assertion", {
                     if (q && isOptional(assertion, q)) {
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, assertion),
+                            loc: getRegexpLocation(assertion),
                             messageId: "optionalAssertion",
                             data: {
                                 quantifier: q.raw.substr(q.element.raw.length),

--- a/lib/rules/no-potentially-useless-backreference.ts
+++ b/lib/rules/no-potentially-useless-backreference.ts
@@ -1,6 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 import {
     isEmptyBackreference,
     isStrictBackreference,
@@ -24,13 +24,13 @@ export default createRule("no-potentially-useless-backreference", {
         type: "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onBackreferenceEnter(backreference) {
                     if (isEmptyBackreference(backreference)) {
@@ -41,11 +41,7 @@ export default createRule("no-potentially-useless-backreference", {
                     if (!isStrictBackreference(backreference)) {
                         context.report({
                             node,
-                            loc: getRegexpLocation(
-                                sourceCode,
-                                node,
-                                backreference,
-                            ),
+                            loc: getRegexpLocation(backreference),
                             messageId: "potentiallyUselessBackreference",
                         })
                     }

--- a/lib/rules/no-trivially-nested-assertion.ts
+++ b/lib/rules/no-trivially-nested-assertion.ts
@@ -1,16 +1,11 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type {
     Node as RegExpNode,
     Assertion,
     LookaroundAssertion,
 } from "regexpp/ast"
-import {
-    createRule,
-    defineRegexpVisitor,
-    fixReplaceNode,
-    getRegexpLocation,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 import { hasSomeDescendant } from "regexp-ast-analysis"
 
 /**
@@ -74,13 +69,14 @@ export default createRule("no-trivially-nested-assertion", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            fixReplaceNode,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onAssertionEnter(aNode) {
                     if (aNode.parent.type === "Quantifier") {
@@ -121,14 +117,9 @@ export default createRule("no-trivially-nested-assertion", {
 
                     context.report({
                         node,
-                        loc: getRegexpLocation(sourceCode, node, aNode),
+                        loc: getRegexpLocation(aNode),
                         messageId: "unexpected",
-                        fix: fixReplaceNode(
-                            sourceCode,
-                            node,
-                            aNode,
-                            replacement,
-                        ),
+                        fix: fixReplaceNode(aNode, replacement),
                     })
                 },
             }

--- a/lib/rules/no-useless-assertions.ts
+++ b/lib/rules/no-useless-assertions.ts
@@ -1,4 +1,3 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type {
     Assertion,
@@ -6,12 +5,8 @@ import type {
     LookaroundAssertion,
     WordBoundaryAssertion,
 } from "regexpp/ast"
-import {
-    createRule,
-    defineRegexpVisitor,
-    getRegexpLocation,
-    parseFlags,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 import {
     Chars,
     getFirstCharAfter,
@@ -57,19 +52,14 @@ export default createRule("no-useless-assertions", {
         type: "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(
-            node: Expression,
-            _pattern: string,
-            flagsStr: string,
-        ): RegExpVisitor.Handlers {
-            const flags = parseFlags(flagsStr)
-
+        function createVisitor({
+            node,
+            flags,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             /** Report */
             function report(
                 assertion: Assertion,
@@ -78,7 +68,7 @@ export default createRule("no-useless-assertions", {
             ) {
                 context.report({
                     node,
-                    loc: getRegexpLocation(sourceCode, node, assertion),
+                    loc: getRegexpLocation(assertion),
                     messageId,
                     data: {
                         assertion: assertion.raw,

--- a/lib/rules/no-useless-backreference.ts
+++ b/lib/rules/no-useless-backreference.ts
@@ -1,4 +1,3 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type {
     Node as RegExpNode,
@@ -6,7 +5,8 @@ import type {
     Alternative,
     CapturingGroup,
 } from "regexpp/ast"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 import {
     getClosestAncestor,
     getMatchingDirection,
@@ -103,13 +103,13 @@ export default createRule("no-useless-backreference", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onBackreferenceEnter(backRef) {
                     const messageId = getUselessMessageId(backRef)
@@ -117,7 +117,7 @@ export default createRule("no-useless-backreference", {
                     if (messageId) {
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, backRef),
+                            loc: getRegexpLocation(backRef),
                             messageId,
                             data: {
                                 bref: backRef.raw,

--- a/lib/rules/no-useless-escape.ts
+++ b/lib/rules/no-useless-escape.ts
@@ -1,10 +1,9 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { Character } from "regexpp/ast"
+import type { RegExpContext } from "../utils"
 import {
     createRule,
     defineRegexpVisitor,
-    getRegexpLocation,
     CP_BACK_SLASH,
     CP_STAR,
     CP_CLOSING_BRACKET,
@@ -62,13 +61,13 @@ export default createRule("no-useless-escape", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             /** Report */
             function report(
                 cNode: Character,
@@ -77,10 +76,7 @@ export default createRule("no-useless-escape", {
             ) {
                 context.report({
                     node,
-                    loc: getRegexpLocation(sourceCode, node, cNode, [
-                        offset,
-                        offset + 1,
-                    ]),
+                    loc: getRegexpLocation(cNode, [offset, offset + 1]),
                     messageId: "unnecessary",
                     data: {
                         character,

--- a/lib/rules/no-useless-exactly-quantifier.ts
+++ b/lib/rules/no-useless-exactly-quantifier.ts
@@ -1,11 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    createRule,
-    defineRegexpVisitor,
-    getRegexpLocation,
-    getQuantifierOffsets,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor, getQuantifierOffsets } from "../utils"
 
 export default createRule("no-useless-exactly-quantifier", {
     meta: {
@@ -20,13 +15,13 @@ export default createRule("no-useless-exactly-quantifier", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onQuantifierEnter(qNode) {
                     if (
@@ -39,7 +34,7 @@ export default createRule("no-useless-exactly-quantifier", {
                         const text = qNode.raw.slice(startOffset, endOffset)
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, qNode, [
+                            loc: getRegexpLocation(qNode, [
                                 startOffset,
                                 endOffset,
                             ]),

--- a/lib/rules/no-useless-non-capturing-group.ts
+++ b/lib/rules/no-useless-non-capturing-group.ts
@@ -1,12 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    canUnwrapped,
-    createRule,
-    defineRegexpVisitor,
-    getRegexpLocation,
-    getRegexpRange,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { canUnwrapped, createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("no-useless-non-capturing-group", {
     meta: {
@@ -24,13 +18,14 @@ export default createRule("no-useless-non-capturing-group", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+            getRegexpRange,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onGroupEnter(gNode) {
                     if (gNode.alternatives.length !== 1) {
@@ -59,19 +54,11 @@ export default createRule("no-useless-non-capturing-group", {
 
                     context.report({
                         node,
-                        loc: getRegexpLocation(sourceCode, node, gNode),
+                        loc: getRegexpLocation(gNode),
                         messageId: "unexpected",
                         fix(fixer) {
-                            const groupRange = getRegexpRange(
-                                sourceCode,
-                                node,
-                                gNode,
-                            )
-                            const altRange = getRegexpRange(
-                                sourceCode,
-                                node,
-                                alt,
-                            )
+                            const groupRange = getRegexpRange(gNode)
+                            const altRange = getRegexpRange(alt)
                             if (!groupRange || !altRange) {
                                 return null
                             }

--- a/lib/rules/no-useless-range.ts
+++ b/lib/rules/no-useless-range.ts
@@ -1,11 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    createRule,
-    defineRegexpVisitor,
-    fixReplaceNode,
-    getRegexpLocation,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("no-useless-range", {
     meta: {
@@ -24,13 +19,14 @@ export default createRule("no-useless-range", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            fixReplaceNode,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCharacterClassRangeEnter(ccrNode) {
                     if (
@@ -41,9 +37,9 @@ export default createRule("no-useless-range", {
                     }
                     context.report({
                         node,
-                        loc: getRegexpLocation(sourceCode, node, ccrNode),
+                        loc: getRegexpLocation(ccrNode),
                         messageId: "unexpected",
-                        fix: fixReplaceNode(sourceCode, node, ccrNode, () => {
+                        fix: fixReplaceNode(ccrNode, () => {
                             const parent = ccrNode.parent
                             const rawBefore = parent.raw.slice(
                                 0,

--- a/lib/rules/no-useless-two-nums-quantifier.ts
+++ b/lib/rules/no-useless-two-nums-quantifier.ts
@@ -1,12 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    createRule,
-    defineRegexpVisitor,
-    getRegexpLocation,
-    getQuantifierOffsets,
-    fixReplaceQuant,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor, getQuantifierOffsets } from "../utils"
 
 export default createRule("no-useless-two-nums-quantifier", {
     meta: {
@@ -22,13 +16,14 @@ export default createRule("no-useless-two-nums-quantifier", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+            fixReplaceQuant,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onQuantifierEnter(qNode) {
                     if (qNode.min === qNode.max) {
@@ -41,7 +36,7 @@ export default createRule("no-useless-two-nums-quantifier", {
                         }
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, qNode, [
+                            loc: getRegexpLocation(qNode, [
                                 startOffset,
                                 endOffset,
                             ]),
@@ -49,12 +44,7 @@ export default createRule("no-useless-two-nums-quantifier", {
                             data: {
                                 expr: text,
                             },
-                            fix: fixReplaceQuant(
-                                sourceCode,
-                                node,
-                                qNode,
-                                `{${qNode.min}}`,
-                            ),
+                            fix: fixReplaceQuant(qNode, `{${qNode.min}}`),
                         })
                     }
                 },

--- a/lib/rules/optimal-lookaround-quantifier.ts
+++ b/lib/rules/optimal-lookaround-quantifier.ts
@@ -1,7 +1,7 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { Alternative, LookaroundAssertion, Quantifier } from "regexpp/ast"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 import { hasSomeDescendant } from "regexp-ast-analysis"
 
 /**
@@ -71,13 +71,13 @@ export default createRule("optimal-lookaround-quantifier", {
         type: "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onAssertionEnter(aNode) {
                     if (
@@ -100,7 +100,7 @@ export default createRule("optimal-lookaround-quantifier", {
 
                             context.report({
                                 node,
-                                loc: getRegexpLocation(sourceCode, node, q),
+                                loc: getRegexpLocation(q),
                                 messageId:
                                     q.min === 0 ? "remove" : "replacedWith",
                                 data: {

--- a/lib/rules/prefer-d.ts
+++ b/lib/rules/prefer-d.ts
@@ -1,13 +1,11 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { CharacterClass, CharacterClassRange } from "regexpp/ast"
+import type { RegExpContext } from "../utils"
 import {
     createRule,
     defineRegexpVisitor,
     CP_DIGIT_ZERO,
     CP_DIGIT_NINE,
-    getRegexpLocation,
-    fixReplaceNode,
 } from "../utils"
 
 export default createRule("prefer-d", {
@@ -25,13 +23,14 @@ export default createRule("prefer-d", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+            fixReplaceNode,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCharacterClassRangeEnter(ccrNode: CharacterClassRange) {
                     if (
@@ -50,11 +49,7 @@ export default createRule("prefer-d", {
                         }
                         context.report({
                             node,
-                            loc: getRegexpLocation(
-                                sourceCode,
-                                node,
-                                reportNode,
-                            ),
+                            loc: getRegexpLocation(reportNode),
                             messageId: "unexpected",
                             data: {
                                 type:
@@ -64,12 +59,7 @@ export default createRule("prefer-d", {
                                 expr: reportNode.raw,
                                 instead,
                             },
-                            fix: fixReplaceNode(
-                                sourceCode,
-                                node,
-                                reportNode,
-                                instead,
-                            ),
+                            fix: fixReplaceNode(reportNode, instead),
                         })
                     }
                 },

--- a/lib/rules/prefer-named-backreference.ts
+++ b/lib/rules/prefer-named-backreference.ts
@@ -1,11 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    createRule,
-    defineRegexpVisitor,
-    fixReplaceNode,
-    getRegexpLocation,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("prefer-named-backreference", {
     meta: {
@@ -21,25 +16,24 @@ export default createRule("prefer-named-backreference", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            fixReplaceNode,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onBackreferenceEnter(bNode) {
                     if (bNode.resolved.name && !bNode.raw.startsWith("\\k<")) {
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, bNode),
+                            loc: getRegexpLocation(bNode),
                             messageId: "unexpected",
                             fix: fixReplaceNode(
-                                sourceCode,
-                                node,
                                 bNode,
-                                () => `\\k<${bNode.resolved.name}>`,
+                                `\\k<${bNode.resolved.name}>`,
                             ),
                         })
                     }

--- a/lib/rules/prefer-plus-quantifier.ts
+++ b/lib/rules/prefer-plus-quantifier.ts
@@ -1,12 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    createRule,
-    defineRegexpVisitor,
-    getRegexpLocation,
-    getQuantifierOffsets,
-    fixReplaceQuant,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor, getQuantifierOffsets } from "../utils"
 
 export default createRule("prefer-plus-quantifier", {
     meta: {
@@ -22,13 +16,14 @@ export default createRule("prefer-plus-quantifier", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+            fixReplaceQuant,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onQuantifierEnter(qNode) {
                     if (qNode.min === 1 && qNode.max === Infinity) {
@@ -39,22 +34,15 @@ export default createRule("prefer-plus-quantifier", {
                         if (text !== "+") {
                             context.report({
                                 node,
-                                loc: getRegexpLocation(
-                                    sourceCode,
-                                    node,
-                                    qNode,
-                                    [startOffset, endOffset],
-                                ),
+                                loc: getRegexpLocation(qNode, [
+                                    startOffset,
+                                    endOffset,
+                                ]),
                                 messageId: "unexpected",
                                 data: {
                                     expr: text,
                                 },
-                                fix: fixReplaceQuant(
-                                    sourceCode,
-                                    node,
-                                    qNode,
-                                    "+",
-                                ),
+                                fix: fixReplaceQuant(qNode, "+"),
                             })
                         }
                     }

--- a/lib/rules/prefer-quantifier.ts
+++ b/lib/rules/prefer-quantifier.ts
@@ -1,11 +1,9 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { Character, CharacterSet, Quantifier } from "regexpp/ast"
+import type { RegExpContext } from "../utils"
 import {
     createRule,
     defineRegexpVisitor,
-    fixerApplyEscape,
-    getRegexpRange,
     isDigit,
     isLetter,
     isSymbol,
@@ -143,9 +141,12 @@ export default createRule("prefer-quantifier", {
 
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            fixerApplyEscape,
+            getRegexpRange,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onAlternativeEnter(aNode) {
                     let charBuffer: CharBuffer | null = null
@@ -205,14 +206,8 @@ export default createRule("prefer-quantifier", {
                         if (buffer.isValid()) {
                             return
                         }
-                        const firstRange = getRegexpRange(
-                            sourceCode,
-                            node,
-                            buffer.elements[0],
-                        )
+                        const firstRange = getRegexpRange(buffer.elements[0])
                         const lastRange = getRegexpRange(
-                            sourceCode,
-                            node,
                             buffer.elements[buffer.elements.length - 1],
                         )
                         let range: [number, number] | null = null
@@ -245,7 +240,7 @@ export default createRule("prefer-quantifier", {
                                 }
                                 return fixer.replaceTextRange(
                                     range,
-                                    fixerApplyEscape(buffer.target.raw, node) +
+                                    fixerApplyEscape(buffer.target.raw) +
                                         buffer.getQuantifier(),
                                 )
                             },

--- a/lib/rules/prefer-range.ts
+++ b/lib/rules/prefer-range.ts
@@ -1,7 +1,7 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { Character, CharacterClassRange } from "regexpp/ast"
-import { createRule, defineRegexpVisitor, getRegexpRange } from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
 import {
     getAllowedCharRanges,
     getAllowedCharValueSchema,
@@ -47,20 +47,19 @@ export default createRule("prefer-range", {
 
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor(
+            regexpContext: RegExpContext,
+        ): RegExpVisitor.Handlers {
+            const { node, getRegexpRange } = regexpContext
+
             /** Get report location ranges */
             function getReportRanges(
                 nodes: (Character | CharacterClassRange)[],
             ): [number, number][] | null {
                 const ranges: [number, number][] = []
                 for (const reportNode of nodes) {
-                    const reportRange = getRegexpRange(
-                        sourceCode,
-                        node,
-                        reportNode,
-                    )
+                    const reportRange = getRegexpRange(reportNode)
                     if (!reportRange) {
                         return null
                     }

--- a/lib/rules/prefer-star-quantifier.ts
+++ b/lib/rules/prefer-star-quantifier.ts
@@ -1,12 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    createRule,
-    defineRegexpVisitor,
-    getRegexpLocation,
-    getQuantifierOffsets,
-    fixReplaceQuant,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor, getQuantifierOffsets } from "../utils"
 
 export default createRule("prefer-star-quantifier", {
     meta: {
@@ -22,13 +16,14 @@ export default createRule("prefer-star-quantifier", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+            getRegexpLocation,
+            fixReplaceQuant,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onQuantifierEnter(qNode) {
                     if (qNode.min === 0 && qNode.max === Infinity) {
@@ -39,22 +34,15 @@ export default createRule("prefer-star-quantifier", {
                         if (text !== "*") {
                             context.report({
                                 node,
-                                loc: getRegexpLocation(
-                                    sourceCode,
-                                    node,
-                                    qNode,
-                                    [startOffset, endOffset],
-                                ),
+                                loc: getRegexpLocation(qNode, [
+                                    startOffset,
+                                    endOffset,
+                                ]),
                                 messageId: "unexpected",
                                 data: {
                                     expr: text,
                                 },
-                                fix: fixReplaceQuant(
-                                    sourceCode,
-                                    node,
-                                    qNode,
-                                    "*",
-                                ),
+                                fix: fixReplaceQuant(qNode, "*"),
                             })
                         }
                     }

--- a/lib/rules/prefer-t.ts
+++ b/lib/rules/prefer-t.ts
@@ -1,12 +1,6 @@
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
-import {
-    createRule,
-    defineRegexpVisitor,
-    getRegexpLocation,
-    CP_TAB,
-    fixReplaceNode,
-} from "../utils"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor, CP_TAB } from "../utils"
 
 export default createRule("prefer-t", {
     meta: {
@@ -22,16 +16,14 @@ export default createRule("prefer-t", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
-         * @param node
          */
         function createVisitor(
-            node: Expression,
+            regexpContext: RegExpContext,
             arrows: string[],
         ): RegExpVisitor.Handlers {
+            const { node, getRegexpLocation, fixReplaceNode } = regexpContext
             return {
                 onCharacterEnter(cNode) {
                     if (
@@ -41,12 +33,12 @@ export default createRule("prefer-t", {
                     ) {
                         context.report({
                             node,
-                            loc: getRegexpLocation(sourceCode, node, cNode),
+                            loc: getRegexpLocation(cNode),
                             messageId: "unexpected",
                             data: {
                                 expr: cNode.raw,
                             },
-                            fix: fixReplaceNode(sourceCode, node, cNode, "\\t"),
+                            fix: fixReplaceNode(cNode, "\\t"),
                         })
                     }
                 },
@@ -54,11 +46,11 @@ export default createRule("prefer-t", {
         }
 
         return defineRegexpVisitor(context, {
-            createLiteralVisitor(node) {
-                return createVisitor(node, [])
+            createLiteralVisitor(regexpContext) {
+                return createVisitor(regexpContext, [])
             },
-            createSourceVisitor(node) {
-                return createVisitor(node, ["\t"])
+            createSourceVisitor(regexpContext) {
+                return createVisitor(regexpContext, ["\t"])
             },
         })
     },

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,13 +1,7 @@
 import type * as ESTree from "estree"
 import type { RuleListener, RuleModule, PartialRuleModule } from "../types"
 import type { RegExpVisitor } from "regexpp/visitor"
-import type {
-    Alternative,
-    Element,
-    Node,
-    Node as RegExpNode,
-    Quantifier,
-} from "regexpp/ast"
+import type { Alternative, Element, Node, Quantifier } from "regexpp/ast"
 import { RegExpParser, visitRegExpAST } from "regexpp"
 import {
     CALL,
@@ -40,7 +34,7 @@ type RegExpHelpersBase = {
      * @returns The SourceLocation
      */
     getRegexpLocation: (
-        regexpNode: RegExpNode,
+        regexpNode: Node,
         offsets?: [number, number],
     ) => AST.SourceLocation
 
@@ -79,7 +73,7 @@ export type RegExpHelpersForLiteral = {
      * @param regexpNode The regexp node to report.
      * @returns The SourceLocation
      */
-    getRegexpRange: (regexpNode: RegExpNode) => AST.Range
+    getRegexpRange: (regexpNode: Node) => AST.Range
 } & RegExpHelpersBase
 export type RegExpHelpersForSource = {
     /**
@@ -87,7 +81,7 @@ export type RegExpHelpersForSource = {
      * @param regexpNode The regexp node to report.
      * @returns The SourceLocation
      */
-    getRegexpRange: (regexpNode: RegExpNode) => AST.Range | null
+    getRegexpRange: (regexpNode: Node) => AST.Range | null
 } & RegExpHelpersBase
 export type RegExpHelpers = RegExpHelpersForLiteral & RegExpHelpersForSource
 
@@ -486,12 +480,12 @@ function buildRegExpHelperBase({
 function getRegexpRange(
     sourceCode: SourceCode,
     node: ESTree.RegExpLiteral,
-    regexpNode: RegExpNode,
+    regexpNode: Node,
 ): AST.Range
 function getRegexpRange(
     sourceCode: SourceCode,
     node: ESTree.Expression,
-    regexpNode: RegExpNode,
+    regexpNode: Node,
 ): AST.Range | null
 /**
  * Creates source range from the given regexp node
@@ -503,7 +497,7 @@ function getRegexpRange(
 function getRegexpRange(
     sourceCode: SourceCode,
     node: ESTree.Expression,
-    regexpNode: RegExpNode,
+    regexpNode: Node,
     offsets?: [number, number],
 ): AST.Range | null {
     const startOffset = regexpNode.start + (offsets?.[0] ?? 0)
@@ -564,7 +558,7 @@ function getRegexpRange(
 function getRegexpLocation(
     sourceCode: SourceCode,
     node: ESTree.Expression,
-    regexpNode: RegExpNode,
+    regexpNode: Node,
     offsets?: [number, number],
 ): AST.SourceLocation {
     const range = getRegexpRange(sourceCode, node, regexpNode)

--- a/tests/lib/rules-with-d-flag.ts
+++ b/tests/lib/rules-with-d-flag.ts
@@ -3,8 +3,8 @@ import * as parser from "@typescript-eslint/parser"
 // @ts-expect-error -- ignore
 import { rules } from "../../lib/index"
 import assert from "assert"
+import type { RegExpContext } from "../../lib/utils"
 import { createRule, defineRegexpVisitor } from "../../lib/utils"
-import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 
 const TEST_RULE = createRule("test", {
@@ -19,7 +19,9 @@ const TEST_RULE = createRule("test", {
     },
 
     create(context) {
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onPatternEnter() {
                     context.report({

--- a/tests/lib/rules-with-unknown-flag.ts
+++ b/tests/lib/rules-with-unknown-flag.ts
@@ -3,9 +3,9 @@ import * as parser from "@typescript-eslint/parser"
 // @ts-expect-error -- ignore
 import { rules } from "../../lib/index"
 import assert from "assert"
+import type { RegExpContext } from "../../lib/utils"
 import { createRule, defineRegexpVisitor } from "../../lib/utils"
 import type { RegExpVisitor } from "regexpp/visitor"
-import type { Expression } from "estree"
 
 const TEST_RULE = createRule("test", {
     meta: {
@@ -19,7 +19,9 @@ const TEST_RULE = createRule("test", {
     },
 
     create(context) {
-        function createVisitor(node: Expression): RegExpVisitor.Handlers {
+        function createVisitor({
+            node,
+        }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onPatternEnter() {
                     context.report({

--- a/tests/lib/utils/regexp-ast.ts
+++ b/tests/lib/utils/regexp-ast.ts
@@ -1,5 +1,6 @@
 import assert from "assert"
 import { parseRegExpLiteral } from "regexpp"
+import { parseFlags } from "../../../lib/utils"
 import { isCoveredNode, isEqualNodes } from "../../../lib/utils/regexp-ast"
 type TestCase = {
     a: RegExp | string
@@ -510,7 +511,10 @@ describe("regexp-ast isCoveredNode", () => {
 
             assert.deepStrictEqual(
                 isCoveredNode(ast1, ast2, {
-                    flags: { left: ast1.flags.raw, right: ast2.flags.raw },
+                    flags: {
+                        left: parseFlags(ast1.flags.raw),
+                        right: parseFlags(ast2.flags.raw),
+                    },
                     canOmitRight: true,
                 }),
                 testCase.result,

--- a/tools/new-rule.ts
+++ b/tools/new-rule.ts
@@ -26,7 +26,7 @@ const logger = console
 import type { Expression } from "estree"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { CharacterClass } from "regexpp/ast"
-import { createRule, defineRegexpVisitor, getRegexpLocation } from "../utils"
+import { createRule, defineRegexpVisitor, RegExpContext } from "../utils"
 
 export default createRule("${ruleId}", {
     meta: {
@@ -41,18 +41,11 @@ export default createRule("${ruleId}", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const sourceCode = context.getSourceCode()
-
         /**
          * Create visitor
          */
-        function createVisitor(
-            _node: Expression,
-            _pattern: string,
-            _flagsStr: string,
-            _regexpNode: Expression,
-            regexpContext: RegExpContext
-        ): RegExpVisitor.Handlers {
+        function createVisitor(regexpContext: RegExpContext): RegExpVisitor.Handlers {
+            const { node, flags, getRegexpLocation } = regexpContext
         }
         return defineRegexpVisitor(context, {
             createVisitor,


### PR DESCRIPTION
This PR refactors `defineRegexpVisitor` to provide some helpers for each rule. This allows we to omit function arguments and shorten we code.

More details on helpers can be found in the `RegExpHelpers` type.
https://github.com/ota-meshi/eslint-plugin-regexp/pull/150/files#diff-76051e819bd9ea2a35405d89d3fbf1831f45019a2b12d5e0a915668d1bd46462R28

Functions provided by helpers

- toCharSet
- getRegexpLocation
- fixerApplyEscape
- fixReplaceNode
- fixReplaceQuant
- getRegexpRange

---

close #149 