### PR TITLE
Improved `no-assertion-capturing-group`

### DIFF
--- a/docs/rules/no-assertion-capturing-group.md
+++ b/docs/rules/no-assertion-capturing-group.md
@@ -25,6 +25,7 @@ var foo = /(a)/;
 var foo = /a(?:\b)/;
 var foo = /a(?:$)/;
 var foo = /(?:^)a/;
+var foo = /(?:^|b)a/;
 
 /* ✗ BAD */
 var foo = /a(\b)/;

--- a/lib/rules/no-assertion-capturing-group.ts
+++ b/lib/rules/no-assertion-capturing-group.ts
@@ -1,3 +1,4 @@
+import { isZeroLength } from "regexp-ast-analysis"
 import type { RegExpVisitor } from "regexpp/visitor"
 import type { RegExpContext } from "../utils"
 import { createRule, defineRegexpVisitor } from "../utils"
@@ -24,11 +25,7 @@ export default createRule("no-assertion-capturing-group", {
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCapturingGroupEnter(cgNode) {
-                    if (
-                        cgNode.alternatives.every((alt) =>
-                            alt.elements.every((e) => e.type === "Assertion"),
-                        )
-                    ) {
+                    if (isZeroLength(cgNode)) {
                         context.report({
                             node,
                             loc: getRegexpLocation(cgNode),

--- a/tests/lib/rules/no-assertion-capturing-group.ts
+++ b/tests/lib/rules/no-assertion-capturing-group.ts
@@ -9,7 +9,7 @@ const tester = new RuleTester({
 })
 
 tester.run("no-assertion-capturing-group", rule as any, {
-    valid: ["/(a)/", "/a(\\bb)/"],
+    valid: ["/(a)/", "/a(\\bb)/", "/a(\\b|b)/"],
     invalid: [
         {
             code: "/a(\\b)/",
@@ -40,6 +40,20 @@ tester.run("no-assertion-capturing-group", rule as any, {
                     endColumn: 5,
                 },
             ],
+        },
+        {
+            code: "/()a/",
+            errors: [
+                {
+                    message: "Unexpected capture assertions.",
+                    column: 2,
+                    endColumn: 4,
+                },
+            ],
+        },
+        {
+            code: "/(\\b\\b|(?:\\B|$))a/",
+            errors: ["Unexpected capture assertions."],
         },
     ],
 })


### PR DESCRIPTION
This brings over half of `clean-regex/no-constant-capturing-group`.

Also, I think we should rename the rule. Even before this update, it also rightfully reported `/()a/` even though `()` obviously doesn't contain assertions. Maybe `no-empty-capturing-group` (because the captured text is always the empty string)?