### PR TITLE
Updated `no-dupe-disjunctions`

### DIFF
--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -612,7 +612,7 @@ function deduplicateResults(results: readonly Result[]): Result[] {
     })
 }
 
-enum ReportOption {
+const enum ReportOption {
     all = "all",
     trivial = "trivial",
     interesting = "interesting",

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -259,10 +259,13 @@ function getSubsetRelation(
  * This function adjusts their subset relation to account for partial NFAs.
  */
 function getPartialSubsetRelation(
-    relation: SubsetRelation,
+    left: ReadonlyNFA,
     leftIsPartial: boolean,
+    right: ReadonlyNFA,
     rightIsPartial: boolean,
 ): SubsetRelation {
+    const relation = getSubsetRelation(left, right)
+
     if (!leftIsPartial && !rightIsPartial) {
         return relation
     }
@@ -497,8 +500,9 @@ function* findDuplicationNfa(
             const others = overlapping.map(([, , a]) => a)
 
             const relation = getPartialSubsetRelation(
-                getSubsetRelation(nfa, othersNfa),
+                nfa,
                 partial,
+                othersNfa,
                 othersPartial,
             )
 

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -700,7 +700,7 @@ export default createRule("no-dupe-disjunctions", {
                     parentNode.alternatives,
                     regexpContext,
                     {
-                        fastAst: true,
+                        fastAst: false,
                         noNfa: false,
                         ignoreOverlap: nodeReport !== ReportOption.all,
                         hasNothingAfter,

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -1,5 +1,6 @@
 import type { RegExpVisitor } from "regexpp/visitor"
 import type {
+    Alternative,
     CapturingGroup,
     Group,
     LookaroundAssertion,
@@ -9,6 +10,492 @@ import type {
 import type { RegExpContext } from "../utils"
 import { createRule, defineRegexpVisitor } from "../utils"
 import { isCoveredNode, isEqualNodes } from "../utils/regexp-ast"
+import type { Expression, FiniteAutomaton, ReadonlyNFA } from "refa"
+import {
+    combineTransformers,
+    Transformers,
+    DFA,
+    NFA,
+    JS,
+    visitAst,
+    transform,
+} from "refa"
+import type { ReadonlyFlags } from "regexp-ast-analysis"
+import {
+    getMatchingDirection,
+    getEffectiveMaximumRepetition,
+} from "regexp-ast-analysis"
+import { RegExpParser } from "regexpp"
+
+type ParentNode = Group | CapturingGroup | Pattern | LookaroundAssertion
+
+/**
+ * Check has after pattern
+ */
+function hasNothingAfterNode(node: ParentNode): boolean {
+    const md = getMatchingDirection(node)
+
+    for (
+        let p:
+            | Group
+            | Pattern
+            | CapturingGroup
+            | LookaroundAssertion
+            | Quantifier
+            | Alternative = node;
+        ;
+        p = p.parent
+    ) {
+        if (p.type === "Assertion" || p.type === "Pattern") {
+            return true
+        }
+
+        if (p.type !== "Alternative") {
+            const parent: Quantifier | Alternative = p.parent
+            if (parent.type === "Quantifier") {
+                if (parent.max > 1) {
+                    return false
+                }
+            } else {
+                const lastIndex: number =
+                    md === "ltr" ? parent.elements.length - 1 : 0
+                if (parent.elements[lastIndex] !== p) {
+                    return false
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Returns whether the given RE AST contains assertions.
+ */
+function containsAssertions(expression: Expression): boolean {
+    try {
+        visitAst(expression, {
+            onAssertionEnter() {
+                throw new Error()
+            },
+        })
+        return false
+    } catch (error) {
+        return true
+    }
+}
+
+const creationOption: Transformers.CreationOptions = {
+    ignoreAmbiguity: true,
+    ignoreOrder: true,
+}
+const assertionTransformer = combineTransformers([
+    Transformers.applyAssertions(creationOption),
+    Transformers.removeUnnecessaryAssertions(creationOption),
+    Transformers.inline(creationOption),
+    Transformers.removeDeadBranches(creationOption),
+])
+
+/**
+ * Create an NFA from the given element.
+ */
+function toNFA(parser: JS.Parser, element: JS.ParsableElement): NFA {
+    try {
+        const { expression, maxCharacter } = parser.parseElement(element, {
+            backreferences: "disable",
+            assertions: "parse",
+        })
+
+        let e
+        if (containsAssertions(expression)) {
+            e = transform(assertionTransformer, expression)
+        } else {
+            e = expression
+        }
+
+        return NFA.fromRegex(e, { maxCharacter }, { assertions: "disable" })
+    } catch (error) {
+        return NFA.empty({
+            maxCharacter: parser.ast.flags.unicode ? 0x10ffff : 0xffff,
+        })
+    }
+}
+
+/**
+ * Unions all given NFAs
+ */
+function unionAll(nfas: readonly ReadonlyNFA[]): ReadonlyNFA {
+    if (nfas.length === 0) {
+        throw new Error("Cannot union 0 NFAs.")
+    } else if (nfas.length === 1) {
+        return nfas[0]
+    }
+
+    const total = nfas[0].copy()
+    for (let i = 1; i < nfas.length; i++) {
+        total.union(nfas[i])
+    }
+    return total
+}
+
+/**
+ * Returns whether one NFA is a subset of another.
+ */
+function isSubsetOf(
+    superset: ReadonlyNFA,
+    subset: ReadonlyNFA,
+): boolean | null {
+    try {
+        const a = DFA.fromIntersection(superset, subset)
+        const b = DFA.fromFA(subset)
+        a.minimize()
+        b.minimize()
+        return a.structurallyEqual(b)
+    } catch (error) {
+        return null
+    }
+}
+
+const enum SubsetRelation {
+    none,
+    leftEqualRight,
+    leftSubsetOfRight,
+    leftSupersetOfRight,
+    unknown,
+}
+
+/**
+ * Returns the subset relation
+ */
+function getSubsetRelation(
+    left: ReadonlyNFA,
+    right: ReadonlyNFA,
+): SubsetRelation {
+    try {
+        const inter = DFA.fromIntersection(left, right)
+        inter.minimize()
+
+        const l = DFA.fromFA(left)
+        l.minimize()
+
+        const r = DFA.fromFA(right)
+        r.minimize()
+
+        const subset = l.structurallyEqual(inter)
+        const superset = r.structurallyEqual(inter)
+
+        if (subset && superset) {
+            return SubsetRelation.leftEqualRight
+        } else if (subset) {
+            return SubsetRelation.leftSubsetOfRight
+        } else if (superset) {
+            return SubsetRelation.leftSupersetOfRight
+        }
+        return SubsetRelation.none
+    } catch (error) {
+        return SubsetRelation.unknown
+    }
+}
+
+/**
+ * Returns the regex source of the given FA.
+ */
+function faToSource(fa: FiniteAutomaton, flags: ReadonlyFlags): string {
+    try {
+        return JS.toLiteral(fa.toRegex(), { flags }).source
+    } catch (error) {
+        return "<ERROR>"
+    }
+}
+
+interface ResultBase {
+    alternative: Alternative
+    others: Alternative[]
+}
+interface DuplicateResult extends ResultBase {
+    type: "Duplicate"
+    others: [Alternative]
+}
+interface SubsetResult extends ResultBase {
+    type: "Subset"
+}
+interface PrefixSubsetResult extends ResultBase {
+    type: "PrefixSubset"
+}
+interface SupersetResult extends ResultBase {
+    type: "Superset"
+}
+interface OverlapResult extends ResultBase {
+    type: "Overlap"
+    overlap: NFA
+}
+type Result =
+    | DuplicateResult
+    | SubsetResult
+    | PrefixSubsetResult
+    | SupersetResult
+    | OverlapResult
+
+interface Options {
+    parser: JS.Parser
+    hasNothingAfter: boolean
+    fastAst: boolean
+    noNfa: boolean
+    ignoreOverlap: boolean
+}
+
+/**
+ * Tries to find duplication in the given alternatives
+ */
+function* findDuplicationAstFast(
+    alternatives: Alternative[],
+    { toCharSet }: RegExpContext,
+): Iterable<Result> {
+    // eslint-disable-next-line func-style -- x
+    const shortCircuit: Parameters<typeof isEqualNodes>[3] = (a) => {
+        return a.type === "CapturingGroup" ? false : null
+    }
+
+    for (let i = 0; i < alternatives.length; i++) {
+        const alternative = alternatives[i]
+
+        for (let j = 0; j < i; j++) {
+            const other = alternatives[j]
+
+            if (isEqualNodes(other, alternative, toCharSet, shortCircuit)) {
+                yield { type: "Duplicate", alternative, others: [other] }
+            }
+        }
+    }
+}
+
+/**
+ * Tries to find duplication in the given alternatives
+ */
+function* findDuplicationAst(
+    alternatives: Alternative[],
+    context: RegExpContext,
+    hasNothingAfter: boolean,
+): Iterable<Result> {
+    const { flags, toCharSet } = context
+
+    const isCoveredOptions: Parameters<typeof isCoveredNode>[2] = {
+        flags,
+        canOmitRight: hasNothingAfter,
+        toCharSet,
+    }
+    const isCoveredOptionsNoPrefix: Parameters<typeof isCoveredNode>[2] = {
+        flags,
+        canOmitRight: false,
+        toCharSet,
+    }
+
+    for (let i = 0; i < alternatives.length; i++) {
+        const alternative = alternatives[i]
+
+        for (let j = 0; j < i; j++) {
+            const other = alternatives[j]
+
+            if (isCoveredNode(other, alternative, isCoveredOptions)) {
+                if (isEqualNodes(other, alternative, toCharSet)) {
+                    yield {
+                        type: "Duplicate",
+                        alternative,
+                        others: [other],
+                    }
+                } else if (
+                    hasNothingAfter &&
+                    !isCoveredNode(other, alternative, isCoveredOptionsNoPrefix)
+                ) {
+                    yield {
+                        type: "PrefixSubset",
+                        alternative,
+                        others: [other],
+                    }
+                } else {
+                    yield { type: "Subset", alternative, others: [other] }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Tries to find duplication in the given alternatives.
+ *
+ * It will search for prefix duplications. I.e. the alternative `ab` in `a|ab`
+ * is a duplicate of `a` because if `ab` accepts, `a` will have already accepted
+ * the input string. This makes `ab` effectively useless.
+ *
+ * This operation will modify the given NFAs.
+ */
+function* findPrefixDuplicationNfa(
+    alternatives: [NFA, Alternative][],
+): Iterable<Result> {
+    if (alternatives.length === 0) {
+        return
+    }
+
+    // For two alternatives `A|B`, `B` is useless if `B` is a subset of `A[^]*`
+
+    const all = NFA.all({ maxCharacter: alternatives[0][0].maxCharacter })
+
+    for (let i = 1; i < alternatives.length; i++) {
+        const [nfa, alternative] = alternatives[i]
+
+        const overlapping = alternatives
+            .slice(0, i)
+            .filter(([otherNfa]) => !nfa.isDisjointWith(otherNfa))
+
+        if (overlapping.length >= 1) {
+            const othersNfa = unionAll(overlapping.map(([n]) => n))
+            const others = overlapping.map(([, a]) => a)
+
+            // Only checking for a subset relation is sufficient here.
+            // Duplicates are VERY unlikely. (Who would use alternatives
+            // like `a|a[^]*`?)
+
+            if (isSubsetOf(othersNfa, nfa)) {
+                yield { type: "PrefixSubset", alternative, others }
+            } else {
+                // The else case is interesting.
+                // It means that _some_ of the paths in the current alternative are useless.
+                // TODO: Decide whether this should be reported as well.
+            }
+        }
+
+        nfa.append(all)
+    }
+}
+
+/**
+ * Tries to find duplication in the given alternatives.
+ */
+function* findDuplicationNfa(
+    alternatives: Alternative[],
+    { hasNothingAfter, parser, ignoreOverlap }: Options,
+): Iterable<Result> {
+    const previous: [NFA, Alternative][] = []
+    for (let i = 0; i < alternatives.length; i++) {
+        const alternative = alternatives[i]
+        const nfa = toNFA(parser, alternative)
+
+        const overlapping = previous.filter(
+            ([otherNfa]) => !nfa.isDisjointWith(otherNfa),
+        )
+
+        if (overlapping.length >= 1) {
+            const othersNfa = unionAll(overlapping.map(([n]) => n))
+            const others = overlapping.map(([, a]) => a)
+
+            const relation = getSubsetRelation(nfa, othersNfa)
+            switch (relation) {
+                case SubsetRelation.leftEqualRight:
+                    if (others.length === 1) {
+                        // only return "duplicate" if there is only one other
+                        // alternative
+                        yield {
+                            type: "Duplicate",
+                            alternative,
+                            others: [others[0]],
+                        }
+                    } else {
+                        yield { type: "Subset", alternative, others }
+                    }
+                    break
+
+                case SubsetRelation.leftSubsetOfRight:
+                    yield { type: "Subset", alternative, others }
+                    break
+
+                case SubsetRelation.leftSupersetOfRight:
+                    yield { type: "Superset", alternative, others }
+                    break
+
+                case SubsetRelation.none:
+                case SubsetRelation.unknown:
+                    // TODO: we might want to report cases where the relation
+                    // couldn't be determined
+                    if (!ignoreOverlap) {
+                        yield {
+                            type: "Overlap",
+                            alternative,
+                            others,
+                            overlap: NFA.fromIntersection(nfa, othersNfa),
+                        }
+                    }
+                    break
+
+                default:
+                    throw new Error(relation)
+            }
+        }
+
+        previous.push([nfa, alternative])
+    }
+
+    if (hasNothingAfter) {
+        yield* findPrefixDuplicationNfa(previous)
+    }
+}
+
+/**
+ * Tries to find duplication in the given alternatives
+ */
+function* findDuplication(
+    alternatives: Alternative[],
+    context: RegExpContext,
+    options: Options,
+): Iterable<Result> {
+    // AST-based approach
+    if (options.fastAst) {
+        yield* findDuplicationAstFast(alternatives, context)
+    } else {
+        yield* findDuplicationAst(
+            alternatives,
+            context,
+            options.hasNothingAfter,
+        )
+    }
+
+    // NFA-based approach
+    if (!options.noNfa) {
+        yield* findDuplicationNfa(alternatives, options)
+    }
+}
+
+const RESULT_TYPE_ORDER: Result["type"][] = [
+    "Duplicate",
+    "Subset",
+    "PrefixSubset",
+    "Superset",
+    "Overlap",
+]
+
+/**
+ * Returns an array of the given results that is sorted by result type from
+ * most important to least important.
+ */
+function sortResultTypes(unsorted: Iterable<Result>): Result[] {
+    return [...unsorted].sort(
+        (a, b) =>
+            RESULT_TYPE_ORDER.indexOf(a.type) -
+            RESULT_TYPE_ORDER.indexOf(b.type),
+    )
+}
+
+/**
+ * Returns an array of the given results that is sorted by result type from
+ * most important to least important.
+ */
+function deduplicateResults(results: readonly Result[]): Result[] {
+    const seen = new Set<Alternative>()
+    return results.filter(({ alternative }) => {
+        if (seen.has(alternative)) {
+            return false
+        }
+        seen.add(alternative)
+        return true
+    })
+}
 
 export default createRule("no-dupe-disjunctions", {
     meta: {
@@ -28,100 +515,123 @@ export default createRule("no-dupe-disjunctions", {
             },
         ],
         messages: {
-            duplicated: "The disjunctions are duplicated.",
-            neverExecute:
-                "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+            duplicate: "Unexpected duplicate alternative.{{exp}}",
+            subset:
+                "Unexpected useless alternative. This alternative is a subset of '{{others}}' and can be removed.{{exp}}",
+            prefixSubset:
+                // TODO: better message
+                "Unexpected useless alternative. This alternative is already covered by '{{others}}' and can be removed.",
+            // TODO: better message
+            superset: "superset others: '{{others}}' TODO:.{{exp}}",
+            overlap:
+                "Unexpected overlap. This alternative overlaps with '{{others}}'. The overlap is '{{expr}}'.{{exp}}",
         },
         type: "suggestion", // "problem",
     },
     create(context) {
-        const disallowNeverMatch = Boolean(
-            context.options[0]?.disallowNeverMatch,
-        )
-
-        /**
-         * Check has after pattern
-         */
-        function hasAfterPattern(
-            node: Group | CapturingGroup | Pattern | LookaroundAssertion,
-        ): boolean {
-            if (node.type === "Assertion") {
-                return false
-            }
-            if (node.type === "Pattern") {
-                return false
-            }
-            let target: Group | CapturingGroup | Quantifier = node
-            let parent = target.parent
-            while (parent) {
-                if (parent.type === "Alternative") {
-                    const index = parent.elements.indexOf(target)
-                    if (index < parent.elements.length - 1) {
-                        return true
-                    }
-                    return hasAfterPattern(parent.parent)
-                }
-                if (parent.type === "Quantifier") {
-                    target = parent
-                    parent = target.parent
-                    continue
-                }
-                return false
-            }
-            return false
-        }
+        // TODO: options
 
         /**
          * Create visitor
          */
-        function createVisitor({
-            node,
-            flags,
-            toCharSet,
-            getRegexpLocation,
-        }: RegExpContext): RegExpVisitor.Handlers {
+        function createVisitor(
+            regexpContext: RegExpContext,
+        ): RegExpVisitor.Handlers {
+            const {
+                patternAst,
+                flagsString,
+                flags,
+                node,
+                getRegexpLocation,
+            } = regexpContext
+
+            const parser = JS.Parser.fromAst({
+                pattern: patternAst,
+                flags: new RegExpParser().parseFlags(
+                    flagsString?.replace(/[^gimsuy]/g, "") ?? "",
+                ),
+            })
+
             /** Verify group node */
-            function verify(
-                regexpNode:
-                    | Group
-                    | CapturingGroup
-                    | Pattern
-                    | LookaroundAssertion,
-            ) {
-                const canOmitRight =
-                    disallowNeverMatch && !hasAfterPattern(regexpNode)
-                const leftAlts = []
-                for (const alt of regexpNode.alternatives) {
-                    const dupeAlt = disallowNeverMatch
-                        ? leftAlts.find((leftAlt) =>
-                              isCoveredNode(leftAlt, alt, {
-                                  flags,
-                                  canOmitRight,
-                                  toCharSet,
-                              }),
-                          )
-                        : leftAlts.find((leftAlt) =>
-                              isEqualNodes(leftAlt, alt, toCharSet, (a, _b) => {
-                                  if (a.type === "CapturingGroup") {
-                                      return false
-                                  }
-                                  return null
-                              }),
-                          )
-                    if (dupeAlt) {
+            function verify(parentNode: ParentNode) {
+                const rawResults = findDuplication(
+                    parentNode.alternatives,
+                    regexpContext,
+                    {
+                        fastAst: false,
+                        noNfa: false,
+                        ignoreOverlap: false,
+                        hasNothingAfter: hasNothingAfterNode(parentNode),
+                        parser,
+                    },
+                )
+
+                const results = deduplicateResults(sortResultTypes(rawResults))
+
+                results.forEach(report)
+            }
+
+            /** Report the given result. */
+            function report(result: Result) {
+                const exp =
+                    getEffectiveMaximumRepetition(result.alternative) > 10
+                        ? " This ambiguity is likely to cause exponential backtracking."
+                        : ""
+
+                const others = result.others.map((a) => a.raw).join("|")
+
+                switch (result.type) {
+                    case "Duplicate":
                         context.report({
                             node,
-                            loc: getRegexpLocation(alt),
-                            messageId:
-                                disallowNeverMatch &&
-                                !isEqualNodes(dupeAlt, alt, toCharSet)
-                                    ? "neverExecute"
-                                    : "duplicated",
+                            loc: getRegexpLocation(result.alternative),
+                            messageId: "duplicate",
+                            data: { exp, others },
                         })
-                        continue
-                    }
+                        break
 
-                    leftAlts.push(alt)
+                    case "Subset":
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(result.alternative),
+                            messageId: "subset",
+                            data: { exp, others },
+                        })
+                        break
+
+                    case "PrefixSubset":
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(result.alternative),
+                            messageId: "prefixSubset",
+                            data: { exp, others },
+                        })
+                        break
+
+                    case "Superset":
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(result.alternative),
+                            messageId: "superset",
+                            data: { exp, others },
+                        })
+                        break
+
+                    case "Overlap":
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(result.alternative),
+                            messageId: "overlap",
+                            data: {
+                                exp,
+                                others,
+                                expr: faToSource(result.overlap, flags),
+                            },
+                        })
+                        break
+
+                    default:
+                        throw new Error(result)
                 }
             }
 

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -635,6 +635,8 @@ export default createRule("no-dupe-disjunctions", {
                         enum: ["all", "trivial", "interesting"],
                     },
                     alwaysReportExponentialBacktracking: { type: "boolean" },
+                    // TODO remove in the next major version
+                    disallowNeverMatch: { type: "boolean" },
                 },
                 additionalProperties: false,
             },

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -589,14 +589,14 @@ export default createRule("no-dupe-disjunctions", {
             },
         ],
         messages: {
-            duplicate: "Unexpected duplicate alternative.{{exp}}",
+            duplicate:
+                "Unexpected duplicate alternative. This alternative can be removed.{{exp}}",
             subset:
-                "Unexpected useless alternative. This alternative is a subset of '{{others}}' and can be removed.{{exp}}",
+                "Unexpected useless alternative. This alternative is a strict subset of '{{others}}' and can be removed.{{exp}}",
             prefixSubset:
-                // TODO: better message
                 "Unexpected useless alternative. This alternative is already covered by '{{others}}' and can be removed.",
-            // TODO: better message
-            superset: "superset others: '{{others}}' TODO:.{{exp}}",
+            superset:
+                "Unexpected superset. This alternative is a superset of '{{others}}'. It might be possible to remove the other alternative(s).{{exp}}",
             overlap:
                 "Unexpected overlap. This alternative overlaps with '{{others}}'. The overlap is '{{expr}}'.{{exp}}",
         },

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -564,16 +564,14 @@ function* findDuplication(
     options: Options,
 ): Iterable<Result> {
     // AST-based approach
-    if (Math.random() > 6) {
-        if (options.fastAst) {
-            yield* findDuplicationAstFast(alternatives, context)
-        } else {
-            yield* findDuplicationAst(
-                alternatives,
-                context,
-                options.hasNothingAfter,
-            )
-        }
+    if (options.fastAst) {
+        yield* findDuplicationAstFast(alternatives, context)
+    } else {
+        yield* findDuplicationAst(
+            alternatives,
+            context,
+            options.hasNothingAfter,
+        )
     }
 
     // NFA-based approach

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -78,6 +78,8 @@ type RegExpHelpersBase = {
     fixReplaceFlags: (
         newFlags: string | (() => string | null),
     ) => (fixer: Rule.RuleFixer) => Rule.Fix[] | Rule.Fix | null
+
+    patternAst: Pattern
 }
 export type RegExpHelpersForLiteral = {
     /**
@@ -523,6 +525,8 @@ function buildRegExpHelperBase({
                 regexpNode,
                 newFlags,
             ),
+
+        patternAst: parsedPattern,
     }
 }
 

--- a/tests/lib/rules/no-dupe-disjunctions.ts
+++ b/tests/lib/rules/no-dupe-disjunctions.ts
@@ -70,6 +70,17 @@ tester.run("no-dupe-disjunctions", rule as any, {
             ],
         },
         {
+            code: `/(?=[a-c])|(?=a)/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected useless alternative. This alternative is a strict subset of '(?=[a-c])' and can be removed.",
+                    column: 12,
+                    endColumn: 17,
+                },
+            ],
+        },
+        {
             code: `/(?=a|a)/`,
             errors: [
                 {

--- a/tests/lib/rules/no-dupe-disjunctions.ts
+++ b/tests/lib/rules/no-dupe-disjunctions.ts
@@ -10,143 +10,134 @@ const tester = new RuleTester({
 
 tester.run("no-dupe-disjunctions", rule as any, {
     valid: [
-        ...[
-            String.raw`/^\s*(eslint-(?:en|dis)able)(?:\s+(\S|\S[\s\S]*\S))?\s*$/u`,
-            `/a|b/`,
-            `/(a|b)/`,
-            `/(?:a|b)/`,
-            `/((?:ab|ba)|(?:ba|ac))/`,
-            `/(?:js|json)$/`,
-            `/(?:js|jso?n?)$/`,
-            `/(?:js|json)abc/`,
-            `/(?:js|json)?abc/`,
-            `/(?:yml|ya?ml)$/`,
-            `/(?:yml|ya?ml)/`,
-        ].reduce(
-            (acc, x) =>
-                acc.concat(x, {
-                    code: x,
-                    options: [{ disallowNeverMatch: true }],
-                }),
-            [] as (RuleTester.ValidTestCase | string)[],
-        ),
-        `/(?:(a)|(a))/`,
-        `/(?:a|ab)/`,
-        `/(?:.|a|b)/`,
-        {
-            code: `/<("[^"]*"|'[^']*'|[^'">])*>/g`,
-            options: [{ disallowNeverMatch: true }],
-        },
+        String.raw`/^\s*(eslint-(?:en|dis)able)(?:\s+(\S|\S[\s\S]*\S))?\s*$/u`,
+        `/a|b/`,
+        `/(a|b)/`,
+        `/(?:a|b)/`,
+        `/((?:ab|ba)|(?:ba|ac))/`,
+        `/(?:js|json)$/`,
+        `/(?:js|jso?n?)$/`,
+        `/(?:js|json)abc/`,
+        `/(?:js|json)?abc/`,
+        `/(?:yml|ya?ml)$/`,
+        `/(?:yml|ya?ml)/`,
+        `/<("[^"]*"|'[^']*'|[^'">])*>/g`,
+        String.raw`/b+(?:\w+|[+-]?\d+)/`,
     ],
     invalid: [
-        ...[
-            {
-                code: `/a|a/`,
-                errors: [
-                    {
-                        message: "The disjunctions are duplicated.",
-                        line: 1,
-                        column: 4,
-                        endLine: 1,
-                        endColumn: 5,
-                    },
-                ],
-            },
-            {
-                code: `/(a|a)/`,
-                errors: [
-                    {
-                        message: "The disjunctions are duplicated.",
-                        line: 1,
-                        column: 5,
-                        endLine: 1,
-                        endColumn: 6,
-                    },
-                ],
-            },
-            {
-                code: `/(?:a|a)/`,
-                errors: [
-                    {
-                        message: "The disjunctions are duplicated.",
-                        line: 1,
-                        column: 7,
-                        endLine: 1,
-                        endColumn: 8,
-                    },
-                ],
-            },
-            {
-                code: `/(?=a|a)/`,
-                errors: [
-                    {
-                        message: "The disjunctions are duplicated.",
-                        line: 1,
-                        column: 7,
-                        endLine: 1,
-                        endColumn: 8,
-                    },
-                ],
-            },
-            {
-                code: `/(?<=a|a)/`,
-                errors: [
-                    {
-                        message: "The disjunctions are duplicated.",
-                        line: 1,
-                        column: 8,
-                        endLine: 1,
-                        endColumn: 9,
-                    },
-                ],
-            },
-            {
-                code: `/(?:[ab]|[ab])/`,
-                errors: ["The disjunctions are duplicated."],
-            },
-            {
-                code: `/(?:[ab]|[ba])/`,
-                errors: ["The disjunctions are duplicated."],
-            },
-            {
-                code: String.raw`/(?:[\da-z]|[a-z\d])/`,
-                errors: ["The disjunctions are duplicated."],
-            },
-            {
-                code: `/((?:ab|ba)|(?:ab|ba))/`,
-                errors: ["The disjunctions are duplicated."],
-            },
-            {
-                code: `/((?:ab|ba)|(?:ba|ab))/`,
-                errors: ["The disjunctions are duplicated."],
-            },
-        ].reduce(
-            (acc, x) =>
-                acc.concat(x, {
-                    ...x,
-                    options: [{ disallowNeverMatch: true }],
-                }),
-            [] as RuleTester.InvalidTestCase[],
-        ),
+        {
+            code: `/a|a/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected duplicate alternative. This alternative can be removed.",
+                    line: 1,
+                    column: 4,
+                    endLine: 1,
+                    endColumn: 5,
+                },
+            ],
+        },
+        {
+            code: `/(a|a)/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected duplicate alternative. This alternative can be removed.",
+                    line: 1,
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6,
+                },
+            ],
+        },
+        {
+            code: `/(?:a|a)/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected duplicate alternative. This alternative can be removed.",
+                    line: 1,
+                    column: 7,
+                    endLine: 1,
+                    endColumn: 8,
+                },
+            ],
+        },
+        {
+            code: `/(?=a|a)/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected duplicate alternative. This alternative can be removed.",
+                    line: 1,
+                    column: 7,
+                    endLine: 1,
+                    endColumn: 8,
+                },
+            ],
+        },
+        {
+            code: `/(?<=a|a)/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected duplicate alternative. This alternative can be removed.",
+                    line: 1,
+                    column: 8,
+                    endLine: 1,
+                    endColumn: 9,
+                },
+            ],
+        },
+        {
+            code: `/(?:[ab]|[ab])/`,
+            errors: [
+                "Unexpected duplicate alternative. This alternative can be removed.",
+            ],
+        },
+        {
+            code: `/(?:[ab]|[ba])/`,
+            errors: [
+                "Unexpected duplicate alternative. This alternative can be removed.",
+            ],
+        },
+        {
+            code: String.raw`/(?:[\da-z]|[a-z\d])/`,
+            errors: [
+                "Unexpected duplicate alternative. This alternative can be removed.",
+            ],
+        },
+        {
+            code: `/((?:ab|ba)|(?:ab|ba))/`,
+            errors: [
+                "Unexpected duplicate alternative. This alternative can be removed.",
+            ],
+        },
+        {
+            code: `/((?:ab|ba)|(?:ba|ab))/`,
+            errors: [
+                "Unexpected duplicate alternative. This alternative can be removed.",
+            ],
+        },
         {
             code: `/(?:(a)|(a))/`,
-            options: [{ disallowNeverMatch: true }],
-            errors: ["The disjunctions are duplicated."],
+            errors: [
+                "Unexpected duplicate alternative. This alternative can be removed. Careful! This alternative contains capturing groups which might be difficult to remove.",
+            ],
         },
         {
             code: `/(?:a|ab)/`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
-                "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                "Unexpected useless alternative. This alternative is already covered by 'a' and can be removed.",
             ],
         },
         {
             code: `/(?:.|a|b)/`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '.' and can be removed.",
                     line: 1,
                     column: 7,
                     endLine: 1,
@@ -154,7 +145,7 @@ tester.run("no-dupe-disjunctions", rule as any, {
                 },
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '.' and can be removed.",
                     line: 1,
                     column: 9,
                     endLine: 1,
@@ -164,181 +155,185 @@ tester.run("no-dupe-disjunctions", rule as any, {
         },
         {
             code: `/.|abc/`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
-                "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                "Unexpected useless alternative. This alternative is already covered by '.' and can be removed.",
             ],
         },
         {
             code: `/a|abc/`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
-                "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
-            ],
-        },
-        {
-            code: String.raw`/\d|abc|123|_|[A-Z]|\$| /`,
-            options: [{ disallowNeverMatch: true }],
-            errors: [
-                {
-                    message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
-                    column: 9,
-                },
-            ],
-        },
-        {
-            code: String.raw`/\D|abc|123|_|[A-Z]|\$| /`,
-            options: [{ disallowNeverMatch: true }],
-            errors: [
-                {
-                    message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
-                    column: 5,
-                },
-                {
-                    message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
-                    column: 13,
-                },
-                {
-                    message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
-                    column: 15,
-                },
-                {
-                    message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
-                    column: 21,
-                },
-                {
-                    message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
-                    column: 24,
-                },
+                "Unexpected useless alternative. This alternative is already covered by 'a' and can be removed.",
             ],
         },
         {
             code: String.raw`/\w|abc|123|_|[A-Z]|\$| /`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is already covered by '\\w' and can be removed.",
                     column: 5,
                 },
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is already covered by '\\w' and can be removed.",
                     column: 9,
                 },
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\w' and can be removed.",
                     column: 13,
                 },
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\w' and can be removed.",
                     column: 15,
                 },
             ],
         },
         {
             code: String.raw`/\W|abc|123|_|[A-Z]|\$| /`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\W' and can be removed.",
                     column: 21,
                 },
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\W' and can be removed.",
                     column: 24,
                 },
             ],
         },
         {
             code: String.raw`/\s|abc|123|_|[A-Z]|\$| /`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\s' and can be removed.",
                     column: 24,
                 },
             ],
         },
         {
             code: String.raw`/\S|abc|123|_|[A-Z]|\$| /`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is already covered by '\\S' and can be removed.",
                     column: 5,
                 },
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is already covered by '\\S' and can be removed.",
                     column: 9,
                 },
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\S' and can be removed.",
                     column: 13,
                 },
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\S' and can be removed.",
                     column: 15,
                 },
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\S' and can be removed.",
                     column: 21,
                 },
             ],
         },
         {
             code: String.raw`/[^\S]|abc|123|_|[A-Z]|\$| /`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
                 {
                     message:
-                        "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                        "Unexpected useless alternative. This alternative is a strict subset of '[^\\S]' and can be removed.",
                     column: 27,
                 },
             ],
         },
         {
             code: String.raw`/[^\r]|./`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
-                "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                "Unexpected useless alternative. This alternative is a strict subset of '[^\\r]' and can be removed.",
+            ],
+        },
+        {
+            code: String.raw`/\s|\S|./`,
+            errors: [
+                "Unexpected useless alternative. This alternative is a strict subset of '\\s|\\S' and can be removed.",
             ],
         },
         {
             code: `/(?:ya?ml|yml)$/`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
-                "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                "Unexpected useless alternative. This alternative is a strict subset of 'ya?ml' and can be removed.",
             ],
         },
         {
             code: `/(?:ya?ml|yml)/`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
-                "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                "Unexpected useless alternative. This alternative is a strict subset of 'ya?ml' and can be removed.",
+            ],
+        },
+        {
+            code: String.raw`/(?:\p{Lu}\p{L}*|[A-Z]\w*):/u`,
+            options: [{ report: "all" }],
+            errors: [
+                "Unexpected overlap. This alternative overlaps with '\\p{Lu}\\p{L}*'. The overlap is '[A-Z][A-Za-z]*'.",
             ],
         },
         {
             code: String.raw`/(?:\p{Lu}\p{L}*|[A-Z]\w*)/u`,
-            options: [{ disallowNeverMatch: true }],
             errors: [
-                "This disjunction can never match. Its condition is covered by previous conditions in the disjunctions.",
+                "Unexpected useless alternative. This alternative is already covered by '\\p{Lu}\\p{L}*' and can be removed.",
+            ],
+        },
+        {
+            code: String(/b+(?:\w+|[+-]?\d+)/),
+            options: [{ report: "all" }],
+            errors: [
+                "Unexpected overlap. This alternative overlaps with '\\w+'. The overlap is '\\d+'.",
+            ],
+        },
+        {
+            code: String(/FOO|foo(?:bar)?/i),
+            errors: [
+                "Unexpected useless alternative. This alternative is already covered by 'FOO' and can be removed.",
+            ],
+        },
+        {
+            code: String(/foo(?:bar)?|foo/),
+            errors: [
+                "Unexpected useless alternative. This alternative is a strict subset of 'foo(?:bar)?' and can be removed.",
+            ],
+        },
+        {
+            code: String(/(?=[\t ]+[\S]{1,}|[\t ]+['"][\S]|[\t ]+$|$)/),
+            errors: [
+                "Unexpected useless alternative. This alternative is a strict subset of '[\\t ]+[\\S]{1,}' and can be removed.",
+            ],
+        },
+        {
+            code: String(/\w+(?:\s+(?:\S+|"[^"]*"))*/),
+            errors: [
+                `Unexpected overlap. This alternative overlaps with '\\S+'. The overlap is '"[^\\s"]*"'. This ambiguity is likely to cause exponential backtracking.`,
+            ],
+        },
+        {
+            code: String(/\b(?:\d|foo|\w+)\b/),
+            options: [{ report: "interesting" }],
+            errors: [
+                "Unexpected superset. This alternative is a superset of '\\d|foo'. It might be possible to remove the other alternative(s).",
+            ],
+        },
+        {
+            code: String(/\d|[a-z]|_|\w/i),
+            errors: [
+                "Unexpected useless alternative. This alternative is a strict subset of '\\d|[a-z]|_' and can be removed.",
             ],
         },
     ],


### PR DESCRIPTION
This brings over the functionality of `clean-regex/disjoint-alternatives`.

---

@ota-meshi This PR is still WIP at the moment. I wanted to ask you a few questions (see my comments) before I continue working on this.

---

The results using Prism's 2k regexes. 

The AST approach (just using `isCoveredNode`) found 25 problems:

<details>

```
C:\Users\micha\Git\prism\components\prism-abap.js
  19:4043  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-actionscript.js
  2:316  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-agda.js
  22:76  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-bash.js
   37:23   warning  Unexpected useless alternative. This alternative is already covered by '--?' and can be removed
   regexp/no-dupe-disjunctions
   37:32   warning  Unexpected useless alternative. This alternative is already covered by '\+\+?' and can be removed
   regexp/no-dupe-disjunctions
   37:48   warning  Unexpected useless alternative. This alternative is already covered by '\*\*?' and can be removed
   regexp/no-dupe-disjunctions
   37:87   warning  Unexpected useless alternative. This alternative is already covered by '&&?' and can be removed
   regexp/no-dupe-disjunctions
   37:101  warning  Unexpected useless alternative. This alternative is already covered by '\|\|?' and can be removed
   regexp/no-dupe-disjunctions
  187:36   warning  Unexpected useless alternative. This alternative is already covered by '==?' and can be removed
   regexp/no-dupe-disjunctions
  187:81   warning  Unexpected useless alternative. This alternative is already covered by '\d?[<>]&?' and can be removed  regexp/no-dupe-disjunctions
  187:85   warning  Unexpected useless alternative. This alternative is already covered by '\d?[<>]&?' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-concurnas.js
  26:51  warning  Unexpected useless alternative. This alternative is already covered by '\?' and can be removed   regexp/no-dupe-disjunctions
p/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-csharp.js
  274:49  warning  Unexpected useless alternative. This alternative is already covered by '[^"'/()]' and can be removed  regexp/no-dupe-disjunctions
  311:53  warning  Unexpected useless alternative. This alternative is already covered by '[^"'/()]' and can be removed  regexp/no-dupe-disjunctions
  314:89  warning  Unexpected useless alternative. This alternative is already covered by '[^"'/()]' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-dhall.js
  62:43  warning  Unexpected useless alternative. This alternative is already covered by '[!=]=' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-django.js
  33:30  warning  Unexpected useless alternative. This alternative is already covered by '[-+*/%=]=?' and can be removed  regexp/no-dupe-disjunctions
  33:38  warning  Unexpected useless alternative. This alternative is already covered by '[-+*/%=]=?' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-factor.js
  65:38  warning  Unexpected useless alternative. This alternative is a subset of '\d*\.\d+' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-lilypond.js
  16:72  warning  Unexpected useless alternative. This alternative is already covered by '[^\s()]' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-parigp.js
  28:113  warning  Unexpected useless alternative. This alternative is already covered by '(?: *<)?(?: *=)?' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-psl.js
  22:1361  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-qml.js
  6:35  warning  Unexpected useless alternative. This alternative is already covered by '[^\\()[\]{}"'/]' and can be removed  regexp/no-dupe-disjunctions
  6:55  warning  Unexpected useless alternative. This alternative is already covered by '[^\\()[\]{}"'/]' and can be removed  regexp/no-dupe-disjunctions

✖ 25 problems (0 errors, 25 warnings)
```

</details>

The new NFA approach found 28 problems: (This is an apples-to-apples comparison. The NFA approach actually finds more problems _types_ than the AST approach. These additional problem types are not reported here.)

<details>

```
C:\Users\micha\Git\prism\components\prism-abap.js
  19:4043  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-actionscript.js
  2:316  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-agda.js
  22:76  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-bash.js
   37:23   warning  Unexpected useless alternative. This alternative is already covered by '--?' and can be removed
   regexp/no-dupe-disjunctions
   37:32   warning  Unexpected useless alternative. This alternative is already covered by '\+\+?' and can be removed
   regexp/no-dupe-disjunctions
   37:48   warning  Unexpected useless alternative. This alternative is already covered by '\*\*?' and can be removed
   regexp/no-dupe-disjunctions
   37:87   warning  Unexpected useless alternative. This alternative is already covered by '&&?' and can be removed
   regexp/no-dupe-disjunctions
   37:101  warning  Unexpected useless alternative. This alternative is already covered by '\|\|?' and can be removed
   regexp/no-dupe-disjunctions
  187:36   warning  Unexpected useless alternative. This alternative is already covered by '==?' and can be removed
   regexp/no-dupe-disjunctions
  187:81   warning  Unexpected useless alternative. This alternative is already covered by '\d?[<>]&?' and can be removed  regexp/no-dupe-disjunctions
  187:85   warning  Unexpected useless alternative. This alternative is already covered by '\d?[<>]&?' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-cmake.js
  17:1198  warning  Unexpected useless alternative. This alternative is a subset of '\w+_(?:CLANG_TIDY|COMPILER_LAUNCHER|CPPCHECK|CPPLINT|INCLUDE_WHAT_YOU_USE|OUTPUT_NAME|POSTFIX|VISIBILITY_PRESET)' and can be removed  regexp/no-dupe-disjunctions
  17:2326  warning  Unexpected useless alternative. This alternative is a subset of '\w+_(?:CLANG_TIDY|COMPILER_LAUNCHER|CPPCHECK|CPPLINT|INCLUDE_WHAT_YOU_USE|OUTPUT_NAME|POSTFIX|VISIBILITY_PRESET)' and can be removed  regexp/no-dupe-disjunctions
  17:3870  warning  Unexpected useless alternative. This alternative is a subset of '\w+_(?:CLANG_TIDY|COMPILER_LAUNCHER|CPPCHECK|CPPLINT|INCLUDE_WHAT_YOU_USE|OUTPUT_NAME|POSTFIX|VISIBILITY_PRESET)' and can be removed  regexp/no-dupe-disjunctions
  17:4791  warning  Unexpected useless alternative. This alternative is a subset of '\w+_(?:CLANG_TIDY|COMPILER_LAUNCHER|CPPCHECK|CPPLINT|INCLUDE_WHAT_YOU_USE|OUTPUT_NAME|POSTFIX|VISIBILITY_PRESET)' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-concurnas.js
  26:51  warning  Unexpected useless alternative. This alternative is already covered by '\?' and can be removed   regexp/no-dupe-disjunctions
  28:30  warning  Unexpected useless alternative. This alternative is already covered by '\w*' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-csharp.js
  274:49  warning  Unexpected useless alternative. This alternative is already covered by '[^"'/()]' and can be removed
 regexp/no-dupe-disjunctions
  311:53  warning  Unexpected useless alternative. This alternative is already covered by '[^"'/()]' and can be removed
 regexp/no-dupe-disjunctions
  314:89  warning  Unexpected useless alternative. This alternative is already covered by '[^"'/()]' and can be removed
 regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-dhall.js
  62:43  warning  Unexpected useless alternative. This alternative is already covered by '[!=]=' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-django.js
  33:30  warning  Unexpected useless alternative. This alternative is already covered by '[-+*/%=]=?' and can be removed  regexp/no-dupe-disjunctions
  33:38  warning  Unexpected useless alternative. This alternative is already covered by '[-+*/%=]=?' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-lilypond.js
  16:72  warning  Unexpected useless alternative. This alternative is already covered by '[^\s()]' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-parigp.js
  28:113  warning  Unexpected useless alternative. This alternative is already covered by '(?: *<)?(?: *=)?' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-psl.js
  22:1361  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-qml.js
  6:35  warning  Unexpected useless alternative. This alternative is already covered by '[^\\()[\]{}"'/]' and can be removed  regexp/no-dupe-disjunctions
  6:55  warning  Unexpected useless alternative. This alternative is already covered by '[^\\()[\]{}"'/]' and can be removed  regexp/no-dupe-disjunctions

✖ 28 problems (0 errors, 28 warnings)
```

</details>

The hybrid approach found 29 problems:

<details>

```
C:\Users\micha\Git\prism\components\prism-abap.js
  19:4043  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-actionscript.js
  2:316  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-agda.js
  22:76  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-bash.js
   37:23   warning  Unexpected useless alternative. This alternative is already covered by '--?' and can be removed
   regexp/no-dupe-disjunctions
   37:32   warning  Unexpected useless alternative. This alternative is already covered by '\+\+?' and can be removed
   regexp/no-dupe-disjunctions
   37:48   warning  Unexpected useless alternative. This alternative is already covered by '\*\*?' and can be removed
   regexp/no-dupe-disjunctions
   37:87   warning  Unexpected useless alternative. This alternative is already covered by '&&?' and can be removed
   regexp/no-dupe-disjunctions
   37:101  warning  Unexpected useless alternative. This alternative is already covered by '\|\|?' and can be removed
   regexp/no-dupe-disjunctions
  187:36   warning  Unexpected useless alternative. This alternative is already covered by '==?' and can be removed
   regexp/no-dupe-disjunctions
  187:81   warning  Unexpected useless alternative. This alternative is already covered by '\d?[<>]&?' and can be removed  regexp/no-dupe-disjunctions
  187:85   warning  Unexpected useless alternative. This alternative is already covered by '\d?[<>]&?' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-cmake.js
  17:1198  warning  Unexpected useless alternative. This alternative is a subset of '\w+_(?:CLANG_TIDY|COMPILER_LAUNCHER|CPPCHECK|CPPLINT|INCLUDE_WHAT_YOU_USE|OUTPUT_NAME|POSTFIX|VISIBILITY_PRESET)' and can be removed  regexp/no-dupe-disjunctions
  17:2326  warning  Unexpected useless alternative. This alternative is a subset of '\w+_(?:CLANG_TIDY|COMPILER_LAUNCHER|CPPCHECK|CPPLINT|INCLUDE_WHAT_YOU_USE|OUTPUT_NAME|POSTFIX|VISIBILITY_PRESET)' and can be removed  regexp/no-dupe-disjunctions
  17:3870  warning  Unexpected useless alternative. This alternative is a subset of '\w+_(?:CLANG_TIDY|COMPILER_LAUNCHER|CPPCHECK|CPPLINT|INCLUDE_WHAT_YOU_USE|OUTPUT_NAME|POSTFIX|VISIBILITY_PRESET)' and can be removed  regexp/no-dupe-disjunctions
  17:4791  warning  Unexpected useless alternative. This alternative is a subset of '\w+_(?:CLANG_TIDY|COMPILER_LAUNCHER|CPPCHECK|CPPLINT|INCLUDE_WHAT_YOU_USE|OUTPUT_NAME|POSTFIX|VISIBILITY_PRESET)' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-concurnas.js
  26:51  warning  Unexpected useless alternative. This alternative is already covered by '\?' and can be removed   regexp/no-dupe-disjunctions
  28:30  warning  Unexpected useless alternative. This alternative is already covered by '\w*' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-csharp.js
  274:49  warning  Unexpected useless alternative. This alternative is already covered by '[^"'/()]' and can be removed
 regexp/no-dupe-disjunctions
  311:53  warning  Unexpected useless alternative. This alternative is already covered by '[^"'/()]' and can be removed
 regexp/no-dupe-disjunctions
  314:89  warning  Unexpected useless alternative. This alternative is already covered by '[^"'/()]' and can be removed
 regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-dhall.js
  62:43  warning  Unexpected useless alternative. This alternative is already covered by '[!=]=' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-django.js
  33:30  warning  Unexpected useless alternative. This alternative is already covered by '[-+*/%=]=?' and can be removed
  regexp/no-dupe-disjunctions
  33:38  warning  Unexpected useless alternative. This alternative is already covered by '[-+*/%=]=?' and can be removed
  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-factor.js
  65:38  warning  Unexpected useless alternative. This alternative is a subset of '\d*\.\d+' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-lilypond.js
  16:72  warning  Unexpected useless alternative. This alternative is already covered by '[^\s()]' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-parigp.js
  28:113  warning  Unexpected useless alternative. This alternative is already covered by '(?: *<)?(?: *=)?' and can be removed  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-psl.js
  22:1361  warning  Unexpected duplicate alternative  regexp/no-dupe-disjunctions

C:\Users\micha\Git\prism\components\prism-qml.js
  6:35  warning  Unexpected useless alternative. This alternative is already covered by '[^\\()[\]{}"'/]' and can be removed  regexp/no-dupe-disjunctions
  6:55  warning  Unexpected useless alternative. This alternative is already covered by '[^\\()[\]{}"'/]' and can be removed  regexp/no-dupe-disjunctions

✖ 29 problems (0 errors, 29 warnings)
```

</details>

The interesting bit here is the difference between AST and NFA approach. The one additional problem found by the AST approach is unfortunately a bug (#178). The 4 additional problems found by the NFA approach are true positives and were too difficult to detect for the AST approach.

This should demonstrate how powerful the NFA approach is. However, the NFA approach has its downsides too:

1. It can't handle assertions very well. Most of the time, it can't analyze alternatives with assertions at all. This is why the AST approach is still necessary.
2. Performance. 
    | Approach | Time taken |
    | --- | --- |
    | AST | 5s |
    | NFA | 15s |
    | Hybrid | 20s |