### PR TITLE
Add `control-character-escape` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | Rule ID | Description |    |
 |:--------|:------------|:---|
 | [regexp/confusing-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/confusing-quantifier.html) | disallow confusing quantifiers |  |
+| [regexp/control-character-escape](https://ota-meshi.github.io/eslint-plugin-regexp/rules/control-character-escape.html) | enforce consistent escaping of control characters | :wrench: |
 | [regexp/hexadecimal-escape](https://ota-meshi.github.io/eslint-plugin-regexp/rules/hexadecimal-escape.html) | enforce consistent usage of hexadecimal escape | :wrench: |
 | [regexp/letter-case](https://ota-meshi.github.io/eslint-plugin-regexp/rules/letter-case.html) | enforce into your favorite case | :wrench: |
 | [regexp/match-any](https://ota-meshi.github.io/eslint-plugin-regexp/rules/match-any.html) | enforce match any character style | :star::wrench: |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -12,6 +12,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | Rule ID | Description |    |
 |:--------|:------------|:---|
 | [regexp/confusing-quantifier](./confusing-quantifier.md) | disallow confusing quantifiers |  |
+| [regexp/control-character-escape](./control-character-escape.md) | enforce consistent escaping of control characters | :wrench: |
 | [regexp/hexadecimal-escape](./hexadecimal-escape.md) | enforce consistent usage of hexadecimal escape | :wrench: |
 | [regexp/letter-case](./letter-case.md) | enforce into your favorite case | :wrench: |
 | [regexp/match-any](./match-any.md) | enforce match any character style | :star::wrench: |

--- a/docs/rules/control-character-escape.md
+++ b/docs/rules/control-character-escape.md
@@ -13,7 +13,7 @@ description: "enforce consistent escaping of control characters"
 
 ## :book: Rule Details
 
-This rule reports ???.
+This rule reports control characters that were not escaped using a control escape (`\0`, `t`, `\n`, `\v`, `f`, `\r`).
 
 <eslint-code-block fix>
 

--- a/docs/rules/control-character-escape.md
+++ b/docs/rules/control-character-escape.md
@@ -1,0 +1,44 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "regexp/control-character-escape"
+description: "enforce consistent escaping of control characters"
+---
+# regexp/control-character-escape
+
+> enforce consistent escaping of control characters
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule reports ???.
+
+<eslint-code-block fix>
+
+```js
+/* eslint regexp/control-character-escape: "error" */
+
+/* ✓ GOOD */
+var foo = /[\n\r]/;
+var foo = /\t/;
+var foo = RegExp("\t+\n");
+
+/* ✗ BAD */
+var foo = /	/;
+var foo = /\u0009/;
+var foo = /\u{a}/u;
+var foo = RegExp("\\u000a");
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/lib/rules/control-character-escape.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/tests/lib/rules/control-character-escape.ts)

--- a/lib/rules/control-character-escape.ts
+++ b/lib/rules/control-character-escape.ts
@@ -1,0 +1,95 @@
+import type { RegExpVisitor } from "regexpp/visitor"
+import type { RegExpContext } from "../utils"
+import {
+    CP_VT,
+    CP_CR,
+    CP_FF,
+    CP_LF,
+    CP_TAB,
+    createRule,
+    defineRegexpVisitor,
+    isRegexpLiteral,
+} from "../utils"
+
+const CONTROL_CHARS = new Map<number, string>([
+    [0, "\\0"],
+    [CP_TAB, "\\t"],
+    [CP_LF, "\\n"],
+    [CP_VT, "\\v"],
+    [CP_FF, "\\f"],
+    [CP_CR, "\\r"],
+])
+
+export default createRule("control-character-escape", {
+    meta: {
+        docs: {
+            description: "enforce consistent escaping of control characters",
+            // TODO Switch to recommended in the major version.
+            // recommended: true,
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [],
+        messages: {
+            unexpected:
+                "Unexpected control character escape '{{actual}}' ({{cp}}). Use '{{expected}}' instead.",
+        },
+        type: "suggestion", // "problem",
+    },
+    create(context) {
+        /**
+         * Create visitor
+         */
+        function createVisitor({
+            node,
+            getRegexpLocation,
+            fixReplaceNode,
+        }: RegExpContext): RegExpVisitor.Handlers {
+            return {
+                onCharacterEnter(cNode) {
+                    if (cNode.parent.type === "CharacterClassRange") {
+                        // ignore ranges
+                        return
+                    }
+
+                    const expectedRaw = CONTROL_CHARS.get(cNode.value)
+                    if (expectedRaw === undefined) {
+                        // not a known control character
+                        return
+                    }
+                    if (cNode.raw === expectedRaw) {
+                        // all good
+                        return
+                    }
+                    if (
+                        !isRegexpLiteral(node) &&
+                        cNode.raw === String.fromCodePoint(cNode.value)
+                    ) {
+                        // we allow the direct usage of control characters in
+                        // string if it's not in regexp literal
+                        // e.g. `RegExp("[\t\n]")` is ok
+                        return
+                    }
+
+                    context.report({
+                        node,
+                        loc: getRegexpLocation(cNode),
+                        messageId: "unexpected",
+                        data: {
+                            actual: cNode.raw,
+                            cp: `U+${cNode.value
+                                .toString(16)
+                                .padStart(4, "0")}`,
+                            expected: expectedRaw,
+                        },
+                        fix: fixReplaceNode(cNode, expectedRaw),
+                    })
+                },
+            }
+        }
+
+        return defineRegexpVisitor(context, {
+            createVisitor,
+        })
+    },
+})

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -1,5 +1,6 @@
 import type { RuleModule } from "../types"
 import confusingQuantifier from "../rules/confusing-quantifier"
+import controlCharacterEscape from "../rules/control-character-escape"
 import hexadecimalEscape from "../rules/hexadecimal-escape"
 import letterCase from "../rules/letter-case"
 import matchAny from "../rules/match-any"
@@ -53,6 +54,7 @@ import unicodeEscape from "../rules/unicode-escape"
 
 export const rules = [
     confusingQuantifier,
+    controlCharacterEscape,
     hexadecimalEscape,
     letterCase,
     matchAny,

--- a/tests/lib/rules/control-character-escape.ts
+++ b/tests/lib/rules/control-character-escape.ts
@@ -1,0 +1,112 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/control-character-escape"
+
+const tester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+})
+
+tester.run("control-character-escape", rule as any, {
+    valid: [
+        String.raw`/\0\t\n\v\f\r/`,
+        String.raw`RegExp(/\0\t\n\v\f\r/, "i")`,
+        String.raw`RegExp("\0\t\n\v\f\r", "i")`,
+        String.raw`RegExp("\\0\\t\\n\\v\\f\\r", "i")`,
+        "/\\t/",
+        "new RegExp('\t')",
+    ],
+    invalid: [
+        {
+            code: String.raw`/\x00/`,
+            output: String.raw`/\0/`,
+            errors: [
+                "Unexpected control character escape '\\x00' (U+0000). Use '\\0' instead.",
+            ],
+        },
+        {
+            code: String.raw`/\x0a/`,
+            output: String.raw`/\n/`,
+            errors: [
+                "Unexpected control character escape '\\x0a' (U+000a). Use '\\n' instead.",
+            ],
+        },
+        {
+            code: String.raw`/\cJ/`,
+            output: String.raw`/\n/`,
+            errors: [
+                "Unexpected control character escape '\\cJ' (U+000a). Use '\\n' instead.",
+            ],
+        },
+        {
+            code: String.raw`/\u{a}/u`,
+            output: String.raw`/\n/u`,
+            errors: [
+                "Unexpected control character escape '\\u{a}' (U+000a). Use '\\n' instead.",
+            ],
+        },
+        {
+            code: String.raw`RegExp("\\cJ")`,
+            output: String.raw`RegExp("\\n")`,
+            errors: [
+                "Unexpected control character escape '\\cJ' (U+000a). Use '\\n' instead.",
+            ],
+        },
+        {
+            code: String.raw`RegExp("\\u{a}", "u")`,
+            output: String.raw`RegExp("\\n", "u")`,
+            errors: [
+                "Unexpected control character escape '\\u{a}' (U+000a). Use '\\n' instead.",
+            ],
+        },
+
+        {
+            code: "/\\u0009/",
+            output: "/\\t/",
+            errors: [
+                {
+                    message:
+                        "Unexpected control character escape '\\u0009' (U+0009). Use '\\t' instead.",
+                    column: 2,
+                    endColumn: 8,
+                },
+            ],
+        },
+        {
+            code: "/\t/",
+            output: "/\\t/",
+            errors: [
+                {
+                    message:
+                        "Unexpected control character escape '\t' (U+0009). Use '\\t' instead.",
+                    column: 2,
+                    endColumn: 3,
+                },
+            ],
+        },
+        {
+            code: String.raw`
+            const s = "\\u0009"
+            new RegExp(s)
+            `,
+            output: String.raw`
+            const s = "\\t"
+            new RegExp(s)
+            `,
+            errors: [
+                "Unexpected control character escape '\\u0009' (U+0009). Use '\\t' instead.",
+            ],
+        },
+        {
+            code: String.raw`
+            const s = "\\u"+"0009"
+            new RegExp(s)
+            `,
+            output: null,
+            errors: [
+                "Unexpected control character escape '\\u0009' (U+0009). Use '\\t' instead.",
+            ],
+        },
+    ],
+})


### PR DESCRIPTION
This resolves #165.

While `\0` is not a [control escape](https://tc39.es/ecma262/#sec-patterns-static-semantics-character-value), I still added it because it is a control character.

I did not deprecate `prefer-t` here because doing so removes it from the recommended config.