### PR TITLE
Fix false positives for `disallowNeverMatch` in `regexp/no-dupe-disjunctions` rule

### DIFF
--- a/lib/utils/regexp-ast/is-covered.ts
+++ b/lib/utils/regexp-ast/is-covered.ts
@@ -521,6 +521,10 @@ function isCoveredAltNodes(
                 if (!isCoveredForNormalizedNode(le, re.element, options)) {
                     return false
                 }
+                // Checks if skipped.
+                if (!isCoveredAltNodes([le, ...left], right, options)) {
+                    return false
+                }
                 const decrementRe = re.decrementMax()
                 if (decrementRe) {
                     // Check for multiple iterations.

--- a/tests/lib/rules/no-dupe-disjunctions.ts
+++ b/tests/lib/rules/no-dupe-disjunctions.ts
@@ -37,6 +37,26 @@ tester.run("no-dupe-disjunctions", rule as any, {
             code: `/<("[^"]*"|'[^']*'|[^'">])*>/g`,
             options: [{ disallowNeverMatch: true }],
         },
+        {
+            code: String.raw`/A+_|A*_/`,
+            options: [{ disallowNeverMatch: true }],
+        },
+        {
+            code: String.raw`/(?:A+|A*)_/`,
+            options: [{ disallowNeverMatch: true }],
+        },
+        {
+            code: String.raw`/\d*\.\d+_|\d+\.\d*_/`,
+            options: [{ disallowNeverMatch: true }],
+        },
+        {
+            code: String.raw`/\d*\.\d+|\d+\.\d*/`,
+            options: [{ disallowNeverMatch: true }],
+        },
+        {
+            code: String.raw`/(?:\d*\.\d+|\d+\.\d*)_/`,
+            options: [{ disallowNeverMatch: true }],
+        },
     ],
     invalid: [
         ...[

--- a/tests/lib/utils/regexp-ast.ts
+++ b/tests/lib/utils/regexp-ast.ts
@@ -500,6 +500,26 @@ const TESTCASES_FOR_COVERED_NODE: TestCase[] = [
         b: /a*b?c_/,
         result: false,
     },
+    {
+        a: /\d+_/,
+        b: /\d*_/,
+        result: false,
+    },
+    {
+        a: /\d+/,
+        b: /\d*/,
+        result: false,
+    },
+    {
+        a: /\d*\.\d+/,
+        b: /\d+\.\d*/,
+        result: false,
+    },
+    {
+        a: /\d*\.\d+_/,
+        b: /\d+\.\d*_/,
+        result: false,
+    },
 ]
 describe("regexp-ast isCoveredNode", () => {
     for (const testCase of [


### PR DESCRIPTION

fixes #178