### PR TITLE
Simplified implementation

### DIFF
--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -206,33 +206,33 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 { message: "Unexpected element '3-6' duplication.", column: 3 },
                 {
                     message:
-                        "Unexpected intersection of '3-6' and '2-4' was found '3-4'.",
+                        "Unexpected intersection of '3-6' and '2-4' was found '[34]'.",
                     column: 3,
                 },
                 {
                     message:
-                        "Unexpected intersection of '3-6' and '5-7' was found '5-6'.",
+                        "Unexpected intersection of '3-6' and '5-7' was found '[56]'.",
                     column: 3,
                 },
                 { message: "Unexpected element '3-6' duplication.", column: 7 },
                 {
                     message:
-                        "Unexpected intersection of '3-6' and '2-4' was found '3-4'.",
+                        "Unexpected intersection of '3-6' and '2-4' was found '[34]'.",
                     column: 7,
                 },
                 {
                     message:
-                        "Unexpected intersection of '3-6' and '5-7' was found '5-6'.",
+                        "Unexpected intersection of '3-6' and '5-7' was found '[56]'.",
                     column: 7,
                 },
                 {
                     message:
-                        "Unexpected intersection of '2-4' and '3-6' was found '3-4'.",
+                        "Unexpected intersection of '2-4' and '3-6' was found '[34]'.",
                     column: 11,
                 },
                 {
                     message:
-                        "Unexpected intersection of '5-7' and '3-6' was found '5-6'.",
+                        "Unexpected intersection of '5-7' and '3-6' was found '[56]'.",
                     column: 15,
                 },
             ],
@@ -397,12 +397,12 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected intersection of '/-7' and '\\w' was found '0-7'.",
+                        "Unexpected intersection of '/-7' and '\\w' was found '[0-7]'.",
                     column: 6,
                 },
                 {
                     message:
-                        "Unexpected intersection of '8-:' and '\\w' was found '8-9'.",
+                        "Unexpected intersection of '8-:' and '\\w' was found '[89]'.",
                     column: 10,
                 },
             ],
@@ -422,12 +422,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected intersection of 'A-_' and '\\w' was found '_'.",
-                    column: 5,
-                },
-                {
-                    message:
-                        "Unexpected intersection of 'A-_' and '\\w' was found 'A-Z'.",
+                        "Unexpected intersection of 'A-_' and '\\w' was found '[A-Z_]'.",
                     column: 5,
                 },
             ],


### PR DESCRIPTION
I changed the implementation to only use `CharSet` functions. This made the `getCharacterClassRangeAndCharacterClassRangeOrCharacterSetIntersections` unnecessary which removed about 100 lines of code.

Also, the overlap between ranges and character sets is now reported as one report (see the `/[\wA-_]/` test case).

---

@ota-meshi This is just an assumption on my part but did you not know how to convert a `CharSet` into something readable? If you have any questions regarding what refa can do, feel free to ask any time.

You can also read [the docs](https://rundevelopment.github.io/refa/docs/latest/). The main points of interest are probably [CharSet](https://rundevelopment.github.io/refa/docs/latest/classes/charset.html) and [toLiteral](https://rundevelopment.github.io/refa/docs/latest/modules/js.html#toliteral).