### PR TITLE
#204 changes

### DIFF
--- a/docs/rules/no-dupe-disjunctions.md
+++ b/docs/rules/no-dupe-disjunctions.md
@@ -161,8 +161,6 @@ This option controls how this rule reports unreachable alternatives in fragments
   const pattern = RegExp(`is (${int})`);
   ```
 
-_Note:_ This option only affects `report` modes other than `"all"`.
-
 ## :rocket: Version
 
 This rule was introduced in eslint-plugin-regexp v0.4.0

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -613,6 +613,13 @@ function deduplicateResults(results: readonly Result[]): Result[] {
     })
 }
 
+/**
+ * Throws if called.
+ */
+function assertNever(value: never): never {
+    throw new Error(`Invalid value: ${value}`)
+}
+
 const enum ReportOption {
     all = "all",
     trivial = "trivial",
@@ -623,9 +630,15 @@ const enum ReportExponentialBacktracking {
     certain = "certain",
     potential = "potential",
 }
-const enum ReportPrefixSubset {
+const enum ReportUnreachable {
     certain = "certain",
     potential = "potential",
+}
+
+const enum MaybeBool {
+    false = 0,
+    true = 1,
+    maybe = 2,
 }
 
 export default createRule("no-dupe-disjunctions", {
@@ -648,7 +661,7 @@ export default createRule("no-dupe-disjunctions", {
                     reportExponentialBacktracking: {
                         enum: ["none", "certain", "potential"],
                     },
-                    reportPrefixSubset: {
+                    reportUnreachable: {
                         enum: ["certain", "potential"],
                     },
 
@@ -690,10 +703,8 @@ export default createRule("no-dupe-disjunctions", {
                     ReportExponentialBacktracking.none
             }
         }
-        let reportPrefixSubset = ReportPrefixSubset.potential
-        if (context.options[0]?.reportPrefixSubset) {
-            reportPrefixSubset = context.options[0]?.reportPrefixSubset
-        }
+        const reportUnreachable: ReportUnreachable =
+            context.options[0]?.reportUnreachable ?? ReportUnreachable.potential
         const report: ReportOption =
             context.options[0]?.report ?? ReportOption.trivial
 
@@ -723,21 +734,83 @@ export default createRule("no-dupe-disjunctions", {
                 ),
             })
 
+            interface FilterInfo {
+                stared: MaybeBool
+                nothingAfter: MaybeBool
+
+                reportExp: boolean
+                reportPrefix: boolean
+            }
+
+            /** Returns the filter information for the given node */
+            function getFilterInfo(parentNode: ParentNode): FilterInfo {
+                const usage = getUsageOfPattern()
+
+                let stared: MaybeBool
+                if (isStared(parentNode)) {
+                    stared = MaybeBool.true
+                } else if (
+                    usage === UsageOfPattern.partial ||
+                    usage === UsageOfPattern.mixed
+                ) {
+                    stared = MaybeBool.maybe
+                } else {
+                    stared = MaybeBool.false
+                }
+
+                // eslint-disable-next-line one-var -- false positive
+                let nothingAfter: MaybeBool
+                if (!hasNothingAfterNode(parentNode)) {
+                    nothingAfter = MaybeBool.false
+                } else if (
+                    usage === UsageOfPattern.partial ||
+                    usage === UsageOfPattern.mixed
+                ) {
+                    nothingAfter = MaybeBool.maybe
+                } else {
+                    nothingAfter = MaybeBool.true
+                }
+
+                // eslint-disable-next-line one-var -- false positive
+                let reportExp: boolean
+                switch (reportExponentialBacktracking) {
+                    case ReportExponentialBacktracking.none:
+                        reportExp = false
+                        break
+
+                    case ReportExponentialBacktracking.certain:
+                        reportExp = stared === MaybeBool.true
+                        break
+
+                    case ReportExponentialBacktracking.potential:
+                        reportExp = stared !== MaybeBool.false
+                        break
+
+                    default:
+                        assertNever(reportExponentialBacktracking)
+                }
+
+                // eslint-disable-next-line one-var -- false positive
+                let reportPrefix: boolean
+                switch (reportUnreachable) {
+                    case ReportUnreachable.certain:
+                        reportPrefix = nothingAfter === MaybeBool.true
+                        break
+
+                    case ReportUnreachable.potential:
+                        reportPrefix = nothingAfter !== MaybeBool.false
+                        break
+
+                    default:
+                        assertNever(reportUnreachable)
+                }
+
+                return { stared, nothingAfter, reportExp, reportPrefix }
+            }
+
             /** Verify group node */
             function verify(parentNode: ParentNode) {
-                // report all if the we report exp backtracking
-                const nodeReport =
-                    reportExponentialBacktracking !==
-                        ReportExponentialBacktracking.none &&
-                    isStared(parentNode)
-                        ? ReportOption.all
-                        : report
-
-                const hasNothingAfter =
-                    hasNothingAfterNode(parentNode) &&
-                    (reportPrefixSubset === ReportPrefixSubset.potential ||
-                        (reportPrefixSubset === ReportPrefixSubset.certain &&
-                            getUsageOfPattern() !== UsageOfPattern.partial))
+                const info = getFilterInfo(parentNode)
 
                 const rawResults = findDuplication(
                     parentNode.alternatives,
@@ -745,46 +818,100 @@ export default createRule("no-dupe-disjunctions", {
                     {
                         fastAst: false,
                         noNfa: false,
-                        ignoreOverlap: nodeReport !== ReportOption.all,
-                        hasNothingAfter,
+                        ignoreOverlap:
+                            !info.reportExp && report !== ReportOption.all,
+                        hasNothingAfter: info.reportPrefix,
                         parser,
                     },
                 )
 
-                let results = deduplicateResults(sortResultTypes(rawResults))
+                let results = filterResults([...rawResults], info)
+                results = deduplicateResults(sortResultTypes(results))
+                results.forEach((result) => reportResult(result, info))
+            }
 
-                if (nodeReport === ReportOption.trivial) {
-                    // For "trivial", we want to filter out all results
-                    // where the user cannot just remove the reported
-                    // alternative. So "Overlap" and "Superset" types are
-                    // removed.
+            /** Filters the results of a parent node. */
+            function filterResults(
+                results: Result[],
+                { nothingAfter, reportExp, reportPrefix }: FilterInfo,
+            ): Result[] {
+                switch (report) {
+                    case ReportOption.all: {
+                        // We really want to report _everything_.
+                        return results
+                    }
+                    case ReportOption.trivial: {
+                        // For "trivial", we want to filter out all results
+                        // where the user cannot just remove the reported
+                        // alternative. So "Overlap" and "Superset" types are
+                        // removed.
 
-                    results = results.filter(({ type }) => {
-                        return !(type === "Overlap" || type === "Superset")
-                    })
-                } else if (nodeReport === ReportOption.interesting) {
-                    // For "interesting", we want to behave like "trivial"
-                    // but we also want to retain "Superset" results like
-                    // `\b(?:Foo|\w+)\b`. So "Overlap" types are always
-                    // removed and "Superset" types are removed if there is
-                    // nothing after it.
+                        return results.filter(({ type }) => {
+                            switch (type) {
+                                case "Duplicate":
+                                case "Subset":
+                                    return true
 
-                    results = results.filter(({ type }) => {
-                        return !(
-                            type === "Overlap" ||
-                            (type === "Superset" && hasNothingAfter)
-                        )
-                    })
+                                case "Overlap":
+                                case "Superset":
+                                    return reportExp
+
+                                case "PrefixSubset":
+                                    return reportPrefix
+
+                                default:
+                                    throw assertNever(type)
+                            }
+                        })
+                    }
+                    case ReportOption.interesting: {
+                        // For "interesting", we want to behave like "trivial"
+                        // but we also want to retain "Superset" results like
+                        // `\b(?:Foo|\w+)\b`. So "Overlap" types are always
+                        // removed and "Superset" types are removed if there is
+                        // nothing after it.
+
+                        return results.filter(({ type }) => {
+                            switch (type) {
+                                case "Duplicate":
+                                case "Subset":
+                                    return true
+
+                                case "Overlap":
+                                    return reportExp
+
+                                case "Superset":
+                                    return (
+                                        reportExp ||
+                                        nothingAfter === MaybeBool.false
+                                    )
+
+                                case "PrefixSubset":
+                                    return reportPrefix
+
+                                default:
+                                    throw assertNever(type)
+                            }
+                        })
+                    }
+                    default:
+                        throw assertNever(report)
                 }
-
-                results.forEach(reportResult)
             }
 
             /** Report the given result. */
-            function reportResult(result: Result) {
-                const exp = isStared(result.alternative)
-                    ? " This ambiguity is likely to cause exponential backtracking."
-                    : ""
+            function reportResult(result: Result, { stared }: FilterInfo) {
+                let exp
+                if (stared === MaybeBool.true) {
+                    exp =
+                        " This ambiguity is likely to cause exponential backtracking."
+                } else if (stared === MaybeBool.maybe) {
+                    exp =
+                        " This ambiguity might cause exponential backtracking."
+                } else {
+                    exp = ""
+                }
+
                 const cap = hasSomeDescendant(
                     result.alternative,
                     (d) => d.type === "CapturingGroup",
@@ -814,20 +941,12 @@ export default createRule("no-dupe-disjunctions", {
                         break
 
                     case "PrefixSubset":
-                        if (
-                            reportPrefixSubset ===
-                                ReportPrefixSubset.potential ||
-                            (reportPrefixSubset ===
-                                ReportPrefixSubset.certain &&
-                                getUsageOfPattern() !== UsageOfPattern.partial)
-                        ) {
-                            context.report({
-                                node,
-                                loc: getRegexpLocation(result.alternative),
-                                messageId: "prefixSubset",
-                                data: { exp, cap, others },
-                            })
-                        }
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(result.alternative),
+                            messageId: "prefixSubset",
+                            data: { exp, cap, others },
+                        })
                         break
 
                     case "Superset":
@@ -840,26 +959,17 @@ export default createRule("no-dupe-disjunctions", {
                         break
 
                     case "Overlap":
-                        if (
-                            isStared(result.alternative) ||
-                            reportExponentialBacktracking ===
-                                ReportExponentialBacktracking.potential ||
-                            (reportExponentialBacktracking ===
-                                ReportExponentialBacktracking.certain &&
-                                getUsageOfPattern() !== UsageOfPattern.partial)
-                        ) {
-                            context.report({
-                                node,
-                                loc: getRegexpLocation(result.alternative),
-                                messageId: "overlap",
-                                data: {
-                                    exp,
-                                    cap,
-                                    others,
-                                    expr: faToSource(result.overlap, flags),
-                                },
-                            })
-                        }
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(result.alternative),
+                            messageId: "overlap",
+                            data: {
+                                exp,
+                                cap,
+                                others,
+                                expr: faToSource(result.overlap, flags),
+                            },
+                        })
                         break
 
                     default:

--- a/tests/lib/rules/no-dupe-disjunctions.ts
+++ b/tests/lib/rules/no-dupe-disjunctions.ts
@@ -34,7 +34,15 @@ tester.run("no-dupe-disjunctions", rule as any, {
             const a = /a|aa/.source;
             const b = RegExp(\`\\b(\${a})\\b\`);
             `,
-            options: [{ reportPrefixSubset: "certain" }],
+            options: [{ reportUnreachable: "certain" }],
+        },
+        {
+            // reportUnreachable: 'certain', but report: "all"
+            code: `
+            const a = /a|aa/.source;
+            const b = RegExp(\`\\b(\${a})\\b\`);
+            `,
+            options: [{ report: "all", reportUnreachable: "certain" }],
         },
     ],
     invalid: [
@@ -439,16 +447,11 @@ tester.run("no-dupe-disjunctions", rule as any, {
         {
             // reportExponentialBacktracking: 'certain'
             code: `
-            const foo = /(?:ac?|\\wb?)a/.source;
-            const bar = RegExp(\`^(?:\${foo})+$\`);
+            const foo1 = /(?:ac?|\\wb?)a/.source;
+            const bar = RegExp(\`^(?:\${foo1})+$\`);
             `,
             options: [{ reportExponentialBacktracking: "certain" }],
             errors: [
-                {
-                    message:
-                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity might cause exponential backtracking.",
-                    line: 2,
-                },
                 {
                     message:
                         "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity is likely to cause exponential backtracking.",
@@ -459,8 +462,8 @@ tester.run("no-dupe-disjunctions", rule as any, {
         {
             // reportExponentialBacktracking: 'certain'
             code: `
-            const foo = /(?:ac?|\\wb?)a/.source;
-            const bar = RegExp(\`^(?:\${foo})+$\`);
+            const foo2 = /(?:ac?|\\wb?)a/.source;
+            const bar = RegExp(\`^(?:\${foo2})+$\`);
             `,
             options: [
                 {
@@ -479,8 +482,8 @@ tester.run("no-dupe-disjunctions", rule as any, {
         {
             // reportExponentialBacktracking: 'certain'
             code: `
-            const foo = /(?:ac?|\\wb?)a/.source;
-            const bar = RegExp(\`^(?:\${foo})+$\`);
+            const foo3 = /(?:ac?|\\wb?)a/.source;
+            const bar = RegExp(\`^(?:\${foo3})+$\`);
             `,
             options: [
                 {
@@ -524,7 +527,7 @@ tester.run("no-dupe-disjunctions", rule as any, {
         {
             // reportExponentialBacktracking: 'certain'
             code: String.raw`
-            const foo = /(?:ac?|\wb?)a/ // overlap exp.
+            const foo4 = /(?:ac?|\wb?)a/ // overlap exp.
             const bar = RegExp("^(?:(?:ac?|\\wb?)a)+$") // overlap exp backtracking
             `,
             options: [{ reportExponentialBacktracking: "certain" }],
@@ -583,21 +586,6 @@ tester.run("no-dupe-disjunctions", rule as any, {
                     message:
                         "Unexpected duplicate alternative. This alternative can be removed.",
                     line: 3,
-                },
-            ],
-        },
-        {
-            // reportPrefixSubset: 'certain', but report: "all"
-            code: `
-            const a = /a|aa/.source;
-            const b = RegExp(\`\\b(\${a})\\b\`);
-            `,
-            options: [{ report: "all", reportPrefixSubset: "certain" }],
-            errors: [
-                {
-                    message:
-                        "Unexpected useless alternative. This alternative is already covered by 'a' and can be removed.",
-                    line: 2,
                 },
             ],
         },

--- a/tests/lib/rules/no-dupe-disjunctions.ts
+++ b/tests/lib/rules/no-dupe-disjunctions.ts
@@ -29,12 +29,12 @@ tester.run("no-dupe-disjunctions", rule as any, {
         String.raw`/\d*\.\d+|\d+\.\d*/`,
         String.raw`/(?:\d*\.\d+|\d+\.\d*)_/`,
         {
-            // reportPrefixSubset: 'certain'
+            // reportUnreachable: 'certain'
             code: `
             const a = /a|aa/.source;
             const b = RegExp(\`\\b(\${a})\\b\`);
             `,
-            options: [{ report: "all", reportPrefixSubset: "certain" }],
+            options: [{ report: "all", reportUnreachable: "certain" }],
         },
     ],
     invalid: [
@@ -372,7 +372,7 @@ tester.run("no-dupe-disjunctions", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'.",
+                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity might cause exponential backtracking.",
                     line: 2,
                 },
                 {
@@ -392,7 +392,7 @@ tester.run("no-dupe-disjunctions", rule as any, {
             errors: [
                 {
                     message:
-                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'.",
+                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity might cause exponential backtracking.",
                     line: 2,
                 },
                 {
@@ -414,6 +414,11 @@ tester.run("no-dupe-disjunctions", rule as any, {
             errors: [
                 {
                     message:
+                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity might cause exponential backtracking.",
+                    line: 2,
+                },
+                {
+                    message:
                         "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity is likely to cause exponential backtracking.",
                     line: 3,
                 },
@@ -429,6 +434,56 @@ tester.run("no-dupe-disjunctions", rule as any, {
                 { report: "all", reportExponentialBacktracking: "certain" },
             ],
             errors: [
+                {
+                    message:
+                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity might cause exponential backtracking.",
+                    line: 2,
+                },
+                {
+                    message:
+                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity is likely to cause exponential backtracking.",
+                    line: 3,
+                },
+            ],
+        },
+        {
+            // reportExponentialBacktracking: 'certain'
+            code: `
+            const foo = /(?:ac?|\\wb?)a/.source;
+            const bar = RegExp(\`^(?:\${foo})+$\`);
+            `,
+            options: [
+                {
+                    report: "interesting",
+                    reportExponentialBacktracking: "certain",
+                },
+            ],
+            errors: [
+                {
+                    message:
+                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity is likely to cause exponential backtracking.",
+                    line: 3,
+                },
+            ],
+        },
+        {
+            // reportExponentialBacktracking: 'certain'
+            code: `
+            const foo = /(?:ac?|\\wb?)a/.source;
+            const bar = RegExp(\`^(?:\${foo})+$\`);
+            `,
+            options: [
+                {
+                    report: "interesting",
+                    reportExponentialBacktracking: "potential",
+                },
+            ],
+            errors: [
+                {
+                    message:
+                        "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity might cause exponential backtracking.",
+                    line: 2,
+                },
                 {
                     message:
                         "Unexpected overlap. This alternative overlaps with 'ac?'. The overlap is 'a'. This ambiguity is likely to cause exponential backtracking.",
@@ -481,12 +536,12 @@ tester.run("no-dupe-disjunctions", rule as any, {
             ],
         },
         {
-            // reportPrefixSubset: 'potential'
+            // reportUnreachable: 'potential'
             code: `
             const a = /a|aa/.source;
             const b = RegExp(\`\\b(\${a})\\b\`);
             `,
-            options: [{ report: "all", reportPrefixSubset: "potential" }],
+            options: [{ report: "all", reportUnreachable: "potential" }],
             errors: [
                 {
                     message:
@@ -496,7 +551,7 @@ tester.run("no-dupe-disjunctions", rule as any, {
             ],
         },
         {
-            // reportPrefixSubset: 'potential' (default)
+            // reportUnreachable: 'potential' (default)
             code: `
             const a = /a|aa/.source;
             const b = RegExp(\`\\b(\${a})\\b\`);
@@ -511,16 +566,16 @@ tester.run("no-dupe-disjunctions", rule as any, {
             ],
         },
         {
-            // reportPrefixSubset: 'certain'
+            // reportUnreachable: 'certain'
             code: `
             const a = /a|a/.source;
             const b = RegExp(\`\\b(\${a})\\b\`);
             `,
-            options: [{ report: "all", reportPrefixSubset: "certain" }],
+            options: [{ report: "all", reportUnreachable: "certain" }],
             errors: [
                 {
                     message:
-                        "Unexpected duplicate alternative. This alternative can be removed.",
+                        "Unexpected duplicate alternative. This alternative can be removed. This ambiguity might cause exponential backtracking.",
                     line: 2,
                 },
                 {


### PR DESCRIPTION
I made a few changes to #204.

Changes:

- Added more documentation. 

- Renamed `reportPrefixSubset` -> `reportUnreachable`. The reported alternatives are unreachable so let's call it that. The "prefix suffix" name is also correct but it's a lot more technical and difficult to understand for our users.

- `report: "all"` and `reportUnreachable: "certain"`: Your initial implementation before my comment "`report: "all"` should just report everything it finds" was better. My comment was wrong and I correct this here.

- I moved the logic that processes options and decides which cases are reported into two functions: `getFilterInfo` and `filterResults`. This separates how filtering is done from determining static properties of the analyses node (e.g. whether the node is under a star quantifier).