### PR TITLE
Update `no-dupe-characters-character-class`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/match-any](https://ota-meshi.github.io/eslint-plugin-regexp/rules/match-any.html) | enforce match any character style | :star::wrench: |
 | [regexp/negation](https://ota-meshi.github.io/eslint-plugin-regexp/rules/negation.html) | enforce use of escapes on negation | :wrench: |
 | [regexp/no-assertion-capturing-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-assertion-capturing-group.html) | disallow capturing group that captures assertions. | :star: |
-| [regexp/no-dupe-characters-character-class](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-dupe-characters-character-class.html) | disallow duplicate characters in the RegExp character class | :star: |
+| [regexp/no-dupe-characters-character-class](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-dupe-characters-character-class.html) | disallow duplicate characters in the RegExp character class | :star::wrench: |
 | [regexp/no-dupe-disjunctions](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-dupe-disjunctions.html) | disallow duplicate disjunctions |  |
 | [regexp/no-empty-alternative](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-alternative.html) | disallow alternatives without elements |  |
 | [regexp/no-empty-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-group.html) | disallow empty group | :star: |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -18,7 +18,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/match-any](./match-any.md) | enforce match any character style | :star::wrench: |
 | [regexp/negation](./negation.md) | enforce use of escapes on negation | :wrench: |
 | [regexp/no-assertion-capturing-group](./no-assertion-capturing-group.md) | disallow capturing group that captures assertions. | :star: |
-| [regexp/no-dupe-characters-character-class](./no-dupe-characters-character-class.md) | disallow duplicate characters in the RegExp character class | :star: |
+| [regexp/no-dupe-characters-character-class](./no-dupe-characters-character-class.md) | disallow duplicate characters in the RegExp character class | :star::wrench: |
 | [regexp/no-dupe-disjunctions](./no-dupe-disjunctions.md) | disallow duplicate disjunctions |  |
 | [regexp/no-empty-alternative](./no-empty-alternative.md) | disallow alternatives without elements |  |
 | [regexp/no-empty-group](./no-empty-group.md) | disallow empty group | :star: |

--- a/docs/rules/no-dupe-characters-character-class.md
+++ b/docs/rules/no-dupe-characters-character-class.md
@@ -10,6 +10,7 @@ since: "v0.1.0"
 > disallow duplicate characters in the RegExp character class
 
 - :gear: This rule is included in `"plugin:regexp/recommended"`.
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Because multiple same character classes in regular expressions only one is useful, they might be typing mistakes.
 
@@ -21,7 +22,7 @@ var foo = /\\(\\)/;
 
 This rule disallows duplicate characters in the RegExp character class.
 
-<eslint-code-block>
+<eslint-code-block fix>
 
 ```js
 /* eslint regexp/no-dupe-characters-character-class: "error" */

--- a/lib/rules/no-dupe-characters-character-class.ts
+++ b/lib/rules/no-dupe-characters-character-class.ts
@@ -160,6 +160,25 @@ function fixRemove(
     })
 }
 
+/**
+ * Creates a string that mentions the given element.
+ */
+function mention(element: CharacterClassElement): string {
+    /** Creates a "U+FFFF" string */
+    function unicode(value: number): string {
+        return `U+${value.toString(16).padStart(4, "0")}`
+    }
+
+    if (element.type === "Character") {
+        return `'${element.raw}' (${unicode(element.value)})`
+    } else if (element.type === "CharacterClassRange") {
+        return `'${element.raw}' (${unicode(element.min.value)} - ${unicode(
+            element.max.value,
+        )})`
+    }
+    return `'${element.raw}'`
+}
+
 export default createRule("no-dupe-characters-character-class", {
     meta: {
         type: "suggestion",
@@ -171,14 +190,14 @@ export default createRule("no-dupe-characters-character-class", {
         fixable: "code",
         schema: [],
         messages: {
-            duplicate: "Unexpected duplicate '{{duplicate}}'.",
+            duplicate: "Unexpected duplicate {{duplicate}}.",
             duplicateNonObvious:
-                "Unexpected duplicate. '{{duplicate}}' is a duplicate of '{{element}}'.",
-            subset: "'{{subsetElement}}' is already included in '{{element}}'.",
+                "Unexpected duplicate. {{duplicate}} is a duplicate of {{element}}.",
+            subset: "{{subsetElement}} is already included in {{element}}.",
             subsetOfMany:
-                "'{{subsetElement}}' is already included by a combination of other elements.",
+                "{{subsetElement}} is already included by a combination of other elements.",
             overlap:
-                "Unexpected overlap of '{{elementA}}' and '{{elementB}}' was found '{{overlap}}'.",
+                "Unexpected overlap of {{elementA}} and {{elementB}} was found '{{overlap}}'.",
         },
     },
     create(context) {
@@ -198,7 +217,7 @@ export default createRule("no-dupe-characters-character-class", {
                     loc: getRegexpLocation(duplicate),
                     messageId: "duplicate",
                     data: {
-                        duplicate: duplicate.raw,
+                        duplicate: mention(duplicate),
                     },
                     fix: fixRemove(regexpContext, duplicate),
                 })
@@ -208,8 +227,8 @@ export default createRule("no-dupe-characters-character-class", {
                     loc: getRegexpLocation(duplicate),
                     messageId: "duplicateNonObvious",
                     data: {
-                        duplicate: duplicate.raw,
-                        element: element.raw,
+                        duplicate: mention(duplicate),
+                        element: mention(element),
                     },
                     fix: fixRemove(regexpContext, duplicate),
                 })
@@ -230,8 +249,8 @@ export default createRule("no-dupe-characters-character-class", {
                 loc: getRegexpLocation(element),
                 messageId: "overlap",
                 data: {
-                    elementA: element.raw,
-                    elementB: intersectElement.raw,
+                    elementA: mention(element),
+                    elementB: mention(intersectElement),
                     overlap,
                 },
             })
@@ -254,8 +273,8 @@ export default createRule("no-dupe-characters-character-class", {
                 loc: getRegexpLocation(subsetElement),
                 messageId: "subset",
                 data: {
-                    subsetElement: subsetElement.raw,
-                    element: element.raw,
+                    subsetElement: mention(subsetElement),
+                    element: mention(element),
                 },
                 fix: fixRemove(regexpContext, subsetElement),
             })
@@ -275,7 +294,7 @@ export default createRule("no-dupe-characters-character-class", {
                 loc: getRegexpLocation(subsetElement),
                 messageId: "subsetOfMany",
                 data: {
-                    subsetElement: subsetElement.raw,
+                    subsetElement: mention(subsetElement),
                 },
                 fix: fixRemove(regexpContext, subsetElement),
             })

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -935,7 +935,7 @@ export function toCharSetSource(
  * Returns whether the concatenation of the two string might create new escape
  * sequences or elements.
  */
-function mightCreateNewElement(
+export function mightCreateNewElement(
     /* eslint-enable complexity -- X( */
     before: string,
     after: string,

--- a/tests/lib/eslint-plugin.ts
+++ b/tests/lib/eslint-plugin.ts
@@ -22,7 +22,6 @@ describe("Integration with eslint-plugin-regexp", () => {
             r.results[0].messages.map((m) => m.ruleId),
             [
                 "regexp/no-dupe-characters-character-class",
-                "regexp/no-dupe-characters-character-class",
                 "regexp/prefer-w",
                 "regexp/prefer-d",
                 "regexp/prefer-d",

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -27,14 +27,10 @@ tester.run("no-dupe-characters-character-class", rule as any, {
     invalid: [
         {
             code: "var re = /[\\\\(\\\\)]/",
+            output: "var re = /[\\\\()]/",
             errors: [
                 {
-                    message: "Unexpected element '\\\\' duplication.",
-                    line: 1,
-                    column: 12,
-                },
-                {
-                    message: "Unexpected element '\\\\' duplication.",
+                    message: "Unexpected duplicate '\\\\'.",
                     line: 1,
                     column: 15,
                 },
@@ -42,9 +38,10 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         },
         {
             code: "var re = /[a-z\\\\s]/",
+            output: "var re = /[a-z\\\\]/",
             errors: [
                 {
-                    message: "The 's' is included in 'a-z'.",
+                    message: "'s' is already included in 'a-z'.",
                     line: 1,
                     column: 17,
                 },
@@ -52,27 +49,29 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         },
         {
             code: "/[aaa]/",
+            output: "/[aa]/",
             errors: [
-                { message: "Unexpected element 'a' duplication.", column: 3 },
-                { message: "Unexpected element 'a' duplication.", column: 4 },
-                { message: "Unexpected element 'a' duplication.", column: 5 },
+                { message: "Unexpected duplicate 'a'.", column: 4 },
+                { message: "Unexpected duplicate 'a'.", column: 5 },
             ],
         },
         {
             code: "/[0-9\\d]/",
+            output: "/[\\d]/",
             errors: [
                 {
-                    message: "The '0-9' is included in '\\d'.",
+                    message: "'0-9' is already included in '\\d'.",
                     column: 3,
                 },
             ],
         },
         {
             code: "/[\\f\\u000C]/",
+            output: "/[\\f]/",
             errors: [
-                { message: "Unexpected element '\\f' duplication.", column: 3 },
                 {
-                    message: "Unexpected element '\\u000C' duplication.",
+                    message:
+                        "Unexpected duplicate. '\\u000C' is a duplicate of '\\f'.",
                     column: 5,
                 },
             ],
@@ -80,229 +79,219 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         {
             code:
                 "/[\\s \\f\\n\\r\\t\\v\\u00a0\\u1680\\u180e\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff]/",
+            output: "/[\\s\\f\\r\\v\\u1680\\u180e\\u2028\\u202f\\u3000]/",
             errors: [
-                { message: "The ' ' is included in '\\s'.", column: 5 },
-                { message: "The '\\f' is included in '\\s'.", column: 6 },
-                { message: "The '\\n' is included in '\\s'.", column: 8 },
-                { message: "The '\\r' is included in '\\s'.", column: 10 },
-                { message: "The '\\t' is included in '\\s'.", column: 12 },
-                { message: "The '\\v' is included in '\\s'.", column: 14 },
-                { message: "The '\\u00a0' is included in '\\s'.", column: 16 },
-                { message: "The '\\u1680' is included in '\\s'.", column: 22 },
+                { message: "' ' is already included in '\\s'.", column: 5 },
+                { message: "'\\f' is already included in '\\s'.", column: 6 },
+                { message: "'\\n' is already included in '\\s'.", column: 8 },
+                { message: "'\\r' is already included in '\\s'.", column: 10 },
+                { message: "'\\t' is already included in '\\s'.", column: 12 },
+                { message: "'\\v' is already included in '\\s'.", column: 14 },
                 {
-                    message: "The '\\u2000-\\u200a' is included in '\\s'.",
+                    message: "'\\u00a0' is already included in '\\s'.",
+                    column: 16,
+                },
+                {
+                    message: "'\\u1680' is already included in '\\s'.",
+                    column: 22,
+                },
+                {
+                    message: "'\\u2000-\\u200a' is already included in '\\s'.",
                     column: 34,
                 },
-                { message: "The '\\u2028' is included in '\\s'.", column: 47 },
-                { message: "The '\\u2029' is included in '\\s'.", column: 53 },
-                { message: "The '\\u202f' is included in '\\s'.", column: 59 },
-                { message: "The '\\u205f' is included in '\\s'.", column: 65 },
-                { message: "The '\\u3000' is included in '\\s'.", column: 71 },
-                { message: "The '\\ufeff' is included in '\\s'.", column: 77 },
-            ],
-        },
-        {
-            code: "/[\\t\t\\u0009]/",
-            errors: [
-                { message: "Unexpected element '\\t' duplication.", column: 3 },
-                { message: "Unexpected element '\t' duplication.", column: 5 },
                 {
-                    message: "Unexpected element '\\u0009' duplication.",
-                    column: 6,
+                    message: "'\\u2028' is already included in '\\s'.",
+                    column: 47,
+                },
+                {
+                    message: "'\\u2029' is already included in '\\s'.",
+                    column: 53,
+                },
+                {
+                    message: "'\\u202f' is already included in '\\s'.",
+                    column: 59,
+                },
+                {
+                    message: "'\\u205f' is already included in '\\s'.",
+                    column: 65,
+                },
+                {
+                    message: "'\\u3000' is already included in '\\s'.",
+                    column: 71,
+                },
+                {
+                    message: "'\\ufeff' is already included in '\\s'.",
+                    column: 77,
                 },
             ],
         },
         {
-            code: "/[\\wA-Za-z0-9_]/",
+            code: "/[\\t\t \\u0009]/",
+            output: "/[\\t ]/",
             errors: [
                 {
-                    message: "The 'A-Z' is included in '\\w'.",
+                    message:
+                        "Unexpected duplicate. '\t' is a duplicate of '\\t'.",
                     column: 5,
                 },
                 {
-                    message: "The 'a-z' is included in '\\w'.",
-                    column: 8,
+                    message:
+                        "Unexpected duplicate. '\\u0009' is a duplicate of '\\t'.",
+                    column: 7,
+                },
+            ],
+        },
+        {
+            code: "/[\\wA-Z a-z:0-9,_]/",
+            output: "/[\\w :,]/",
+            errors: [
+                {
+                    message: "'A-Z' is already included in '\\w'.",
+                    column: 5,
                 },
                 {
-                    message: "The '0-9' is included in '\\w'.",
-                    column: 11,
+                    message: "'a-z' is already included in '\\w'.",
+                    column: 9,
                 },
-                { message: "The '_' is included in '\\w'.", column: 14 },
+                {
+                    message: "'0-9' is already included in '\\w'.",
+                    column: 13,
+                },
+                { message: "'_' is already included in '\\w'.", column: 17 },
             ],
         },
         {
             code: "/[!-z_abc-]/",
+            output: "/[!-zac]/",
             errors: [
-                { message: "The '_' is included in '!-z'.", column: 6 },
-                { message: "The 'a' is included in '!-z'.", column: 7 },
-                { message: "The 'b' is included in '!-z'.", column: 8 },
-                { message: "The 'c' is included in '!-z'.", column: 9 },
-                { message: "The '-' is included in '!-z'.", column: 10 },
+                { message: "'_' is already included in '!-z'.", column: 6 },
+                { message: "'a' is already included in '!-z'.", column: 7 },
+                { message: "'b' is already included in '!-z'.", column: 8 },
+                { message: "'c' is already included in '!-z'.", column: 9 },
+                { message: "'-' is already included in '!-z'.", column: 10 },
             ],
         },
         {
             code: "/[\\w_abc-][\\s \\t\\r\\n\\u2000\\u3000]/",
+            output: "/[\\wac-][\\s\\t\\n\\u3000]/",
             errors: [
-                { message: "The '_' is included in '\\w'.", column: 5 },
-                { message: "The 'a' is included in '\\w'.", column: 6 },
-                { message: "The 'b' is included in '\\w'.", column: 7 },
-                { message: "The 'c' is included in '\\w'.", column: 8 },
-                { message: "The ' ' is included in '\\s'.", column: 14 },
-                { message: "The '\\t' is included in '\\s'.", column: 15 },
-                { message: "The '\\r' is included in '\\s'.", column: 17 },
-                { message: "The '\\n' is included in '\\s'.", column: 19 },
-                { message: "The '\\u2000' is included in '\\s'.", column: 21 },
-                { message: "The '\\u3000' is included in '\\s'.", column: 27 },
+                { message: "'_' is already included in '\\w'.", column: 5 },
+                { message: "'a' is already included in '\\w'.", column: 6 },
+                { message: "'b' is already included in '\\w'.", column: 7 },
+                { message: "'c' is already included in '\\w'.", column: 8 },
+                { message: "' ' is already included in '\\s'.", column: 14 },
+                { message: "'\\t' is already included in '\\s'.", column: 15 },
+                { message: "'\\r' is already included in '\\s'.", column: 17 },
+                { message: "'\\n' is already included in '\\s'.", column: 19 },
+                {
+                    message: "'\\u2000' is already included in '\\s'.",
+                    column: 21,
+                },
+                {
+                    message: "'\\u3000' is already included in '\\s'.",
+                    column: 27,
+                },
             ],
         },
         {
             code: "/[a-z a-z]/",
-            errors: [
-                { message: "Unexpected element 'a-z' duplication.", column: 3 },
-                { message: "Unexpected element 'a-z' duplication.", column: 7 },
-            ],
+            output: "/[a-z ]/",
+            errors: [{ message: "Unexpected duplicate 'a-z'.", column: 7 }],
         },
         {
             code: "/[a-d e-h_d-e+c-d]/",
+            output: "/[a-d e-h_+]/",
             errors: [
                 {
                     message:
-                        "Unexpected intersection of 'a-d' and 'd-e' was found 'd'.",
-                    column: 3,
-                },
-                {
-                    message:
-                        "Unexpected intersection of 'e-h' and 'd-e' was found 'e'.",
-                    column: 7,
-                },
-                {
-                    message:
-                        "Unexpected intersection of 'd-e' and 'a-d' was found 'd'.",
+                        "'d-e' is already included by a combination of other elements.",
                     column: 11,
                 },
                 {
-                    message:
-                        "Unexpected intersection of 'd-e' and 'e-h' was found 'e'.",
-                    column: 11,
-                },
-                {
-                    message:
-                        "Unexpected intersection of 'd-e' and 'c-d' was found 'd'.",
-                    column: 11,
-                },
-                {
-                    message: "The 'c-d' is included in 'a-d'.",
-                    column: 15,
-                },
-                {
-                    message:
-                        "Unexpected intersection of 'c-d' and 'd-e' was found 'd'.",
+                    message: "'c-d' is already included in 'a-d'.",
                     column: 15,
                 },
             ],
         },
         {
             code: "/[3-6 3-6_2-4+5-7]/",
+            output: "/[ _2-4+5-7]/",
             errors: [
-                { message: "Unexpected element '3-6' duplication.", column: 3 },
                 {
                     message:
-                        "Unexpected intersection of '3-6' and '2-4' was found '[34]'.",
+                        "'3-6' is already included by a combination of other elements.",
                     column: 3,
                 },
                 {
+                    message: "Unexpected duplicate '3-6'.",
+                    column: 7,
+                },
+            ],
+        },
+        {
+            code: "/[3-6 3-6_5-7]/",
+            output: "/[3-6 _5-7]/",
+            errors: [
+                {
                     message:
-                        "Unexpected intersection of '3-6' and '5-7' was found '[56]'.",
+                        "Unexpected overlap of '3-6' and '5-7' was found '[56]'.",
                     column: 3,
                 },
-                { message: "Unexpected element '3-6' duplication.", column: 7 },
                 {
-                    message:
-                        "Unexpected intersection of '3-6' and '2-4' was found '[34]'.",
+                    message: "Unexpected duplicate '3-6'.",
                     column: 7,
-                },
-                {
-                    message:
-                        "Unexpected intersection of '3-6' and '5-7' was found '[56]'.",
-                    column: 7,
-                },
-                {
-                    message:
-                        "Unexpected intersection of '2-4' and '3-6' was found '[34]'.",
-                    column: 11,
-                },
-                {
-                    message:
-                        "Unexpected intersection of '5-7' and '3-6' was found '[56]'.",
-                    column: 15,
                 },
             ],
         },
         {
             code: "/[\\s\\s \\s]/",
+            output: "/[\\s ]/",
             errors: [
-                { message: "Unexpected element '\\s' duplication.", column: 3 },
-                { message: "Unexpected element '\\s' duplication.", column: 5 },
-                { message: "The ' ' is included in '\\s'.", column: 7 },
-                { message: "Unexpected element '\\s' duplication.", column: 8 },
+                { message: "Unexpected duplicate '\\s'.", column: 5 },
+                { message: "' ' is already included in '\\s'.", column: 7 },
+                { message: "Unexpected duplicate '\\s'.", column: 8 },
             ],
         },
         {
             code: "/[\\S\\S \\sa]/",
+            output: "/[\\S \\s]/",
             errors: [
-                { message: "Unexpected element '\\S' duplication.", column: 3 },
-                { message: "Unexpected element '\\S' duplication.", column: 5 },
-                { message: "The ' ' is included in '\\s'.", column: 7 },
-                { message: "The 'a' is included in '\\S'.", column: 10 },
+                { message: "Unexpected duplicate '\\S'.", column: 5 },
+                { message: "' ' is already included in '\\s'.", column: 7 },
+                { message: "'a' is already included in '\\S'.", column: 10 },
             ],
         },
         {
             code: "/[\\d 0-9_!-z]/",
+            output: "/[ _!-z]/",
             errors: [
                 {
-                    message: "The '\\d' is included in '!-z'.",
+                    message: "'\\d' is already included in '!-z'.",
                     column: 3,
                 },
                 {
-                    message: "The '0-9' is included in '!-z'.",
+                    message: "'0-9' is already included in '!-z'.",
                     column: 6,
                 },
-                {
-                    message: "The '0-9' is included in '\\d'.",
-                    column: 6,
-                },
-                { message: "The '_' is included in '!-z'.", column: 9 },
+                { message: "'_' is already included in '!-z'.", column: 9 },
             ],
         },
         {
             code: "/[\\W\\W\\w \\d\\d\\D]/",
+            output: "/[\\W\\w\\d\\D]/",
             errors: [
-                { message: "Unexpected element '\\W' duplication.", column: 3 },
                 {
-                    message: "The '\\W' is included in '\\D'.",
+                    message: "'\\W' is already included in '\\D'.",
                     column: 3,
                 },
-                { message: "Unexpected element '\\W' duplication.", column: 5 },
+                { message: "Unexpected duplicate '\\W'.", column: 5 },
+                { message: "' ' is already included in '\\W'.", column: 9 },
                 {
-                    message: "The '\\W' is included in '\\D'.",
-                    column: 5,
-                },
-                { message: "The ' ' is included in '\\W'.", column: 9 },
-                { message: "The ' ' is included in '\\D'.", column: 9 },
-                {
-                    message: "Unexpected element '\\d' duplication.",
+                    message: "'\\d' is already included in '\\w'.",
                     column: 10,
                 },
                 {
-                    message: "The '\\d' is included in '\\w'.",
-                    column: 10,
-                },
-                {
-                    message: "Unexpected element '\\d' duplication.",
-                    column: 12,
-                },
-                {
-                    message: "The '\\d' is included in '\\w'.",
+                    message: "Unexpected duplicate '\\d'.",
                     column: 12,
                 },
             ],
@@ -310,129 +299,120 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         {
             code:
                 "/[\\p{ASCII}\\P{ASCII}\\p{Script=Hiragana}\\P{Script=Hiragana}\\p{ASCII}\\p{Script=Hiragana}]/u",
+            output: "/[\\P{ASCII}\\P{Script=Hiragana}\\p{Script=Hiragana}]/u",
             errors: [
                 {
-                    message: "Unexpected element '\\p{ASCII}' duplication.",
+                    message:
+                        "'\\p{ASCII}' is already included in '\\P{Script=Hiragana}'.",
                     column: 3,
                 },
                 {
                     message:
-                        "The '\\p{ASCII}' is included in '\\P{Script=Hiragana}'.",
-                    column: 3,
-                },
-                {
-                    message:
-                        "Unexpected element '\\p{Script=Hiragana}' duplication.",
+                        "'\\p{Script=Hiragana}' is already included in '\\P{ASCII}'.",
                     column: 21,
                 },
                 {
-                    message:
-                        "The '\\p{Script=Hiragana}' is included in '\\P{ASCII}'.",
-                    column: 21,
-                },
-                {
-                    message: "Unexpected element '\\p{ASCII}' duplication.",
+                    message: "Unexpected duplicate '\\p{ASCII}'.",
                     column: 59,
                 },
                 {
-                    message:
-                        "The '\\p{ASCII}' is included in '\\P{Script=Hiragana}'.",
-                    column: 59,
-                },
-                {
-                    message:
-                        "Unexpected element '\\p{Script=Hiragana}' duplication.",
-                    column: 68,
-                },
-                {
-                    message:
-                        "The '\\p{Script=Hiragana}' is included in '\\P{ASCII}'.",
+                    message: "Unexpected duplicate '\\p{Script=Hiragana}'.",
                     column: 68,
                 },
             ],
         },
         {
             code: "/[\\p{ASCII} abc\\P{ASCII}]/u",
+            output: "/[\\p{ASCII}ac\\P{ASCII}]/u",
             errors: [
                 {
-                    message: "The ' ' is included in '\\p{ASCII}'.",
+                    message: "' ' is already included in '\\p{ASCII}'.",
                     column: 12,
                 },
                 {
-                    message: "The 'a' is included in '\\p{ASCII}'.",
+                    message: "'a' is already included in '\\p{ASCII}'.",
                     column: 13,
                 },
                 {
-                    message: "The 'b' is included in '\\p{ASCII}'.",
+                    message: "'b' is already included in '\\p{ASCII}'.",
                     column: 14,
                 },
                 {
-                    message: "The 'c' is included in '\\p{ASCII}'.",
+                    message: "'c' is already included in '\\p{ASCII}'.",
                     column: 15,
                 },
             ],
         },
         {
             code: "/[\\P{Script=Hiragana} abc\\p{Script=Hiragana}]/u",
+            output: "/[\\P{Script=Hiragana}ac\\p{Script=Hiragana}]/u",
             errors: [
                 {
-                    message: "The ' ' is included in '\\P{Script=Hiragana}'.",
+                    message:
+                        "' ' is already included in '\\P{Script=Hiragana}'.",
                     column: 22,
                 },
                 {
-                    message: "The 'a' is included in '\\P{Script=Hiragana}'.",
+                    message:
+                        "'a' is already included in '\\P{Script=Hiragana}'.",
                     column: 23,
                 },
                 {
-                    message: "The 'b' is included in '\\P{Script=Hiragana}'.",
+                    message:
+                        "'b' is already included in '\\P{Script=Hiragana}'.",
                     column: 24,
                 },
                 {
-                    message: "The 'c' is included in '\\P{Script=Hiragana}'.",
+                    message:
+                        "'c' is already included in '\\P{Script=Hiragana}'.",
                     column: 25,
                 },
             ],
         },
         {
             code: "/[\\w /-7+8-:]/",
+            output: null,
             errors: [
                 {
                     message:
-                        "Unexpected intersection of '/-7' and '\\w' was found '[0-7]'.",
+                        "Unexpected overlap of '/-7' and '\\w' was found '[0-7]'.",
                     column: 6,
                 },
                 {
                     message:
-                        "Unexpected intersection of '8-:' and '\\w' was found '[89]'.",
+                        "Unexpected overlap of '8-:' and '\\w' was found '[89]'.",
                     column: 10,
                 },
             ],
         },
         {
             code: "/[ -/\\s]/",
+            output: null,
             errors: [
                 {
                     message:
-                        "Unexpected intersection of ' -/' and '\\s' was found ' '.",
+                        "Unexpected overlap of ' -/' and '\\s' was found ' '.",
                     column: 3,
                 },
             ],
         },
         {
             code: "/[\\wA-_]/",
+            output: null,
             errors: [
                 {
                     message:
-                        "Unexpected intersection of 'A-_' and '\\w' was found '[A-Z_]'.",
+                        "Unexpected overlap of 'A-_' and '\\w' was found '[A-Z_]'.",
                     column: 5,
                 },
             ],
         },
         {
             code: String.raw`/[\w0-z]/`,
+            output: String.raw`/[0-z]/`,
             errors: [
                 {
-                    message: "The '\\w' is included in '0-z'.",
+                    message: "'\\w' is already included in '0-z'.",
                     line: 1,
                     column: 3,
                     endLine: 1,
@@ -442,9 +422,10 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         },
         {
             code: String.raw`/[\t-\uFFFF\s]/`,
+            output: String.raw`/[\t-\uFFFF]/`,
             errors: [
                 {
-                    message: "The '\\s' is included in '\\t-\\uFFFF'.",
+                    message: "'\\s' is already included in '\\t-\\uFFFF'.",
                     line: 1,
                     column: 12,
                     endLine: 1,
@@ -454,68 +435,133 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         },
         {
             code: "/[\\Sa]/",
+            output: "/[\\S]/",
             errors: [
                 {
-                    message: "The 'a' is included in '\\S'.",
+                    message: "'a' is already included in '\\S'.",
                     column: 5,
                 },
             ],
         },
         {
             code: "/[a-z\\p{L}]/u",
+            output: "/[\\p{L}]/u",
             errors: [
                 {
-                    message: "The 'a-z' is included in '\\p{L}'.",
+                    message: "'a-z' is already included in '\\p{L}'.",
                     column: 3,
                 },
             ],
         },
         {
             code: "/[\\d\\p{ASCII}]/u",
+            output: "/[\\p{ASCII}]/u",
             errors: [
                 {
-                    message: "The '\\d' is included in '\\p{ASCII}'.",
+                    message: "'\\d' is already included in '\\p{ASCII}'.",
                     column: 3,
                 },
             ],
         },
         {
             code: "/[\\t\\s]/",
+            output: "/[\\s]/",
             errors: [
                 {
-                    message: "The '\\t' is included in '\\s'.",
+                    message: "'\\t' is already included in '\\s'.",
                     column: 3,
                 },
             ],
         },
         {
             code: String.raw`/[A-Z a-\uFFFF]/i`,
+            output: String.raw`/[ a-\uFFFF]/i`,
             errors: [
                 {
-                    message: "The 'A-Z' is included in 'a-\\uFFFF'.",
+                    message: "'A-Z' is already included in 'a-\\uFFFF'.",
                     column: 3,
                 },
             ],
         },
         {
             code: String.raw`/[\xA0-\uFFFF\s]/`,
+            output: null,
             errors: [
                 {
                     message:
-                        "Unexpected intersection of '\\xA0-\\uFFFF' and '\\s' was found '\\xa0'.",
+                        "Unexpected overlap of '\\xA0-\\uFFFF' and '\\s' was found '\\xa0'.",
                     column: 3,
                 },
             ],
         },
         {
             code: String.raw`/[\u1fff-\u2005\s]/`,
+            output: null,
             errors: [
                 {
                     message:
-                        "Unexpected intersection of '\\u1fff-\\u2005' and '\\s' was found '[\\u2000-\\u2005]'.",
+                        "Unexpected overlap of '\\u1fff-\\u2005' and '\\s' was found '[\\u2000-\\u2005]'.",
                     column: 3,
                 },
             ],
+        },
+        {
+            // GH issue: #189
+            code: String(
+                // eslint-disable-next-line no-control-regex -- x
+                /[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]/i,
+            ),
+            output: null,
+            errors: [
+                {
+                    message:
+                        "Unexpected overlap of '\\x21-\\x5a' and '\\x53-\\x7f' was found '[A-Z]'.",
+                    column: 29,
+                },
+            ],
+        },
+
+        // sometimes, we might have to do some escaping
+        {
+            code: String.raw`/[a^\w]/`,
+            output: String.raw`/[\^\w]/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[0a-a-9a-z]/`,
+            output: String.raw`/[0\-9a-z]/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[a:^\w]/`,
+            output: String.raw`/[:^\w]/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[\sa-\w]/`,
+            output: String.raw`/[\s-\w]/`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[\x01\d-\x03\w]/`,
+            output: String.raw`/[\x01\-\x03\w]/`,
+            errors: 1,
+        },
+        // sometimes, we can't can't remove the element
+        {
+            code: String.raw`/[\x01-\d\x03\w]/`,
+            output: null,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[\s0-\s9]/`,
+            output: null,
+            errors: 1,
+        },
+        {
+            code: "/[\\x0x9]/",
+            output: null,
+            errors: 1,
         },
     ],
 })

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -30,7 +30,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "var re = /[\\\\()]/",
             errors: [
                 {
-                    message: "Unexpected duplicate '\\\\'.",
+                    message: "Unexpected duplicate '\\\\' (U+005c).",
                     line: 1,
                     column: 15,
                 },
@@ -41,7 +41,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "var re = /[a-z\\\\]/",
             errors: [
                 {
-                    message: "'s' is already included in 'a-z'.",
+                    message:
+                        "'s' (U+0073) is already included in 'a-z' (U+0061 - U+007a).",
                     line: 1,
                     column: 17,
                 },
@@ -51,8 +52,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             code: "/[aaa]/",
             output: "/[aa]/",
             errors: [
-                { message: "Unexpected duplicate 'a'.", column: 4 },
-                { message: "Unexpected duplicate 'a'.", column: 5 },
+                { message: "Unexpected duplicate 'a' (U+0061).", column: 4 },
+                { message: "Unexpected duplicate 'a' (U+0061).", column: 5 },
             ],
         },
         {
@@ -60,7 +61,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "/[\\d]/",
             errors: [
                 {
-                    message: "'0-9' is already included in '\\d'.",
+                    message:
+                        "'0-9' (U+0030 - U+0039) is already included in '\\d'.",
                     column: 3,
                 },
             ],
@@ -71,7 +73,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected duplicate. '\\u000C' is a duplicate of '\\f'.",
+                        "Unexpected duplicate. '\\u000C' (U+000c) is a duplicate of '\\f' (U+000c).",
                     column: 5,
                 },
             ],
@@ -81,46 +83,65 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                 "/[\\s \\f\\n\\r\\t\\v\\u00a0\\u1680\\u180e\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff]/",
             output: "/[\\s\\f\\r\\v\\u1680\\u180e\\u2028\\u202f\\u3000]/",
             errors: [
-                { message: "' ' is already included in '\\s'.", column: 5 },
-                { message: "'\\f' is already included in '\\s'.", column: 6 },
-                { message: "'\\n' is already included in '\\s'.", column: 8 },
-                { message: "'\\r' is already included in '\\s'.", column: 10 },
-                { message: "'\\t' is already included in '\\s'.", column: 12 },
-                { message: "'\\v' is already included in '\\s'.", column: 14 },
                 {
-                    message: "'\\u00a0' is already included in '\\s'.",
+                    message: "' ' (U+0020) is already included in '\\s'.",
+                    column: 5,
+                },
+                {
+                    message: "'\\f' (U+000c) is already included in '\\s'.",
+                    column: 6,
+                },
+                {
+                    message: "'\\n' (U+000a) is already included in '\\s'.",
+                    column: 8,
+                },
+                {
+                    message: "'\\r' (U+000d) is already included in '\\s'.",
+                    column: 10,
+                },
+                {
+                    message: "'\\t' (U+0009) is already included in '\\s'.",
+                    column: 12,
+                },
+                {
+                    message: "'\\v' (U+000b) is already included in '\\s'.",
+                    column: 14,
+                },
+                {
+                    message: "'\\u00a0' (U+00a0) is already included in '\\s'.",
                     column: 16,
                 },
                 {
-                    message: "'\\u1680' is already included in '\\s'.",
+                    message: "'\\u1680' (U+1680) is already included in '\\s'.",
                     column: 22,
                 },
                 {
-                    message: "'\\u2000-\\u200a' is already included in '\\s'.",
+                    message:
+                        "'\\u2000-\\u200a' (U+2000 - U+200a) is already included in '\\s'.",
                     column: 34,
                 },
                 {
-                    message: "'\\u2028' is already included in '\\s'.",
+                    message: "'\\u2028' (U+2028) is already included in '\\s'.",
                     column: 47,
                 },
                 {
-                    message: "'\\u2029' is already included in '\\s'.",
+                    message: "'\\u2029' (U+2029) is already included in '\\s'.",
                     column: 53,
                 },
                 {
-                    message: "'\\u202f' is already included in '\\s'.",
+                    message: "'\\u202f' (U+202f) is already included in '\\s'.",
                     column: 59,
                 },
                 {
-                    message: "'\\u205f' is already included in '\\s'.",
+                    message: "'\\u205f' (U+205f) is already included in '\\s'.",
                     column: 65,
                 },
                 {
-                    message: "'\\u3000' is already included in '\\s'.",
+                    message: "'\\u3000' (U+3000) is already included in '\\s'.",
                     column: 71,
                 },
                 {
-                    message: "'\\ufeff' is already included in '\\s'.",
+                    message: "'\\ufeff' (U+feff) is already included in '\\s'.",
                     column: 77,
                 },
             ],
@@ -131,12 +152,12 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected duplicate. '\t' is a duplicate of '\\t'.",
+                        "Unexpected duplicate. '\t' (U+0009) is a duplicate of '\\t' (U+0009).",
                     column: 5,
                 },
                 {
                     message:
-                        "Unexpected duplicate. '\\u0009' is a duplicate of '\\t'.",
+                        "Unexpected duplicate. '\\u0009' (U+0009) is a duplicate of '\\t' (U+0009).",
                     column: 7,
                 },
             ],
@@ -146,49 +167,99 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "/[\\w :,]/",
             errors: [
                 {
-                    message: "'A-Z' is already included in '\\w'.",
+                    message:
+                        "'A-Z' (U+0041 - U+005a) is already included in '\\w'.",
                     column: 5,
                 },
                 {
-                    message: "'a-z' is already included in '\\w'.",
+                    message:
+                        "'a-z' (U+0061 - U+007a) is already included in '\\w'.",
                     column: 9,
                 },
                 {
-                    message: "'0-9' is already included in '\\w'.",
+                    message:
+                        "'0-9' (U+0030 - U+0039) is already included in '\\w'.",
                     column: 13,
                 },
-                { message: "'_' is already included in '\\w'.", column: 17 },
+                {
+                    message: "'_' (U+005f) is already included in '\\w'.",
+                    column: 17,
+                },
             ],
         },
         {
             code: "/[!-z_abc-]/",
             output: "/[!-zac]/",
             errors: [
-                { message: "'_' is already included in '!-z'.", column: 6 },
-                { message: "'a' is already included in '!-z'.", column: 7 },
-                { message: "'b' is already included in '!-z'.", column: 8 },
-                { message: "'c' is already included in '!-z'.", column: 9 },
-                { message: "'-' is already included in '!-z'.", column: 10 },
+                {
+                    message:
+                        "'_' (U+005f) is already included in '!-z' (U+0021 - U+007a).",
+                    column: 6,
+                },
+                {
+                    message:
+                        "'a' (U+0061) is already included in '!-z' (U+0021 - U+007a).",
+                    column: 7,
+                },
+                {
+                    message:
+                        "'b' (U+0062) is already included in '!-z' (U+0021 - U+007a).",
+                    column: 8,
+                },
+                {
+                    message:
+                        "'c' (U+0063) is already included in '!-z' (U+0021 - U+007a).",
+                    column: 9,
+                },
+                {
+                    message:
+                        "'-' (U+002d) is already included in '!-z' (U+0021 - U+007a).",
+                    column: 10,
+                },
             ],
         },
         {
             code: "/[\\w_abc-][\\s \\t\\r\\n\\u2000\\u3000]/",
             output: "/[\\wac-][\\s\\t\\n\\u3000]/",
             errors: [
-                { message: "'_' is already included in '\\w'.", column: 5 },
-                { message: "'a' is already included in '\\w'.", column: 6 },
-                { message: "'b' is already included in '\\w'.", column: 7 },
-                { message: "'c' is already included in '\\w'.", column: 8 },
-                { message: "' ' is already included in '\\s'.", column: 14 },
-                { message: "'\\t' is already included in '\\s'.", column: 15 },
-                { message: "'\\r' is already included in '\\s'.", column: 17 },
-                { message: "'\\n' is already included in '\\s'.", column: 19 },
                 {
-                    message: "'\\u2000' is already included in '\\s'.",
+                    message: "'_' (U+005f) is already included in '\\w'.",
+                    column: 5,
+                },
+                {
+                    message: "'a' (U+0061) is already included in '\\w'.",
+                    column: 6,
+                },
+                {
+                    message: "'b' (U+0062) is already included in '\\w'.",
+                    column: 7,
+                },
+                {
+                    message: "'c' (U+0063) is already included in '\\w'.",
+                    column: 8,
+                },
+                {
+                    message: "' ' (U+0020) is already included in '\\s'.",
+                    column: 14,
+                },
+                {
+                    message: "'\\t' (U+0009) is already included in '\\s'.",
+                    column: 15,
+                },
+                {
+                    message: "'\\r' (U+000d) is already included in '\\s'.",
+                    column: 17,
+                },
+                {
+                    message: "'\\n' (U+000a) is already included in '\\s'.",
+                    column: 19,
+                },
+                {
+                    message: "'\\u2000' (U+2000) is already included in '\\s'.",
                     column: 21,
                 },
                 {
-                    message: "'\\u3000' is already included in '\\s'.",
+                    message: "'\\u3000' (U+3000) is already included in '\\s'.",
                     column: 27,
                 },
             ],
@@ -196,7 +267,23 @@ tester.run("no-dupe-characters-character-class", rule as any, {
         {
             code: "/[a-z a-z]/",
             output: "/[a-z ]/",
-            errors: [{ message: "Unexpected duplicate 'a-z'.", column: 7 }],
+            errors: [
+                {
+                    message: "Unexpected duplicate 'a-z' (U+0061 - U+007a).",
+                    column: 7,
+                },
+            ],
+        },
+        {
+            code: "/[a-z A-Z]/i",
+            output: "/[a-z ]/i",
+            errors: [
+                {
+                    message:
+                        "Unexpected duplicate. 'A-Z' (U+0041 - U+005a) is a duplicate of 'a-z' (U+0061 - U+007a).",
+                    column: 7,
+                },
+            ],
         },
         {
             code: "/[a-d e-h_d-e+c-d]/",
@@ -204,11 +291,12 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "'d-e' is already included by a combination of other elements.",
+                        "'d-e' (U+0064 - U+0065) is already included by a combination of other elements.",
                     column: 11,
                 },
                 {
-                    message: "'c-d' is already included in 'a-d'.",
+                    message:
+                        "'c-d' (U+0063 - U+0064) is already included in 'a-d' (U+0061 - U+0064).",
                     column: 15,
                 },
             ],
@@ -219,11 +307,11 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "'3-6' is already included by a combination of other elements.",
+                        "'3-6' (U+0033 - U+0036) is already included by a combination of other elements.",
                     column: 3,
                 },
                 {
-                    message: "Unexpected duplicate '3-6'.",
+                    message: "Unexpected duplicate '3-6' (U+0033 - U+0036).",
                     column: 7,
                 },
             ],
@@ -234,11 +322,11 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected overlap of '3-6' and '5-7' was found '[56]'.",
+                        "Unexpected overlap of '3-6' (U+0033 - U+0036) and '5-7' (U+0035 - U+0037) was found '[56]'.",
                     column: 3,
                 },
                 {
-                    message: "Unexpected duplicate '3-6'.",
+                    message: "Unexpected duplicate '3-6' (U+0033 - U+0036).",
                     column: 7,
                 },
             ],
@@ -248,7 +336,10 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "/[\\s ]/",
             errors: [
                 { message: "Unexpected duplicate '\\s'.", column: 5 },
-                { message: "' ' is already included in '\\s'.", column: 7 },
+                {
+                    message: "' ' (U+0020) is already included in '\\s'.",
+                    column: 7,
+                },
                 { message: "Unexpected duplicate '\\s'.", column: 8 },
             ],
         },
@@ -257,8 +348,14 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "/[\\S \\s]/",
             errors: [
                 { message: "Unexpected duplicate '\\S'.", column: 5 },
-                { message: "' ' is already included in '\\s'.", column: 7 },
-                { message: "'a' is already included in '\\S'.", column: 10 },
+                {
+                    message: "' ' (U+0020) is already included in '\\s'.",
+                    column: 7,
+                },
+                {
+                    message: "'a' (U+0061) is already included in '\\S'.",
+                    column: 10,
+                },
             ],
         },
         {
@@ -266,14 +363,20 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "/[ _!-z]/",
             errors: [
                 {
-                    message: "'\\d' is already included in '!-z'.",
+                    message:
+                        "'\\d' is already included in '!-z' (U+0021 - U+007a).",
                     column: 3,
                 },
                 {
-                    message: "'0-9' is already included in '!-z'.",
+                    message:
+                        "'0-9' (U+0030 - U+0039) is already included in '!-z' (U+0021 - U+007a).",
                     column: 6,
                 },
-                { message: "'_' is already included in '!-z'.", column: 9 },
+                {
+                    message:
+                        "'_' (U+005f) is already included in '!-z' (U+0021 - U+007a).",
+                    column: 9,
+                },
             ],
         },
         {
@@ -285,7 +388,10 @@ tester.run("no-dupe-characters-character-class", rule as any, {
                     column: 3,
                 },
                 { message: "Unexpected duplicate '\\W'.", column: 5 },
-                { message: "' ' is already included in '\\W'.", column: 9 },
+                {
+                    message: "' ' (U+0020) is already included in '\\W'.",
+                    column: 9,
+                },
                 {
                     message: "'\\d' is already included in '\\w'.",
                     column: 10,
@@ -326,19 +432,23 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "/[\\p{ASCII}ac\\P{ASCII}]/u",
             errors: [
                 {
-                    message: "' ' is already included in '\\p{ASCII}'.",
+                    message:
+                        "' ' (U+0020) is already included in '\\p{ASCII}'.",
                     column: 12,
                 },
                 {
-                    message: "'a' is already included in '\\p{ASCII}'.",
+                    message:
+                        "'a' (U+0061) is already included in '\\p{ASCII}'.",
                     column: 13,
                 },
                 {
-                    message: "'b' is already included in '\\p{ASCII}'.",
+                    message:
+                        "'b' (U+0062) is already included in '\\p{ASCII}'.",
                     column: 14,
                 },
                 {
-                    message: "'c' is already included in '\\p{ASCII}'.",
+                    message:
+                        "'c' (U+0063) is already included in '\\p{ASCII}'.",
                     column: 15,
                 },
             ],
@@ -349,22 +459,22 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "' ' is already included in '\\P{Script=Hiragana}'.",
+                        "' ' (U+0020) is already included in '\\P{Script=Hiragana}'.",
                     column: 22,
                 },
                 {
                     message:
-                        "'a' is already included in '\\P{Script=Hiragana}'.",
+                        "'a' (U+0061) is already included in '\\P{Script=Hiragana}'.",
                     column: 23,
                 },
                 {
                     message:
-                        "'b' is already included in '\\P{Script=Hiragana}'.",
+                        "'b' (U+0062) is already included in '\\P{Script=Hiragana}'.",
                     column: 24,
                 },
                 {
                     message:
-                        "'c' is already included in '\\P{Script=Hiragana}'.",
+                        "'c' (U+0063) is already included in '\\P{Script=Hiragana}'.",
                     column: 25,
                 },
             ],
@@ -375,12 +485,12 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected overlap of '/-7' and '\\w' was found '[0-7]'.",
+                        "Unexpected overlap of '/-7' (U+002f - U+0037) and '\\w' was found '[0-7]'.",
                     column: 6,
                 },
                 {
                     message:
-                        "Unexpected overlap of '8-:' and '\\w' was found '[89]'.",
+                        "Unexpected overlap of '8-:' (U+0038 - U+003a) and '\\w' was found '[89]'.",
                     column: 10,
                 },
             ],
@@ -391,7 +501,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected overlap of ' -/' and '\\s' was found ' '.",
+                        "Unexpected overlap of ' -/' (U+0020 - U+002f) and '\\s' was found ' '.",
                     column: 3,
                 },
             ],
@@ -402,7 +512,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected overlap of 'A-_' and '\\w' was found '[A-Z_]'.",
+                        "Unexpected overlap of 'A-_' (U+0041 - U+005f) and '\\w' was found '[A-Z_]'.",
                     column: 5,
                 },
             ],
@@ -412,7 +522,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: String.raw`/[0-z]/`,
             errors: [
                 {
-                    message: "'\\w' is already included in '0-z'.",
+                    message:
+                        "'\\w' is already included in '0-z' (U+0030 - U+007a).",
                     line: 1,
                     column: 3,
                     endLine: 1,
@@ -425,7 +536,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: String.raw`/[\t-\uFFFF]/`,
             errors: [
                 {
-                    message: "'\\s' is already included in '\\t-\\uFFFF'.",
+                    message:
+                        "'\\s' is already included in '\\t-\\uFFFF' (U+0009 - U+ffff).",
                     line: 1,
                     column: 12,
                     endLine: 1,
@@ -438,7 +550,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "/[\\S]/",
             errors: [
                 {
-                    message: "'a' is already included in '\\S'.",
+                    message: "'a' (U+0061) is already included in '\\S'.",
                     column: 5,
                 },
             ],
@@ -448,7 +560,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "/[\\p{L}]/u",
             errors: [
                 {
-                    message: "'a-z' is already included in '\\p{L}'.",
+                    message:
+                        "'a-z' (U+0061 - U+007a) is already included in '\\p{L}'.",
                     column: 3,
                 },
             ],
@@ -468,7 +581,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: "/[\\s]/",
             errors: [
                 {
-                    message: "'\\t' is already included in '\\s'.",
+                    message: "'\\t' (U+0009) is already included in '\\s'.",
                     column: 3,
                 },
             ],
@@ -478,7 +591,8 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             output: String.raw`/[ a-\uFFFF]/i`,
             errors: [
                 {
-                    message: "'A-Z' is already included in 'a-\\uFFFF'.",
+                    message:
+                        "'A-Z' (U+0041 - U+005a) is already included in 'a-\\uFFFF' (U+0061 - U+ffff).",
                     column: 3,
                 },
             ],
@@ -489,7 +603,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected overlap of '\\xA0-\\uFFFF' and '\\s' was found '\\xa0'.",
+                        "Unexpected overlap of '\\xA0-\\uFFFF' (U+00a0 - U+ffff) and '\\s' was found '\\xa0'.",
                     column: 3,
                 },
             ],
@@ -500,7 +614,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected overlap of '\\u1fff-\\u2005' and '\\s' was found '[\\u2000-\\u2005]'.",
+                        "Unexpected overlap of '\\u1fff-\\u2005' (U+1fff - U+2005) and '\\s' was found '[\\u2000-\\u2005]'.",
                     column: 3,
                 },
             ],
@@ -515,7 +629,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected overlap of '\\x21-\\x5a' and '\\x53-\\x7f' was found '[A-Z]'.",
+                        "Unexpected overlap of '\\x21-\\x5a' (U+0021 - U+005a) and '\\x53-\\x7f' (U+0053 - U+007f) was found '[A-Z]'.",
                     column: 29,
                 },
             ],

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -291,7 +291,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "'d-e' (U+0064 - U+0065) is already included by a combination of other elements.",
+                        "'d-e' (U+0064 - U+0065) is already included by the elements 'a-de-h' ('a-d' (U+0061 - U+0064), 'e-h' (U+0065 - U+0068)).",
                     column: 11,
                 },
                 {
@@ -307,7 +307,7 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             errors: [
                 {
                     message:
-                        "'3-6' (U+0033 - U+0036) is already included by a combination of other elements.",
+                        "'3-6' (U+0033 - U+0036) is already included by the elements '2-45-7' ('2-4' (U+0032 - U+0034), '5-7' (U+0035 - U+0037)).",
                     column: 3,
                 },
                 {


### PR DESCRIPTION
This improves the `no-dupe-characters-character-class` rule. 

Changes:

1. The rule is now fixable!
1. It now finds more cases. E.g. the case `[a-bc-db-c]` was previously reported as a bunch of intersection messages. The rule now only reports that `b-c` is a subset of the other elements.
1. Duplicates are now reported differently. E.g. `[aa]` both `a`s were reported previously but now only the second `a` will be reported. I changed this because reporting both `a` doesn't work with fixers.
1. More descriptive error messages.

I also fixed #189 while I was at it.

---

The rule now covers most of the functionality of `clean-regex/optimized-character-class`.