### PR TITLE
Add `no-useless-quantifier` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-useless-lazy](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-lazy.html) | disallow unnecessarily non-greedy quantifiers | :wrench: |
 | [regexp/no-useless-non-capturing-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-non-capturing-group.html) | disallow unnecessary Non-capturing group | :wrench: |
 | [regexp/no-useless-non-greedy](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-non-greedy.html) | disallow unnecessarily non-greedy quantifiers | :wrench: |
+| [regexp/no-useless-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-quantifier.html) | disallow quantifiers that can be removed | :wrench: |
 | [regexp/no-useless-range](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-range.html) | disallow unnecessary range of characters by using a hyphen | :wrench: |
 | [regexp/no-useless-two-nums-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-two-nums-quantifier.html) | disallow unnecessary `{n,m}` quantifier | :star::wrench: |
 | [regexp/optimal-lookaround-quantifier](https://ota-meshi.github.io/eslint-plugin-regexp/rules/optimal-lookaround-quantifier.html) | disallow the alternatives of lookarounds that end with a non-constant quantifier |  |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -46,6 +46,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-useless-lazy](./no-useless-lazy.md) | disallow unnecessarily non-greedy quantifiers | :wrench: |
 | [regexp/no-useless-non-capturing-group](./no-useless-non-capturing-group.md) | disallow unnecessary Non-capturing group | :wrench: |
 | [regexp/no-useless-non-greedy](./no-useless-non-greedy.md) | disallow unnecessarily non-greedy quantifiers | :wrench: |
+| [regexp/no-useless-quantifier](./no-useless-quantifier.md) | disallow quantifiers that can be removed | :wrench: |
 | [regexp/no-useless-range](./no-useless-range.md) | disallow unnecessary range of characters by using a hyphen | :wrench: |
 | [regexp/no-useless-two-nums-quantifier](./no-useless-two-nums-quantifier.md) | disallow unnecessary `{n,m}` quantifier | :star::wrench: |
 | [regexp/optimal-lookaround-quantifier](./optimal-lookaround-quantifier.md) | disallow the alternatives of lookarounds that end with a non-constant quantifier |  |

--- a/docs/rules/no-useless-quantifier.md
+++ b/docs/rules/no-useless-quantifier.md
@@ -1,0 +1,59 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "regexp/no-useless-quantifier"
+description: "disallow quantifiers that can be removed"
+---
+# regexp/no-useless-quantifier
+
+> disallow quantifiers that can be removed
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule reports quantifiers that can trivially be removed without affecting the pattern.
+
+This rule only fixes constant one quantifiers (e.g. `a{1}`). All other reported useless quantifiers hint at programmer oversight or fundamental problems with the pattern.
+
+Examples:
+
+- `a{1}`
+
+  It's clear that the `{1}` quantifier can be removed.
+
+- `(?:a+b*|c*)?`
+
+  It might not very obvious that the `?` quantifier can be removed. Without this quantifier, that pattern can still match the empty string by choosing 0 many `c`s in the `c*` alternative.
+
+- `(?:\b)+`
+
+  The `+` quantifier can be removed because its quantified element doesn't consume characters.
+
+<eslint-code-block fix>
+
+```js
+/* eslint regexp/no-useless-quantifier: "error" */
+
+/* ✓ GOOD */
+var foo = /a*/;
+var foo = /(?:a|b?)??/;
+var foo = /(?:\b|(?!a))*/;
+
+/* ✗ BAD */
+var foo = /a{1}/;
+var foo = /(?:\b)+/;
+var foo = /(?:a+b*|c*)?/;
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/lib/rules/no-useless-quantifier.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/tests/lib/rules/no-useless-quantifier.ts)

--- a/lib/rules/no-useless-quantifier.ts
+++ b/lib/rules/no-useless-quantifier.ts
@@ -1,0 +1,132 @@
+import type { Rule } from "eslint"
+import type { RegExpVisitor } from "regexpp/visitor"
+import type { Quantifier } from "regexpp/ast"
+import type { RegExpContext } from "../utils"
+import { canUnwrapped, createRule, defineRegexpVisitor } from "../utils"
+import { isEmpty, isPotentiallyEmpty, isZeroLength } from "regexp-ast-analysis"
+
+export default createRule("no-useless-quantifier", {
+    meta: {
+        docs: {
+            description: "disallow quantifiers that can be removed",
+            // TODO Switch to recommended in the major version.
+            // recommended: true,
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [],
+        messages: {
+            constOne: "Unexpected useless quantifier.",
+            empty:
+                "Unexpected useless quantifier. The quantified element doesn't consume or assert characters.",
+            emptyQuestionMark:
+                "Unexpected useless quantifier. The quantified element can already accept the empty string, so this quantifier is redundant.",
+            zeroLength:
+                "Unexpected useless quantifier. The quantified element doesn't consume characters.",
+
+            // suggestions
+            remove: "Remove the '{{quant}}' quantifier.",
+        },
+        type: "suggestion", // "problem",
+    },
+    create(context) {
+        /**
+         * Create visitor
+         */
+        function createVisitor(
+            regexpContext: RegExpContext,
+        ): RegExpVisitor.Handlers {
+            const { node, getRegexpLocation, fixReplaceNode } = regexpContext
+
+            /**
+             * Returns a fix that replaces the given quantifier with its
+             * quantified element
+             */
+            function fixRemoveQuant(qNode: Quantifier) {
+                return fixReplaceNode(qNode, () => {
+                    const text = qNode.element.raw
+                    return canUnwrapped(qNode, text) ? text : null
+                })
+            }
+
+            /**
+             * Returns a suggestion that replaces the given quantifier with its
+             * quantified element
+             */
+            function suggestRemoveQuant(
+                qNode: Quantifier,
+            ): Rule.SuggestionReportDescriptor {
+                const quant = qNode.raw.slice(qNode.element.end - qNode.start)
+
+                return {
+                    messageId: "remove",
+                    data: { quant },
+                    fix: fixReplaceNode(qNode, () => {
+                        const text = qNode.element.raw
+                        return canUnwrapped(qNode, text) ? text : null
+                    }),
+                }
+            }
+
+            return {
+                onQuantifierEnter(qNode) {
+                    // trivial case
+                    // e.g. a{1}
+                    if (qNode.min === 1 && qNode.max === 1) {
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(qNode),
+                            messageId: "constOne",
+                            fix: fixRemoveQuant(qNode),
+                        })
+                        return
+                    }
+
+                    // the quantified element already accepts the empty string
+                    // e.g. (||)*
+                    if (isEmpty(qNode.element)) {
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(qNode),
+                            messageId: "empty",
+                            suggest: [suggestRemoveQuant(qNode)],
+                        })
+                        return
+                    }
+
+                    // the quantified element already accepts the empty string
+                    // e.g. (a?)?
+                    if (
+                        qNode.min === 0 &&
+                        qNode.max === 1 &&
+                        qNode.greedy &&
+                        isPotentiallyEmpty(qNode.element)
+                    ) {
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(qNode),
+                            messageId: "emptyQuestionMark",
+                            suggest: [suggestRemoveQuant(qNode)],
+                        })
+                        return
+                    }
+
+                    // the quantified is zero length
+                    // e.g. (\b){5}
+                    if (qNode.min >= 1 && isZeroLength(qNode.element)) {
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(qNode),
+                            messageId: "zeroLength",
+                            suggest: [suggestRemoveQuant(qNode)],
+                        })
+                    }
+                },
+            }
+        }
+
+        return defineRegexpVisitor(context, {
+            createVisitor,
+        })
+    },
+})

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -34,6 +34,7 @@ import noUselessFlag from "../rules/no-useless-flag"
 import noUselessLazy from "../rules/no-useless-lazy"
 import noUselessNonCapturingGroup from "../rules/no-useless-non-capturing-group"
 import noUselessNonGreedy from "../rules/no-useless-non-greedy"
+import noUselessQuantifier from "../rules/no-useless-quantifier"
 import noUselessRange from "../rules/no-useless-range"
 import noUselessTwoNumsQuantifier from "../rules/no-useless-two-nums-quantifier"
 import optimalLookaroundQuantifier from "../rules/optimal-lookaround-quantifier"
@@ -92,6 +93,7 @@ export const rules = [
     noUselessLazy,
     noUselessNonCapturingGroup,
     noUselessNonGreedy,
+    noUselessQuantifier,
     noUselessRange,
     noUselessTwoNumsQuantifier,
     optimalLookaroundQuantifier,

--- a/tests/lib/rules/no-useless-quantifier.ts
+++ b/tests/lib/rules/no-useless-quantifier.ts
@@ -1,0 +1,167 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-useless-quantifier"
+
+const tester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+})
+
+tester.run("no-useless-quantifier", rule as any, {
+    valid: [
+        String.raw`/a*/`,
+        String.raw`/(?:a)?/`,
+        String.raw`/(?:a|b?)??/`,
+        String.raw`/(?:\b|a)?/`,
+        String.raw`/(?:\b)*/`,
+        String.raw`/(?:\b|(?!a))*/`,
+        String.raw`/(?:\b|(?!))*/`,
+        String.raw`/#[\da-z]+|#(?:-|([+/\\*~<>=@%|&?!])\1?)|#(?=\()/`,
+    ],
+    invalid: [
+        // trivial
+        {
+            code: String.raw`/a{1}/`,
+            output: String.raw`/a/`,
+            errors: ["Unexpected useless quantifier."],
+        },
+        {
+            code: String.raw`/a{1,1}?/`,
+            output: String.raw`/a/`,
+            errors: ["Unexpected useless quantifier."],
+        },
+
+        // empty quantified element
+        {
+            code: String.raw`/(?:)+/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "empty",
+                    suggestions: [
+                        { messageId: "remove", output: String.raw`/(?:)/` },
+                    ],
+                },
+            ],
+        },
+        {
+            code: String.raw`/(?:|(?:)){5,9}/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "empty",
+                    suggestions: [
+                        {
+                            messageId: "remove",
+                            output: String.raw`/(?:|(?:))/`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            code: String.raw`/(?:|()()())*/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "empty",
+                    suggestions: [
+                        {
+                            messageId: "remove",
+                            output: String.raw`/(?:|()()())/`,
+                        },
+                    ],
+                },
+            ],
+        },
+
+        // unnecessary optional quantifier (?) because the quantified element is potentially empty
+        {
+            code: String.raw`/(?:a+b*|c*)?/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "emptyQuestionMark",
+                    suggestions: [
+                        {
+                            messageId: "remove",
+                            output: String.raw`/(?:a+b*|c*)/`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            code: String.raw`/(?:a|b?c?d?e?f?)?/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "emptyQuestionMark",
+                    suggestions: [
+                        {
+                            messageId: "remove",
+                            output: String.raw`/(?:a|b?c?d?e?f?)/`,
+                        },
+                    ],
+                },
+            ],
+        },
+
+        // quantified elements which do not consume characters
+        {
+            code: String.raw`/(?:\b)+/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "zeroLength",
+                    suggestions: [
+                        { messageId: "remove", output: String.raw`/(?:\b)/` },
+                    ],
+                },
+            ],
+        },
+        {
+            code: String.raw`/(?:\b){5,100}/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "zeroLength",
+                    suggestions: [
+                        { messageId: "remove", output: String.raw`/(?:\b)/` },
+                    ],
+                },
+            ],
+        },
+        {
+            code: String.raw`/(?:\b|(?!a))+/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "zeroLength",
+                    suggestions: [
+                        {
+                            messageId: "remove",
+                            output: String.raw`/(?:\b|(?!a))/`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            code: String.raw`/(?:\b|(?!)){6}/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "zeroLength",
+                    suggestions: [
+                        {
+                            messageId: "remove",
+                            output: String.raw`/(?:\b|(?!))/`,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+})


### PR DESCRIPTION
This brings over the `clean-regex/no-unnecessary-quantifier` rule.

---

There is some overlap with `regexp/no-useless-exactly-quantifier`. @ota-meshi, [you said that we might want to deprecate this rule](https://github.com/ota-meshi/eslint-plugin-regexp/issues/91#issuecomment-821790265) and I agree.

However, if we do deprecate `regexp/no-useless-exactly-quantifier`, then we have to handle the zero-quantifier case (e.g. `a{0}`) somewhere else. I think it might be a good idea to add a rule specifically for zero-quantifiers, similar to `clean-regex/no-zero-quantifier`.