### PR TITLE
#204 dedupe fix

### DIFF
--- a/tests/lib/rules/no-dupe-disjunctions.ts
+++ b/tests/lib/rules/no-dupe-disjunctions.ts
@@ -589,5 +589,37 @@ tester.run("no-dupe-disjunctions", rule as any, {
                 },
             ],
         },
+        {
+            // don't overshadow potential exponential backtracking
+            code: `
+            const partial = /a?|a+/.source;
+            const whole = RegExp(\`^(?:\${partial})+$\`);
+            `,
+            options: [
+                {
+                    reportExponentialBacktracking: "potential",
+                    reportUnreachable: "potential",
+                },
+            ],
+            errors: [
+                {
+                    message:
+                        "Unexpected useless alternative. This alternative is already covered by 'a?' and can be removed.",
+                    line: 2,
+                    column: 33,
+                },
+                {
+                    message:
+                        "Unexpected overlap. This alternative overlaps with 'a?'. The overlap is 'a'. This ambiguity might cause exponential backtracking.",
+                    line: 2,
+                    column: 33,
+                },
+                {
+                    message:
+                        "Unexpected overlap. This alternative overlaps with 'a?'. The overlap is 'a'. This ambiguity is likely to cause exponential backtracking.",
+                    line: 3,
+                },
+            ],
+        },
     ],
 })


### PR DESCRIPTION
The result deduplication is an issue now. Example:

```js
var partial = /a?|a+/.source; // overlap between `a?` and `a+` is `a`
var whole = RegExp(`^(?:${partial})+$`);
```

Let's assume that all potential cases of exp backtracking and unreachable alternatives are configured to be reported. What actually gets reported here?

We will report the unreachable alternative `a+` for `partial` and exponential backtracking because of the overlap in `whole`. But we don't report the potential exp backtracking in `partial`! This is a problem because `whole` might not be in the same file as `partial`, so we might not be able to detect the exp backtracking in `whole`.

Even worse, not only do we not warn the user about the potential exp backtracking in `partial`, we even report a false positive instead. The user might even turn off this rule for the `partial` regex because of the false positive...

This problem only happens if a `PrefixSubset` result overshadows another result for the same alternative. The fix is to report one addition `Superset` or `Overlap` if the first reported result of a `PrefixSubset`.
