### PR TITLE
Improved `no-useless-non-capturing-group` rule

### DIFF
--- a/docs/rules/no-useless-non-capturing-group.md
+++ b/docs/rules/no-useless-non-capturing-group.md
@@ -13,7 +13,7 @@ since: "v0.4.0"
 
 ## :book: Rule Details
 
-This rule reports unnecessary Non-capturing group
+This rule reports unnecessary non-capturing group
 
 <eslint-code-block fix>
 
@@ -22,18 +22,48 @@ This rule reports unnecessary Non-capturing group
 
 /* ✓ GOOD */
 var foo = /(?:abcd)?/
-var foo = /(?:ab|cd)/
+var foo = /a(?:ab|cd)/
 
 /* ✗ BAD */
+var foo = /(?:ab|cd)/
 var foo = /(?:abcd)/
 var foo = /(?:[a-d])/
+var foo = /(?:[a-d])|e/
+var foo = /(?:a|(?:b|c)|d)/
 ```
 
 </eslint-code-block>
 
 ## :wrench: Options
 
-Nothing.
+```json5
+{
+  "regexp/no-useless-non-capturing-group": ["error", {
+    "allowTop": true
+  }]
+}
+```
+
+- `"allowTop"`:
+  Whether a top-level non-capturing group is allowed. Defaults to `false`.
+
+<eslint-code-block fix>
+
+```js
+/* eslint regexp/no-useless-non-capturing-group: ["error", { allowTop: true }] */
+
+/* ✓ GOOD */
+var foo = /(?:abcd)/
+var foo = /(?:ab|cd)/
+var foo = /(?:abcd)/
+var foo = /(?:[a-d])/
+
+/* ✗ BAD */
+var foo = /(?:[a-d])|e/
+var foo = /(?:a|(?:b|c)|d)/
+```
+
+</eslint-code-block>
 
 ## :rocket: Version
 

--- a/docs/rules/no-useless-non-capturing-group.md
+++ b/docs/rules/no-useless-non-capturing-group.md
@@ -47,6 +47,8 @@ var foo = /(?:a|(?:b|c)|d)/
 - `"allowTop"`:
   Whether a top-level non-capturing group is allowed. Defaults to `false`.
 
+  Sometimes it's useful to wrap a whole pattern into a non-capturing group (e.g. when the pattern is used as a building block to construct more complex patterns). Use this option to allow top-level non-capturing groups.
+
 <eslint-code-block fix>
 
 ```js

--- a/lib/rules/no-useless-non-capturing-group.ts
+++ b/lib/rules/no-useless-non-capturing-group.ts
@@ -1,6 +1,26 @@
+import type { Group } from "regexpp/ast"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { RegExpContext } from "../utils"
 import { canUnwrapped, createRule, defineRegexpVisitor } from "../utils"
+
+/**
+ * Returns whether the given group is the top-level group of its pattern.
+ *
+ * A pattern with a top-level groups is of the form `/(?:...)/flags`.
+ */
+function isTopLevel(group: Group): boolean {
+    const parent = group.parent
+    if (parent.type === "Alternative" && parent.elements.length === 1) {
+        const parentParent = parent.parent
+        if (
+            parentParent.type === "Pattern" &&
+            parentParent.alternatives.length === 1
+        ) {
+            return true
+        }
+    }
+    return false
+}
 
 export default createRule("no-useless-non-capturing-group", {
     meta: {
@@ -11,62 +31,73 @@ export default createRule("no-useless-non-capturing-group", {
             recommended: false,
         },
         fixable: "code",
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowTop: { type: "boolean" },
+                },
+                additionalProperties: false,
+            },
+        ],
         messages: {
             unexpected: "Unexpected quantifier Non-capturing group.",
         },
         type: "suggestion", // "problem",
     },
     create(context) {
+        const allowTop = context.options[0]?.allowTop ?? false
+
         /**
          * Create visitor
          */
         function createVisitor({
             node,
             getRegexpLocation,
-            getRegexpRange,
+            fixReplaceNode,
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onGroupEnter(gNode) {
-                    if (gNode.alternatives.length !== 1) {
-                        // Useful when using disjunctions.
-                        // e.g. /(?:a|b)/
+                    if (allowTop && isTopLevel(gNode)) {
                         return
                     }
-                    const alt = gNode.alternatives[0]
-                    if (alt.elements.length === 0) {
-                        // Ignore empty groups. You can check with another rule.
-                        // e.g. /(?:)/
-                        return
-                    }
-                    const parent = gNode.parent
-                    if (
-                        parent.type === "Quantifier" &&
-                        (alt.elements.length > 1 ||
-                            alt.elements[0].type === "Quantifier")
-                    ) {
-                        // e.g. /(?:ab)?/
-                        return
-                    }
-                    if (!canUnwrapped(gNode, alt.raw)) {
-                        return
+
+                    if (gNode.alternatives.length === 1) {
+                        const alt = gNode.alternatives[0]
+                        if (alt.elements.length === 0) {
+                            // Ignore empty groups. You can check with another rule.
+                            // e.g. /(?:)/
+                            return
+                        }
+                        const parent = gNode.parent
+                        if (
+                            parent.type === "Quantifier" &&
+                            (alt.elements.length > 1 ||
+                                alt.elements[0].type === "Quantifier")
+                        ) {
+                            // e.g. /(?:ab)?/
+                            return
+                        }
+                        if (!canUnwrapped(gNode, alt.raw)) {
+                            return
+                        }
+                    } else {
+                        // the group might still be useless
+                        // e.g. /a(?:b|(?:c|d)|e)/
+                        const parent = gNode.parent
+                        if (parent.type !== "Alternative") {
+                            return
+                        }
+                        if (parent.elements.length !== 1) {
+                            return
+                        }
                     }
 
                     context.report({
                         node,
                         loc: getRegexpLocation(gNode),
                         messageId: "unexpected",
-                        fix(fixer) {
-                            const groupRange = getRegexpRange(gNode)
-                            const altRange = getRegexpRange(alt)
-                            if (!groupRange || !altRange) {
-                                return null
-                            }
-                            return [
-                                fixer.removeRange([groupRange[0], altRange[0]]),
-                                fixer.removeRange([altRange[1], groupRange[1]]),
-                            ]
-                        },
+                        fix: fixReplaceNode(gNode, gNode.raw.slice(3, -1)),
                     })
                 },
             }

--- a/tests/lib/rules/no-useless-non-capturing-group.ts
+++ b/tests/lib/rules/no-useless-non-capturing-group.ts
@@ -11,14 +11,37 @@ const tester = new RuleTester({
 tester.run("no-useless-non-capturing-group", rule as any, {
     valid: [
         `/(?:abcd)?/`,
-        `/(?:ab|cd)/`,
-        `/(?:a|b)/`,
         `/(?:)/`,
+        {
+            code: `/(?:a|b)/`,
+            options: [{ allowTop: true }],
+        },
         String.raw`/()\1(?:0)/`,
         String.raw`/\1(?:0)/`,
         String.raw`/\0(?:1)/`,
         String.raw`/(\d)(?=(?:\d{3})+(?!\d))/g`,
-        `/(?:.|a|b)/`,
+
+        String(/(?:a{2})+/),
+        String(/{(?:2)}/),
+        String(/{(?:2,)}/),
+        String(/{(?:2,5)}/),
+        String(/{2,(?:5)}/),
+        String(/a{(?:5})/),
+        String(/\u{(?:41)}/),
+        String(/(.)\1(?:2\s)/),
+        String(/\0(?:2)/),
+        String(/\x4(?:1)*/),
+        String(/\x4(?:1)/),
+        String(/(?:\x4)1/),
+        String(/\x(?:4)1/),
+        String(/\x(?:41\w+)/),
+        String(/\u004(?:1)/),
+        String(/\u00(?:4)1/),
+        String(/\u0(?:0)41/),
+        String(/\u(?:0)041/),
+        String(/\c(?:A)/),
+        String(/(?:)/),
+        String(/(?:a|b)c/),
     ],
     invalid: [
         {
@@ -46,6 +69,16 @@ tester.run("no-useless-non-capturing-group", rule as any, {
                     endColumn: 12,
                 },
             ],
+        },
+        {
+            code: `/(?:ab|cd)/`,
+            output: `/ab|cd/`,
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: `/a(?:ab|(?:.|a|b))/`,
+            output: `/a(?:ab|.|a|b)/`,
+            errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
             code: `/(?:[abcd]+?)/`,
@@ -93,6 +126,47 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             const s = "(?:a"+"\\n)"
             new RegExp(s)`,
             output: null,
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+
+        {
+            code: String(/(?:a)/),
+            output: String(/a/),
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: String(/(?:a)+/),
+            output: String(/a+/),
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: String(/(?:\w)/),
+            output: String(/\w/),
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: String(/(?:[abc])*/),
+            output: String(/[abc]*/),
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: String(/foo(?:[abc]*)bar/),
+            output: String(/foo[abc]*bar/),
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: String(/foo(?:bar)/),
+            output: String(/foobar/),
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: String(/(?:a|b)/),
+            output: String(/a|b/),
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: String(/a|(?:b|c)/),
+            output: String(/a|b|c/),
             errors: ["Unexpected quantifier Non-capturing group."],
         },
     ],


### PR DESCRIPTION
Changes:

- The rule can now also simplify `a(?:b|(?:c|d)|e)` to `a(?:b|c|d|e)`
- New option to allow a top-level non-capturing group.
- Improved `canUnwrapped` function.
- Improved docs

This makes the rule compatible with `clean-regex/no-unnecessary-group`.