### PR TITLE
Updated `prefer-character-class` rule

### DIFF
--- a/docs/rules/prefer-character-class.md
+++ b/docs/rules/prefer-character-class.md
@@ -13,7 +13,15 @@ since: "v0.4.0"
 
 ## :book: Rule Details
 
-This rule is aimed to use character classes instead of the disjunction of single element alternatives.
+Instead of single-character alternatives (e.g. `(?:a|b|c)`), character classes (e.g. `[abc]`) should be preferred.
+
+The main reason for doing this is performance. Character classes don't require backtracking and are heavily optimized by the regex engine. On the other hand, alternatives are usually quite tricky to optimize.
+
+Character classes are also safer than alternatives because they don't require backtracking. While `^(?:\w|a)+b$` will take _O(2^n)_ time to reject a string of _n_ many `a`s, the regex `^[\wa]+b$` will reject a string of _n_ many `a`s in _O(n)_.
+
+### Limitations
+
+This rule might not be able to merge all single-character alternatives.
 
 <eslint-code-block fix>
 
@@ -22,9 +30,13 @@ This rule is aimed to use character classes instead of the disjunction of single
 
 /* ✓ GOOD */
 var foo = /[abc]/
+var foo = /(?:a|b)/
 
 /* ✗ BAD */
 var foo = /a|b|c/
+var foo = /(a|b|c)c/
+var foo = /.|\s/
+var foo = /(\w|\d)+:/
 ```
 
 </eslint-code-block>

--- a/lib/rules/prefer-character-class.ts
+++ b/lib/rules/prefer-character-class.ts
@@ -1,15 +1,415 @@
 import type { RegExpVisitor } from "regexpp/visitor"
 import type {
+    Alternative,
     CapturingGroup,
     Character,
     CharacterClass,
+    CharacterClassElement,
     CharacterSet,
+    Element,
     Group,
     LookaroundAssertion,
+    Node,
     Pattern,
 } from "regexpp/ast"
 import type { RegExpContext } from "../utils"
 import { createRule, defineRegexpVisitor } from "../utils"
+import type { CharSet } from "refa"
+import type { FirstConsumedChar } from "regexp-ast-analysis"
+import { getFirstConsumedChar, getMatchingDirection } from "regexp-ast-analysis"
+import type { Position, SourceLocation } from "estree"
+
+/**
+ * Find the first index of an element that satisfies the given condition.
+ */
+function findIndex<T>(
+    arr: readonly T[],
+    condFn: (item: T, index: number) => boolean,
+): number {
+    return arr.findIndex(condFn)
+}
+
+/**
+ * Find the last index of an element that satisfies the given condition.
+ */
+function findLastIndex<T>(
+    arr: readonly T[],
+    condFn: (item: T, index: number) => boolean,
+): number {
+    for (let i = arr.length - 1; i >= 0; i--) {
+        if (condFn(arr[i], i)) {
+            return i
+        }
+    }
+    return -1
+}
+
+type NodeWithAlternatives =
+    | Group
+    | CapturingGroup
+    | Pattern
+    | LookaroundAssertion
+
+type RawAlternative = RawCharAlternative | RawNonCharAlternative
+interface RawCharAlternative {
+    readonly isCharacter: true
+    readonly alternative: Alternative
+    readonly element: Character | CharacterSet | CharacterClass
+}
+interface RawNonCharAlternative {
+    readonly isCharacter: false
+    readonly alternative: Alternative
+}
+
+type ParsedAlternative = ParsedCharAlternative | ParsedNonCharAlternative
+type CharElementArray = Readonly<CharacterClassElement>[]
+interface ParsedCharAlternative {
+    readonly isCharacter: true
+    readonly raw: string
+    readonly char: CharSet
+    readonly elements: CharElementArray
+}
+interface ParsedNonCharAlternative {
+    readonly isCharacter: false
+    readonly raw: string
+    readonly firstChar: FirstConsumedChar
+}
+
+/**
+ * Returns the string representation of the given character class elements in a character class.
+ */
+function elementsToCharacterClass(elements: CharElementArray): string {
+    // This won't do any optimization.
+    // Its ONLY job is to generate a valid character class from the given elements.
+    // Optimizations can be done by another rule.
+
+    let result = "["
+
+    elements.forEach((e, i) => {
+        switch (e.type) {
+            case "Character":
+                if (e.raw === "-") {
+                    if (i === 0 || i === elements.length - 1) {
+                        result += "-"
+                    } else {
+                        result += "\\-"
+                    }
+                } else if (e.raw === "^") {
+                    if (i === 0) {
+                        result += "\\^"
+                    } else {
+                        result += "^"
+                    }
+                } else if (e.raw === "]") {
+                    result += "\\]"
+                } else {
+                    result += e.raw
+                }
+                break
+
+            case "CharacterClassRange":
+                if (e.min.raw === "^" && i === 0) {
+                    result += `\\^-${e.max.raw}`
+                } else {
+                    result += `${e.min.raw}-${e.max.raw}`
+                }
+                break
+
+            case "CharacterSet":
+                result += e.raw
+                break
+
+            default:
+                throw new Error(e)
+        }
+    })
+
+    result += "]"
+
+    return result
+}
+
+/**
+ * Given alternatives, this will return an array in which each alternative is categorized by whether it contains only a
+ * single character (that can be combined with other characters in a character class) or not.
+ */
+function categorizeRawAlts(
+    alternatives: readonly Alternative[],
+    { toCharSet }: RegExpContext,
+): RawAlternative[] {
+    return alternatives.map<RawAlternative>((alternative) => {
+        if (alternative.elements.length === 1) {
+            const element = alternative.elements[0]
+            if (
+                element.type === "Character" ||
+                element.type === "CharacterClass" ||
+                element.type === "CharacterSet"
+            ) {
+                return {
+                    isCharacter: true,
+                    alternative,
+                    element,
+                    char: toCharSet(element),
+                }
+            }
+        }
+        return {
+            isCharacter: false,
+            alternative,
+        }
+    })
+}
+
+/**
+ * Returns whether the given set contains a character class.
+ */
+function containsCharacterClass(alts: readonly RawAlternative[]): boolean {
+    for (const alt of alts) {
+        if (alt.isCharacter && alt.alternative.elements.length === 1) {
+            const e = alt.alternative.elements[0]
+            if (e.type === "CharacterClass" && !e.negate) {
+                return true
+            }
+        }
+    }
+    return false
+}
+
+/**
+ * Tries to convert the given element into character class elements.
+ *
+ * The returned array may be empty.
+ */
+function toCharacterClassElement(element: Element): CharElementArray | null {
+    if (element.type === "CharacterSet") {
+        // normal dot is not possible (it technically is but it's complicated)
+        if (element.kind === "any") {
+            return null
+        }
+        return [element]
+    } else if (element.type === "CharacterClass") {
+        if (element.negate) {
+            // we can't (easily) combine negated character classes
+            return null
+        }
+        return element.elements
+    } else if (element.type === "Character") {
+        return [element]
+    }
+    return null
+}
+
+/**
+ * Parses the given raw alternatives.
+ */
+function parseRawAlts(
+    alternatives: readonly RawAlternative[],
+    { flags, toCharSet }: RegExpContext,
+): ParsedAlternative[] {
+    return alternatives.map<ParsedAlternative>((a) => {
+        if (a.isCharacter) {
+            const elements = toCharacterClassElement(a.element)
+            if (elements) {
+                return {
+                    isCharacter: true,
+                    elements,
+                    char: toCharSet(a.element),
+                    raw: a.alternative.raw,
+                }
+            }
+        }
+        return {
+            isCharacter: false,
+            firstChar: getFirstConsumedChar(
+                a.alternative,
+                getMatchingDirection(a.alternative),
+                flags,
+            ),
+            raw: a.alternative.raw,
+        }
+    })
+}
+
+/**
+ * Tries to merge as many character alternatives as possible.
+ */
+function optimizeCharacterAlts(alternatives: ParsedAlternative[]): void {
+    /**
+     * The actual merge implementation.
+     */
+    function merge(
+        a: ParsedCharAlternative,
+        b: ParsedCharAlternative,
+    ): ParsedCharAlternative {
+        const elements = [...a.elements, ...b.elements]
+        return {
+            isCharacter: true,
+            char: a.char.union(b.char),
+            elements,
+            raw: elementsToCharacterClass(elements),
+        }
+    }
+
+    // Here's how the merge algorithm works:
+    //
+    // We go through all alternatives from left to right. If we find a character alternative A, we will merge all
+    // following character alternatives into it until
+    // 1) we find a non-character alternative with a first character that can be the empty string,
+    // 2) we find a non-character alternative B such that the union of first character in B is the "all" set, or
+    // 3) we find a character alternative C such that C is not disjoint with the union of all the first characters
+    //    of all non-character alternatives between A and C.
+    //
+    // This re-ordering approach has the following properties:
+    // a) It keeps the order of non-character alternatives and the order of character alternatives intact.
+    // b) It runs in O(n) with n being the number of alternatives.
+
+    for (let i = 0; i < alternatives.length - 1; i++) {
+        let curr = alternatives[i]
+        if (!curr.isCharacter) {
+            continue
+        }
+
+        /**
+         * The union of all character sets a char alternative has to be disjoint with in order to be moved.
+         */
+        let nonCharTotal: CharSet | undefined = undefined
+        for (let j = i + 1; j < alternatives.length; j++) {
+            const far = alternatives[j]
+            if (far.isCharacter) {
+                // character alternative
+                if (
+                    nonCharTotal === undefined ||
+                    far.char.isDisjointWith(nonCharTotal)
+                ) {
+                    curr = merge(curr, far)
+                    alternatives.splice(j, 1)
+                    j--
+                } else {
+                    break
+                }
+            } else {
+                // non-character alternative
+                if (!far.firstChar.empty) {
+                    if (nonCharTotal === undefined) {
+                        nonCharTotal = far.firstChar.char
+                    } else {
+                        nonCharTotal = nonCharTotal.union(far.firstChar.char)
+                    }
+                    if (nonCharTotal.isAll) {
+                        // Since, it's impossible for any non-empty character set to be disjoint with the "all" set,
+                        // we can stop right here.
+                        break
+                    }
+                } else {
+                    // this means that the `far` alternative accepts the empty word.
+                    // Since we don't know what comes after the alternative, we have to assume that it may be any
+                    // character, meaning that `nonCharTotal` will be set to the "all" character set.
+                    break
+                }
+            }
+        }
+
+        alternatives[i] = curr
+    }
+}
+
+/**
+ * Return whether all character alternatives are disjoint with each other.
+ */
+function findNonDisjointAlt(
+    alternatives: readonly ParsedAlternative[],
+): ParsedCharAlternative | null {
+    let total: CharSet | undefined = undefined
+    for (const a of alternatives) {
+        if (a.isCharacter) {
+            if (total === undefined) {
+                total = a.char
+            } else {
+                if (!total.isDisjointWith(a.char)) {
+                    return a
+                }
+                total = total.union(a.char)
+            }
+        }
+    }
+    return null
+}
+
+/**
+ * Returns where the given alternative can accept any character.
+ */
+function totalIsAll(
+    alternatives: readonly RawAlternative[],
+    { toCharSet }: RegExpContext,
+): boolean {
+    let total: CharSet | undefined = undefined
+    for (const a of alternatives) {
+        if (a.isCharacter) {
+            if (total === undefined) {
+                total = toCharSet(a.element)
+            } else {
+                total = total.union(toCharSet(a.element))
+            }
+        }
+    }
+    return total !== undefined && total.isAll
+}
+
+/**
+ * Returns the content prefix and suffix of the given parent node.
+ */
+function getParentPrefixAndSuffix(
+    parent: NodeWithAlternatives,
+): [string, string] {
+    switch (parent.type) {
+        case "Assertion":
+            return [
+                `(?${parent.kind === "lookahead" ? "" : "<"}${
+                    parent.negate ? "!" : "="
+                }`,
+                ")",
+            ]
+
+        case "CapturingGroup":
+            if (parent.name !== null) {
+                return [`(?<${parent.name}>`, ")"]
+            }
+            return ["(", ")"]
+
+        case "Group":
+            return ["(?:", ")"]
+
+        case "Pattern":
+            return ["", ""]
+
+        default:
+            throw new Error(parent)
+    }
+}
+
+/**
+ * Returns the minimum position.
+ */
+function minPos(a: Position, b: Position): Position {
+    if (a.column < b.column) {
+        return a
+    } else if (b.column < a.column) {
+        return b
+    }
+    return a.line < b.line ? a : b
+}
+
+/**
+ * Returns the maximum position.
+ */
+function maxPos(a: Position, b: Position): Position {
+    if (a.column > b.column) {
+        return a
+    } else if (b.column > a.column) {
+        return b
+    }
+    return a.line > b.line ? a : b
+}
 
 export default createRule("prefer-character-class", {
     meta: {
@@ -31,90 +431,144 @@ export default createRule("prefer-character-class", {
         /**
          * Create visitor
          */
-        function createVisitor({
-            node,
-            fixerApplyEscape,
-            getRegexpLocation,
-            getRegexpRange,
-        }: RegExpContext): RegExpVisitor.Handlers {
-            /** Verify alternatives */
-            function verify(
-                regexpNode:
-                    | Group
-                    | CapturingGroup
-                    | Pattern
-                    | LookaroundAssertion,
+        function createVisitor(
+            regexpContext: RegExpContext,
+        ): RegExpVisitor.Handlers {
+            const { node, getRegexpLocation, fixReplaceNode } = regexpContext
+
+            /**
+             * Replaces the alternatives of the given node with the given
+             * new alternatives.
+             */
+            function fixReplaceAlternatives(
+                n: NodeWithAlternatives,
+                newAlternatives: string,
             ) {
-                if (regexpNode.alternatives.length <= 1) {
-                    return
-                }
-                const elements: (
-                    | Character
-                    | CharacterSet
-                    | CharacterClass
-                )[] = []
-                for (const alt of regexpNode.alternatives) {
-                    if (alt.elements.length !== 1) {
-                        return
-                    }
-                    const element = alt.elements[0]
-                    if (element.type === "CharacterSet") {
-                        if (element.kind === "any") {
-                            return
-                        }
-                    } else if (
-                        element.type !== "Character" &&
-                        element.type !== "CharacterClass"
-                    ) {
-                        return
-                    }
-                    elements.push(element)
+                const [prefix, suffix] = getParentPrefixAndSuffix(n)
+                return fixReplaceNode(n, prefix + newAlternatives + suffix)
+            }
+
+            /**
+             * Returns the combined location of the locations of the given
+             * elements.
+             */
+            function unionRegexpLocations(elements: Node[]): SourceLocation {
+                let { start, end } = getRegexpLocation(elements[0])
+
+                for (let i = 1; i < elements.length; i++) {
+                    const other = getRegexpLocation(elements[1])
+                    start = minPos(start, other.start)
+                    end = maxPos(end, other.end)
                 }
 
-                context.report({
-                    node,
-                    loc: getRegexpLocation(regexpNode),
-                    messageId: "unexpected",
-                    fix(fixer) {
-                        let replaceRange: [number, number] | null = null
-                        let newText = ""
-                        for (const element of elements) {
-                            const range = getRegexpRange(element)
-                            if (!range) {
-                                return null
-                            }
-                            if (!replaceRange) {
-                                replaceRange = [...range]
-                            } else {
-                                replaceRange[1] = range[1]
-                            }
-                            const text =
-                                element.type === "CharacterClass"
-                                    ? element.raw.slice(1, -1)
-                                    : element.raw
-                            if (text.startsWith("-")) {
-                                newText += fixerApplyEscape("\\")
-                            }
-                            newText += fixerApplyEscape(text)
-                        }
-                        return fixer.replaceTextRange(
-                            replaceRange!,
-                            `[${newText}]`,
+                return { start, end }
+            }
+
+            // eslint-disable-next-line require-jsdoc -- X
+            function process(n: NodeWithAlternatives): void {
+                if (n.alternatives.length < 2) {
+                    // we need at least 2 alternatives with characters to make this work
+                    return
+                }
+
+                const alts = categorizeRawAlts(n.alternatives, regexpContext)
+                const characterAltsCount = alts.filter((a) => a.isCharacter)
+                    .length
+
+                if (characterAltsCount < 2) {
+                    // we need at least 2 character alternatives
+                    return
+                }
+
+                if (
+                    alts.every((a) => a.isCharacter) &&
+                    totalIsAll(alts, regexpContext)
+                ) {
+                    // This is the special case where:
+                    // 1) all alternatives are characters,
+                    // 2) there are at least 2 alternatives, and
+                    // 3) the union of all alternatives accepts all characters.
+
+                    context.report({
+                        node,
+                        loc: getRegexpLocation(n),
+                        messageId: "unexpected",
+                        fix: fixReplaceAlternatives(n, "[^]"),
+                    })
+                    return
+                }
+
+                // This is the general case:
+                // We have both character and non-character alternatives. The following will try to merge character
+                // alternatives and might even re-order alternatives to do so.
+                //
+                // We will only try to optimize alternatives if
+                // 1) there are >= 3 character alternatives, or
+                // 2) the characters of the character alternatives are not disjoint, or
+                // 3) the union of all character alternatives is the "all" set.
+
+                const parsedAlts = parseRawAlts(alts, regexpContext)
+
+                if (
+                    characterAltsCount >= 3 ||
+                    containsCharacterClass(alts) ||
+                    totalIsAll(alts, regexpContext) ||
+                    findNonDisjointAlt(parsedAlts)
+                ) {
+                    optimizeCharacterAlts(parsedAlts)
+
+                    if (parsedAlts.length !== alts.length) {
+                        // Something (don't know what exactly) was changed
+
+                        // Try to narrow down the range of which alternatives changed as much as possible.
+                        // This won't change that we replace the whole element but it will give a lot more precise error
+                        // messages for elements with many alternatives.
+                        const firstChanged = findIndex(
+                            parsedAlts,
+                            (a, i) => a.raw !== n.alternatives[i].raw,
                         )
-                    },
-                })
+                        const lastChanged = findLastIndex(
+                            parsedAlts,
+                            (a, i) => {
+                                const index =
+                                    n.alternatives.length +
+                                    i -
+                                    parsedAlts.length
+                                return a.raw !== n.alternatives[index].raw
+                            },
+                        )
+                        const changedNodes = [
+                            n.alternatives[firstChanged],
+                            n.alternatives[
+                                n.alternatives.length +
+                                    lastChanged -
+                                    parsedAlts.length
+                            ],
+                        ]
+
+                        context.report({
+                            node,
+                            loc: unionRegexpLocations(changedNodes),
+                            messageId: "unexpected",
+                            fix: fixReplaceAlternatives(
+                                n,
+                                parsedAlts.map((a) => a.raw).join("|"),
+                            ),
+                        })
+                    }
+                }
             }
 
             return {
-                onPatternEnter: verify,
-                onGroupEnter: verify,
-                onCapturingGroupEnter: verify,
+                onPatternEnter: process,
+                onGroupEnter: process,
+                onCapturingGroupEnter: process,
                 onAssertionEnter(aNode) {
                     if (
                         aNode.kind === "lookahead" ||
                         aNode.kind === "lookbehind"
                     ) {
-                        verify(aNode)
+                        process(aNode)
                     }
                 },
             }

--- a/tests/lib/rules/prefer-character-class.ts
+++ b/tests/lib/rules/prefer-character-class.ts
@@ -13,8 +13,12 @@ tester.run("prefer-character-class", rule as any, {
         `/regexp/`,
         `/[regexp]/`,
         `/reg|exp/`,
-        String.raw`/a|b|c|\d|(d)/`,
-        String.raw`/a|.|c|\d|c|[-d-f]/`,
+
+        String.raw`/(?:a|b)/`,
+        String.raw`/(?:a|b|c\b)/`,
+        String.raw`/(?:[ab]|c\b)/`,
+        String.raw`/(?:[ab]|cd)/`,
+        String.raw`/(?:[ab]|(c))/`,
     ],
     invalid: [
         {
@@ -39,9 +43,9 @@ tester.run("prefer-character-class", rule as any, {
                     message:
                         "Unexpected the disjunction of single element alternatives. Use character class '[...]' instead.",
                     line: 1,
-                    column: 2,
+                    column: 3,
                     endLine: 1,
-                    endColumn: 12,
+                    endColumn: 11,
                 },
             ],
         },
@@ -53,9 +57,9 @@ tester.run("prefer-character-class", rule as any, {
                     message:
                         "Unexpected the disjunction of single element alternatives. Use character class '[...]' instead.",
                     line: 1,
-                    column: 2,
+                    column: 5,
                     endLine: 1,
-                    endColumn: 14,
+                    endColumn: 13,
                 },
             ],
         },
@@ -67,9 +71,9 @@ tester.run("prefer-character-class", rule as any, {
                     message:
                         "Unexpected the disjunction of single element alternatives. Use character class '[...]' instead.",
                     line: 1,
-                    column: 2,
+                    column: 5,
                     endLine: 1,
-                    endColumn: 14,
+                    endColumn: 13,
                 },
             ],
         },
@@ -81,9 +85,9 @@ tester.run("prefer-character-class", rule as any, {
                     message:
                         "Unexpected the disjunction of single element alternatives. Use character class '[...]' instead.",
                     line: 1,
-                    column: 2,
+                    column: 6,
                     endLine: 1,
-                    endColumn: 15,
+                    endColumn: 14,
                 },
             ],
         },
@@ -123,6 +127,162 @@ tester.run("prefer-character-class", rule as any, {
             output: null,
             errors: [
                 "Unexpected the disjunction of single element alternatives. Use character class '[...]' instead.",
+            ],
+        },
+
+        { code: String.raw`/a|b|c/`, output: String.raw`/[abc]/`, errors: 1 },
+        { code: String.raw`/]|a|b/`, output: String.raw`/[\]ab]/`, errors: 1 },
+        { code: String.raw`/-|a|c/`, output: String.raw`/[-ac]/`, errors: 1 },
+        { code: String.raw`/a|-|c/`, output: String.raw`/[a\-c]/`, errors: 1 },
+        {
+            code: String.raw`/a|[-]|c/`,
+            output: String.raw`/[a\-c]/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?:a|b|c)/`,
+            output: String.raw`/(?:[abc])/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(a|b|c)/`,
+            output: String.raw`/([abc])/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?<name>a|b|c)/`,
+            output: String.raw`/(?<name>[abc])/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?:a|b|c|d\b)/`,
+            output: String.raw`/(?:[abc]|d\b)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?:a|b\b|[c]|d)/`,
+            output: String.raw`/(?:[acd]|b\b)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?:a|\w|\s|["'])/`,
+            output: String.raw`/(?:[a\w\s"'])/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?:\w|-|\+|\*|\/)+/`,
+            output: String.raw`/(?:[\w\-\+\*\/])+/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?=a|b|c)/`,
+            output: String.raw`/(?=[abc])/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?!a|b|c)/`,
+            output: String.raw`/(?![abc])/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?<=a|b|c)/`,
+            output: String.raw`/(?<=[abc])/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?<!a|b|c)/`,
+            output: String.raw`/(?<![abc])/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?=a|b|c|dd|e)/`,
+            output: String.raw`/(?=[abce]|dd)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?!a|b|c|dd|e)/`,
+            output: String.raw`/(?![abce]|dd)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?<=a|b|c|dd|e)/`,
+            output: String.raw`/(?<=[abce]|dd)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?<!a|b|c|dd|e)/`,
+            output: String.raw`/(?<![abce]|dd)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[abc]|d/`,
+            output: String.raw`/[abcd]/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[abc]|d|ee/`,
+            output: String.raw`/[abcd]|ee/`,
+            errors: 1,
+        },
+
+        // always merge non-disjoint
+        {
+            code: String.raw`/(?:a|\w|b\b)/`,
+            output: String.raw`/(?:[a\w]|b\b)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?:\w|a|b\b)/`,
+            output: String.raw`/(?:[\wa]|b\b)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?:\w|b\b|a)/`,
+            output: String.raw`/(?:[\wa]|b\b)/`,
+            errors: 1,
+        },
+
+        // always do match all
+        {
+            code: String.raw`/(?:\s|\S|b\b)/`,
+            output: String.raw`/(?:[\s\S]|b\b)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?:\w|\D|b\b)/`,
+            output: String.raw`/(?:[\w\D]|b\b)/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/(?:\w|\W|b\b)/`,
+            output: String.raw`/(?:[\w\W]|b\b)/`,
+            errors: 1,
+        },
+
+        {
+            code: String.raw`/--?|-=|\+\+?|\+=|!=?|~|\*\*?|\*=|\/=?|%=?|<<=?|>>=?|<=?|>=?|==?|&&?|&=|\^=?|\|\|?|\|=|\?|:/`,
+            output: String.raw`/--?|-=|\+\+?|\+=|!=?|[~\?:]|\*\*?|\*=|\/=?|%=?|<<=?|>>=?|<=?|>=?|==?|&&?|&=|\^=?|\|\|?|\|=/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&|\|\|?|\?|\*|\/|~|\^|%/`,
+            output: String.raw`/--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&|\|\|?|[\?\*\/~\^%]/`,
+            errors: 1,
+        },
+
+        // only report affected alternatives
+        {
+            code: String.raw`/foo|bar|a|b|c|baz/`,
+            output: String.raw`/foo|bar|[abc]|baz/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected the disjunction of single element alternatives. Use character class '[...]' instead.",
+                    line: 1,
+                    column: 10,
+                    endLine: 1,
+                    endColumn: 15,
+                },
             ],
         },
     ],


### PR DESCRIPTION
This reimplements the `prefer-character-class` using the `clean-regex/prefer-character-class` implementation.

The `clean-regex` implementation is a lot more aggressive and will combine basically anything into a character class that is possible to combine. It will even ignore alternative order if it's safe to do so (e.g. `a|bb|c|d` -> `[acd]|bb`).