### PR TITLE
Use refa's `CharRange` instead

### DIFF
--- a/lib/utils/char-ranges.ts
+++ b/lib/utils/char-ranges.ts
@@ -8,11 +8,7 @@ import {
     CP_SMALL_Z,
 } from "./unicode"
 import type { JSONSchema4 } from "json-schema"
-
-export interface CharRange {
-    readonly min: number
-    readonly max: number
-}
+import type { CharRange } from "refa"
 
 const ALL_RANGES: readonly CharRange[] = [{ min: 0, max: 0x10ffff }]
 const ALPHANUMERIC_RANGES: readonly CharRange[] = [


### PR DESCRIPTION
For some reason, I added an interface that is exactly equivalent to refa's `CharRange`...

This PR removes the `CharRange` interface and imports refa's CharRange interface instead.