### PR TITLE
Add `regexp/no-useless-lazy` rule that same `regexp/no-useless-non-greedy` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-useless-escape](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-escape.html) | disallow unnecessary escape characters in RegExp |  |
 | [regexp/no-useless-exactly-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-exactly-quantifier.html) | disallow unnecessary exactly quantifier | :star: |
 | [regexp/no-useless-flag](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-flag.html) | disallow unnecessary regex flags | :wrench: |
+| [regexp/no-useless-lazy](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-lazy.html) | disallow unnecessarily non-greedy quantifiers | :wrench: |
 | [regexp/no-useless-non-capturing-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-non-capturing-group.html) | disallow unnecessary Non-capturing group | :wrench: |
 | [regexp/no-useless-non-greedy](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-non-greedy.html) | disallow unnecessarily non-greedy quantifiers | :wrench: |
 | [regexp/no-useless-range](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-range.html) | disallow unnecessary range of characters by using a hyphen | :wrench: |

--- a/docs/.vuepress/components/rules/index.js
+++ b/docs/.vuepress/components/rules/index.js
@@ -37,6 +37,9 @@ const allRules = []
 
 for (const k of Object.keys(plugin.rules)) {
     const rule = plugin.rules[k]
+    if (rule.meta.deprecated) {
+        continue
+    }
     rule.meta.docs.category = rule.meta.docs.recommended
         ? "recommended"
         : "uncategorized"

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -42,6 +42,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-useless-escape](./no-useless-escape.md) | disallow unnecessary escape characters in RegExp |  |
 | [regexp/no-useless-exactly-quantifier](./no-useless-exactly-quantifier.md) | disallow unnecessary exactly quantifier | :star: |
 | [regexp/no-useless-flag](./no-useless-flag.md) | disallow unnecessary regex flags | :wrench: |
+| [regexp/no-useless-lazy](./no-useless-lazy.md) | disallow unnecessarily non-greedy quantifiers | :wrench: |
 | [regexp/no-useless-non-capturing-group](./no-useless-non-capturing-group.md) | disallow unnecessary Non-capturing group | :wrench: |
 | [regexp/no-useless-non-greedy](./no-useless-non-greedy.md) | disallow unnecessarily non-greedy quantifiers | :wrench: |
 | [regexp/no-useless-range](./no-useless-range.md) | disallow unnecessary range of characters by using a hyphen | :wrench: |

--- a/docs/rules/no-useless-lazy.md
+++ b/docs/rules/no-useless-lazy.md
@@ -1,0 +1,58 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "regexp/no-useless-lazy"
+description: "disallow unnecessarily non-greedy quantifiers"
+---
+# regexp/no-useless-lazy
+
+> disallow unnecessarily non-greedy quantifiers
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule reports lazy quantifiers that don't need to by lazy.
+
+There are two reasons why a lazy quantifier doesn't have to lazy:
+
+1. It's a constant quantifier (e.g. `a{3}?`).
+
+2. The quantifier is effectively possessive (e.g. `a+?b`).
+
+   Whether a quantifier (let's call it _q_) is effectively possessive depends on the expression after it (let's call it _e_). _q_ is effectively possessive if _q_ cannot accept the character accepted by _e_ and _e_ cannot accept the characters accepted by _q_.
+
+   In the example above, the character `a` and the character `b` do not overlap. Therefore the quantifier `a+` is possessive.
+
+   Since an effectively possessive quantifier cannot give up characters to the expression after it, it doesn't matter whether the quantifier greedy or lazy. However, greedy quantifiers should be preferred because they require less characters to write and are easier to visually parse.
+
+<eslint-code-block fix>
+
+```js
+/* eslint regexp/no-useless-lazy: "error" */
+
+/* ✓ GOOD */
+var foo = /a*?/;
+var foo = /a+?/;
+var foo = /a{4,}?/;
+var foo = /a{2,4}?/;
+var foo = /a[\s\S]*?bar/;
+
+/* ✗ BAD */
+var foo = /a{1}?/;
+var foo = /a{4}?/;
+var foo = /a{2,2}?/;
+var foo = /ab+?c/;
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/lib/rules/no-useless-lazy.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/tests/lib/rules/no-useless-lazy.ts)

--- a/docs/rules/no-useless-non-greedy.md
+++ b/docs/rules/no-useless-non-greedy.md
@@ -13,44 +13,10 @@ since: "v0.3.0"
 
 ## :book: Rule Details
 
-This rule reports lazy quantifiers that don't need to by lazy.
+This rule is the same as the [regexp/no-useless-lazy] rule. Use [regexp/no-useless-lazy] instead.
+Replaced by [regexp/no-useless-lazy] in v1.0.0, this rule will be marked as **deprecated**.
 
-There are two reasons why a lazy quantifier doesn't have to lazy:
-
-1. It's a constant quantifier (e.g. `a{3}?`).
-
-2. The quantifier is effectively possessive (e.g. `a+?b`).
-
-   Whether a quantifier (let's call it _q_) is effectively possessive depends on the expression after it (let's call it _e_). _q_ is effectively possessive if _q_ cannot accept the character accepted by _e_ and _e_ cannot accept the characters accepted by _q_.
-
-   In the example above, the character `a` and the character `b` do not overlap. Therefore the quantifier `a+` is possessive.
-
-   Since an effectively possessive quantifier cannot give up characters to the expression after it, it doesn't matter whether the quantifier greedy or lazy. However, greedy quantifiers should be preferred because they require less characters to write and are easier to visually parse.
-
-<eslint-code-block fix>
-
-```js
-/* eslint regexp/no-useless-non-greedy: "error" */
-
-/* ✓ GOOD */
-var foo = /a*?/;
-var foo = /a+?/;
-var foo = /a{4,}?/;
-var foo = /a{2,4}?/;
-var foo = /a[\s\S]*?bar/;
-
-/* ✗ BAD */
-var foo = /a{1}?/;
-var foo = /a{4}?/;
-var foo = /a{2,2}?/;
-var foo = /ab+?c/;
-```
-
-</eslint-code-block>
-
-## :wrench: Options
-
-Nothing.
+[regexp/no-useless-lazy]: no-useless-lazy.md
 
 ## :rocket: Version
 

--- a/lib/rules/no-useless-lazy.ts
+++ b/lib/rules/no-useless-lazy.ts
@@ -1,0 +1,119 @@
+import type { Rule } from "eslint"
+import type { SourceLocation } from "estree"
+import {
+    getMatchingDirection,
+    getFirstConsumedChar,
+    getFirstCharAfter,
+} from "regexp-ast-analysis"
+import type { Quantifier } from "regexpp/ast"
+import type { RegExpVisitor } from "regexpp/visitor"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
+
+/**
+ * Returns a fix that makes the given quantifier greedy.
+ */
+function makeGreedy({ getRegexpRange }: RegExpContext, qNode: Quantifier) {
+    return (fixer: Rule.RuleFixer): Rule.Fix | null => {
+        const range = getRegexpRange(qNode)
+        if (range == null) {
+            return null
+        }
+        return fixer.removeRange([range[1] - 1, range[1]])
+    }
+}
+
+/**
+ * Returns the source location of the lazy modifier of the given quantifier.
+ */
+function getLazyLoc(
+    { getRegexpLocation }: RegExpContext,
+    qNode: Quantifier,
+): SourceLocation {
+    const offset = qNode.raw.length - 1
+    return getRegexpLocation(qNode, [offset, offset + 1])
+}
+
+export default createRule("no-useless-lazy", {
+    meta: {
+        docs: {
+            description: "disallow unnecessarily non-greedy quantifiers",
+            // TODO In the major version
+            // recommended: true,
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [],
+        messages: {
+            constant: "Unexpected non-greedy constant quantifier.",
+            possessive:
+                "Unexpected non-greedy constant quantifier. The quantifier is effectively possessive, so it doesn't matter whether it is greedy or not.",
+        },
+        type: "suggestion", // "problem",
+    },
+    create(context) {
+        /**
+         * Create visitor
+         */
+        function createVisitor(
+            regexpContext: RegExpContext,
+        ): RegExpVisitor.Handlers {
+            const { node, flags } = regexpContext
+            return {
+                onQuantifierEnter(qNode) {
+                    if (qNode.greedy) {
+                        return
+                    }
+
+                    if (qNode.min === qNode.max) {
+                        // a constant lazy quantifier (e.g. /a{2}?/)
+
+                        context.report({
+                            node,
+                            loc: getLazyLoc(regexpContext, qNode),
+                            messageId: "constant",
+                            fix: makeGreedy(regexpContext, qNode),
+                        })
+                        return
+                    }
+
+                    // This is more tricky.
+                    // The basic idea here is that if the first character of the
+                    // quantified element and the first character of whatever
+                    // comes after the quantifier are always different, then the
+                    // lazy modifier doesn't matter.
+                    // E.g. /a+?b+/ == /a+b+/
+
+                    const matchingDir = getMatchingDirection(qNode)
+                    const firstChar = getFirstConsumedChar(
+                        qNode,
+                        matchingDir,
+                        flags,
+                    )
+                    if (!firstChar.empty) {
+                        const after = getFirstCharAfter(
+                            qNode,
+                            matchingDir,
+                            flags,
+                        )
+                        if (
+                            !after.edge &&
+                            firstChar.char.isDisjointWith(after.char)
+                        ) {
+                            context.report({
+                                node,
+                                loc: getLazyLoc(regexpContext, qNode),
+                                messageId: "possessive",
+                                fix: makeGreedy(regexpContext, qNode),
+                            })
+                        }
+                    }
+                },
+            }
+        }
+
+        return defineRegexpVisitor(context, {
+            createVisitor,
+        })
+    },
+})

--- a/lib/rules/no-useless-non-greedy.ts
+++ b/lib/rules/no-useless-non-greedy.ts
@@ -1,119 +1,19 @@
-import type { Rule } from "eslint"
-import type { SourceLocation } from "estree"
-import {
-    getMatchingDirection,
-    getFirstConsumedChar,
-    getFirstCharAfter,
-} from "regexp-ast-analysis"
-import type { Quantifier } from "regexpp/ast"
-import type { RegExpVisitor } from "regexpp/visitor"
-import type { RegExpContext } from "../utils"
-import { createRule, defineRegexpVisitor } from "../utils"
+import { createRule } from "../utils"
 
-/**
- * Returns a fix that makes the given quantifier greedy.
- */
-function makeGreedy({ getRegexpRange }: RegExpContext, qNode: Quantifier) {
-    return (fixer: Rule.RuleFixer): Rule.Fix | null => {
-        const range = getRegexpRange(qNode)
-        if (range == null) {
-            return null
-        }
-        return fixer.removeRange([range[1] - 1, range[1]])
-    }
-}
-
-/**
- * Returns the source location of the lazy modifier of the given quantifier.
- */
-function getLazyLoc(
-    { getRegexpLocation }: RegExpContext,
-    qNode: Quantifier,
-): SourceLocation {
-    const offset = qNode.raw.length - 1
-    return getRegexpLocation(qNode, [offset, offset + 1])
-}
+import nonUselessLazy from "./no-useless-lazy"
 
 export default createRule("no-useless-non-greedy", {
     meta: {
+        ...nonUselessLazy.meta,
         docs: {
-            description: "disallow unnecessarily non-greedy quantifiers",
-            // TODO In the major version
-            // recommended: true,
+            ...nonUselessLazy.meta.docs,
             recommended: false,
+            replacedBy: ["no-useless-lazy"],
         },
-        fixable: "code",
-        schema: [],
-        messages: {
-            constant: "Unexpected non-greedy constant quantifier.",
-            possessive:
-                "Unexpected non-greedy constant quantifier. The quantifier is effectively possessive, so it doesn't matter whether it is greedy or not.",
-        },
-        type: "suggestion", // "problem",
+        // TODO Switch to deprecated in the major version.
+        // deprecated: true,
     },
     create(context) {
-        /**
-         * Create visitor
-         */
-        function createVisitor(
-            regexpContext: RegExpContext,
-        ): RegExpVisitor.Handlers {
-            const { node, flags } = regexpContext
-            return {
-                onQuantifierEnter(qNode) {
-                    if (qNode.greedy) {
-                        return
-                    }
-
-                    if (qNode.min === qNode.max) {
-                        // a constant lazy quantifier (e.g. /a{2}?/)
-
-                        context.report({
-                            node,
-                            loc: getLazyLoc(regexpContext, qNode),
-                            messageId: "constant",
-                            fix: makeGreedy(regexpContext, qNode),
-                        })
-                        return
-                    }
-
-                    // This is more tricky.
-                    // The basic idea here is that if the first character of the
-                    // quantified element and the first character of whatever
-                    // comes after the quantifier are always different, then the
-                    // lazy modifier doesn't matter.
-                    // E.g. /a+?b+/ == /a+b+/
-
-                    const matchingDir = getMatchingDirection(qNode)
-                    const firstChar = getFirstConsumedChar(
-                        qNode,
-                        matchingDir,
-                        flags,
-                    )
-                    if (!firstChar.empty) {
-                        const after = getFirstCharAfter(
-                            qNode,
-                            matchingDir,
-                            flags,
-                        )
-                        if (
-                            !after.edge &&
-                            firstChar.char.isDisjointWith(after.char)
-                        ) {
-                            context.report({
-                                node,
-                                loc: getLazyLoc(regexpContext, qNode),
-                                messageId: "possessive",
-                                fix: makeGreedy(regexpContext, qNode),
-                            })
-                        }
-                    }
-                },
-            }
-        }
-
-        return defineRegexpVisitor(context, {
-            createVisitor,
-        })
+        return nonUselessLazy.create(context)
     },
 })

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,7 +15,7 @@ export interface RuleMetaData {
         url: string
         ruleId: string
         ruleName: string
-        replacedBy?: []
+        replacedBy?: string[]
         default?: "error" | "warn"
     }
     messages: { [messageId: string]: string }
@@ -34,7 +34,7 @@ export interface PartialRuleMetaData {
     docs: {
         description: string
         recommended: boolean
-        replacedBy?: []
+        replacedBy?: string[]
         default?: "error" | "warn"
     }
     messages: { [messageId: string]: string }

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -30,6 +30,7 @@ import noUselessDollarReplacements from "../rules/no-useless-dollar-replacements
 import noUselessEscape from "../rules/no-useless-escape"
 import noUselessExactlyQuantifier from "../rules/no-useless-exactly-quantifier"
 import noUselessFlag from "../rules/no-useless-flag"
+import noUselessLazy from "../rules/no-useless-lazy"
 import noUselessNonCapturingGroup from "../rules/no-useless-non-capturing-group"
 import noUselessNonGreedy from "../rules/no-useless-non-greedy"
 import noUselessRange from "../rules/no-useless-range"
@@ -86,6 +87,7 @@ export const rules = [
     noUselessEscape,
     noUselessExactlyQuantifier,
     noUselessFlag,
+    noUselessLazy,
     noUselessNonCapturingGroup,
     noUselessNonGreedy,
     noUselessRange,

--- a/tests/lib/rules/no-useless-lazy.ts
+++ b/tests/lib/rules/no-useless-lazy.ts
@@ -1,0 +1,80 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-useless-lazy"
+
+const tester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+})
+
+tester.run("no-useless-lazy", rule as any, {
+    valid: [
+        `/a*?/`,
+        `/a+?/`,
+        `/a{4,}?/`,
+        `/a{2,4}?/`,
+        `/a{2,2}/`,
+        `/a{3}/`,
+        `/a+?b*/`,
+        `/[\\s\\S]+?bar/`,
+        `/a??a?/`,
+    ],
+    invalid: [
+        {
+            code: `/a{1}?/`,
+            output: `/a{1}/`,
+            errors: [
+                {
+                    messageId: "constant",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7,
+                },
+            ],
+        },
+        {
+            code: `/a{4}?/`,
+            output: `/a{4}/`,
+            errors: [
+                {
+                    messageId: "constant",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7,
+                },
+            ],
+        },
+        {
+            code: `/a{2,2}?/`,
+            output: `/a{2,2}/`,
+            errors: [{ messageId: "constant" }],
+        },
+        {
+            code: String.raw`const s = "\\d{1}?"
+            new RegExp(s)`,
+            output: String.raw`const s = "\\d{1}"
+            new RegExp(s)`,
+            errors: [{ messageId: "constant" }],
+        },
+        {
+            code: String.raw`const s = "\\d"+"{1}?"
+            new RegExp(s)`,
+            output: null,
+            errors: [{ messageId: "constant" }],
+        },
+
+        {
+            code: `/a+?b+/`,
+            output: `/a+b+/`,
+            errors: [{ messageId: "possessive" }],
+        },
+        {
+            code: `/(?:a|cd)+?(?:b+|zzz)/`,
+            output: `/(?:a|cd)+(?:b+|zzz)/`,
+            errors: [{ messageId: "possessive" }],
+        },
+    ],
+})

--- a/tests/lib/rules/no-useless-non-greedy.ts
+++ b/tests/lib/rules/no-useless-non-greedy.ts
@@ -9,72 +9,12 @@ const tester = new RuleTester({
 })
 
 tester.run("no-useless-non-greedy", rule as any, {
-    valid: [
-        `/a*?/`,
-        `/a+?/`,
-        `/a{4,}?/`,
-        `/a{2,4}?/`,
-        `/a{2,2}/`,
-        `/a{3}/`,
-        `/a+?b*/`,
-        `/[\\s\\S]+?bar/`,
-        `/a??a?/`,
-    ],
+    valid: [`/a*?/`],
     invalid: [
         {
             code: `/a{1}?/`,
             output: `/a{1}/`,
-            errors: [
-                {
-                    messageId: "constant",
-                    line: 1,
-                    column: 6,
-                    endLine: 1,
-                    endColumn: 7,
-                },
-            ],
-        },
-        {
-            code: `/a{4}?/`,
-            output: `/a{4}/`,
-            errors: [
-                {
-                    messageId: "constant",
-                    line: 1,
-                    column: 6,
-                    endLine: 1,
-                    endColumn: 7,
-                },
-            ],
-        },
-        {
-            code: `/a{2,2}?/`,
-            output: `/a{2,2}/`,
-            errors: [{ messageId: "constant" }],
-        },
-        {
-            code: String.raw`const s = "\\d{1}?"
-            new RegExp(s)`,
-            output: String.raw`const s = "\\d{1}"
-            new RegExp(s)`,
-            errors: [{ messageId: "constant" }],
-        },
-        {
-            code: String.raw`const s = "\\d"+"{1}?"
-            new RegExp(s)`,
-            output: null,
-            errors: [{ messageId: "constant" }],
-        },
-
-        {
-            code: `/a+?b+/`,
-            output: `/a+b+/`,
-            errors: [{ messageId: "possessive" }],
-        },
-        {
-            code: `/(?:a|cd)+?(?:b+|zzz)/`,
-            output: `/(?:a|cd)+(?:b+|zzz)/`,
-            errors: [{ messageId: "possessive" }],
+            errors: 1,
         },
     ],
 })


### PR DESCRIPTION
This PR adds the `regexp/no-useless-lazy` rule that has the same functionality as the `regexp/no-useless-non-greedy` rule.

Unlike #110, this PR does not abolish the `regexp/no-useless-non-greedy` rule. Therefore, this PR can be merged before v1.0.
