### PR TITLE
Add option to allow only partial use to the `allowTop` option of `regexp/no-useless-non-capturing-group` rule.

### DIFF
--- a/docs/rules/no-useless-non-capturing-group.md
+++ b/docs/rules/no-useless-non-capturing-group.md
@@ -21,15 +21,15 @@ This rule reports unnecessary non-capturing group
 /* eslint regexp/no-useless-non-capturing-group: "error" */
 
 /* ✓ GOOD */
-var foo = /(?:abcd)?/
-var foo = /a(?:ab|cd)/
+var foo = /(?:abcd)?/.test(str)
+var foo = /a(?:ab|cd)/.test(str)
 
 /* ✗ BAD */
-var foo = /(?:ab|cd)/
-var foo = /(?:abcd)/
-var foo = /(?:[a-d])/
-var foo = /(?:[a-d])|e/
-var foo = /(?:a|(?:b|c)|d)/
+var foo = /(?:ab|cd)/.test(str)
+var foo = /(?:abcd)/.test(str)
+var foo = /(?:[a-d])/.test(str)
+var foo = /(?:[a-d])|e/.test(str)
+var foo = /(?:a|(?:b|c)|d)/.test(str)
 ```
 
 </eslint-code-block>
@@ -57,11 +57,15 @@ var foo = /(?:a|(?:b|c)|d)/
     /* eslint regexp/no-useless-non-capturing-group: ["error", { allowTop: "partial" }] */
 
     /* ✓ GOOD */
-    var foo = /(?:ab|cd)/
-    var bar = new RexExp(foo.source + 'e')
+    var foo = /(?:ab|cd)/;
+    var bar = /(?:ab|cd)/; // We still don't know how it will be used.
 
     /* ✗ BAD */
-    var baz = /(?:ab|cd)/
+    /(?:ab|cd)/.test(str);
+
+    /*-------*/
+    var baz = new RexExp(foo.source + 'e');
+    baz.test(str);
     ```
 
     </eslint-code-block>
@@ -75,14 +79,14 @@ var foo = /(?:a|(?:b|c)|d)/
     /* eslint regexp/no-useless-non-capturing-group: ["error", { allowTop: "always" }] */
 
     /* ✓ GOOD */
-    var foo = /(?:abcd)/
-    var foo = /(?:ab|cd)/
-    var foo = /(?:abcd)/
-    var foo = /(?:[a-d])/
+    var foo = /(?:abcd)/.test(str)
+    var foo = /(?:ab|cd)/.test(str)
+    var foo = /(?:abcd)/.test(str)
+    var foo = /(?:[a-d])/.test(str)
 
     /* ✗ BAD */
-    var foo = /(?:[a-d])|e/
-    var foo = /(?:a|(?:b|c)|d)/
+    var foo = /(?:[a-d])|e/.test(str)
+    var foo = /(?:a|(?:b|c)|d)/.test(str)
     ```
 
     </eslint-code-block>
@@ -96,10 +100,14 @@ var foo = /(?:a|(?:b|c)|d)/
     /* eslint regexp/no-useless-non-capturing-group: ["error", { allowTop: "never" }] */
 
     /* ✗ BAD */
-    var foo = /(?:ab|cd)/
-    var bar = new RexExp(foo.source + 'e')
+    var foo = /(?:ab|cd)/;
+    var bar = /(?:ab|cd)/;
 
-    var baz = /(?:ab|cd)/
+    /(?:ab|cd)/.test(str);
+
+    /*-------*/
+    var baz = new RexExp(foo.source + 'e');
+    baz.test(str);
     ```
 
     </eslint-code-block>

--- a/docs/rules/no-useless-non-capturing-group.md
+++ b/docs/rules/no-useless-non-capturing-group.md
@@ -39,33 +39,70 @@ var foo = /(?:a|(?:b|c)|d)/
 ```json5
 {
   "regexp/no-useless-non-capturing-group": ["error", {
-    "allowTop": true
+    "allowTop": "partial" // or "always" or "never"
   }]
 }
 ```
 
 - `"allowTop"`:
-  Whether a top-level non-capturing group is allowed. Defaults to `false`.
+  Whether a top-level non-capturing group is allowed. Defaults to `"partial"`.
 
   Sometimes it's useful to wrap a whole pattern into a non-capturing group (e.g. when the pattern is used as a building block to construct more complex patterns). Use this option to allow top-level non-capturing groups.
+  - `"partial"`:
+    Allows top-level non-capturing groups of patterns used as strings via `.source`.
 
-<eslint-code-block fix>
+    <eslint-code-block fix>
 
-```js
-/* eslint regexp/no-useless-non-capturing-group: ["error", { allowTop: true }] */
+    ```js
+    /* eslint regexp/no-useless-non-capturing-group: ["error", { allowTop: "partial" }] */
 
-/* ✓ GOOD */
-var foo = /(?:abcd)/
-var foo = /(?:ab|cd)/
-var foo = /(?:abcd)/
-var foo = /(?:[a-d])/
+    /* ✓ GOOD */
+    var foo = /(?:ab|cd)/
+    var bar = new RexExp(foo.source + 'e')
 
-/* ✗ BAD */
-var foo = /(?:[a-d])|e/
-var foo = /(?:a|(?:b|c)|d)/
-```
+    /* ✗ BAD */
+    var baz = /(?:ab|cd)/
+    ```
 
-</eslint-code-block>
+    </eslint-code-block>
+
+  - `"always"`:
+    Always allow top-level non-capturing groups.
+
+    <eslint-code-block fix>
+
+    ```js
+    /* eslint regexp/no-useless-non-capturing-group: ["error", { allowTop: "always" }] */
+
+    /* ✓ GOOD */
+    var foo = /(?:abcd)/
+    var foo = /(?:ab|cd)/
+    var foo = /(?:abcd)/
+    var foo = /(?:[a-d])/
+
+    /* ✗ BAD */
+    var foo = /(?:[a-d])|e/
+    var foo = /(?:a|(?:b|c)|d)/
+    ```
+
+    </eslint-code-block>
+
+  - `"never"`:
+    Never allow top-level non-capturing groups.
+
+    <eslint-code-block fix>
+
+    ```js
+    /* eslint regexp/no-useless-non-capturing-group: ["error", { allowTop: "never" }] */
+
+    /* ✗ BAD */
+    var foo = /(?:ab|cd)/
+    var bar = new RexExp(foo.source + 'e')
+
+    var baz = /(?:ab|cd)/
+    ```
+
+    </eslint-code-block>
 
 ## :rocket: Version
 

--- a/lib/rules/no-useless-non-capturing-group.ts
+++ b/lib/rules/no-useless-non-capturing-group.ts
@@ -72,27 +72,24 @@ export default createRule("no-useless-non-capturing-group", {
             fixReplaceNode,
             getUsageOfPattern,
         }: RegExpContext): RegExpVisitor.Handlers {
-            let isIgnore: (gNode: Group) => boolean
+            let isIgnored: (gNode: Group) => boolean
             if (allowTop === "always") {
-                isIgnore = isTopLevel
+                isIgnored = isTopLevel
             } else if (allowTop === "partial") {
                 const usageOfPattern = getUsageOfPattern()
-                if (
-                    usageOfPattern === UsageOfPattern.partial ||
-                    usageOfPattern === UsageOfPattern.mixed
-                ) {
-                    isIgnore = isTopLevel
+                if (usageOfPattern !== UsageOfPattern.whole) {
+                    isIgnored = isTopLevel
                 } else {
-                    isIgnore = () => false
+                    isIgnored = () => false
                 }
             } else {
                 // allowTop === "never"
-                isIgnore = () => false
+                isIgnored = () => false
             }
 
             return {
                 onGroupEnter(gNode) {
-                    if (isIgnore(gNode)) {
+                    if (isIgnored(gNode)) {
                         return
                     }
 

--- a/lib/rules/no-useless-non-capturing-group.ts
+++ b/lib/rules/no-useless-non-capturing-group.ts
@@ -76,8 +76,7 @@ export default createRule("no-useless-non-capturing-group", {
             if (allowTop === "always") {
                 isIgnored = isTopLevel
             } else if (allowTop === "partial") {
-                const usageOfPattern = getUsageOfPattern()
-                if (usageOfPattern !== UsageOfPattern.whole) {
+                if (getUsageOfPattern() !== UsageOfPattern.whole) {
                     isIgnored = isTopLevel
                 } else {
                     isIgnored = () => false
@@ -128,7 +127,18 @@ export default createRule("no-useless-non-capturing-group", {
                         node,
                         loc: getRegexpLocation(gNode),
                         messageId: "unexpected",
-                        fix: fixReplaceNode(gNode, gNode.raw.slice(3, -1)),
+                        fix: fixReplaceNode(gNode, () => {
+                            if (
+                                allowTop === "never" &&
+                                isTopLevel(gNode) &&
+                                getUsageOfPattern() !== UsageOfPattern.whole
+                            ) {
+                                // Top-level group and potentially partially used patterns
+                                // do not autofix because they can cause side effects.
+                                return null
+                            }
+                            return gNode.raw.slice(3, -1)
+                        }),
                     })
                 },
             }

--- a/tests/lib/rules/no-useless-non-capturing-group.ts
+++ b/tests/lib/rules/no-useless-non-capturing-group.ts
@@ -16,6 +16,34 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             code: `/(?:a|b)/`,
             options: [{ allowTop: true }],
         },
+        {
+            code: `/(?:a|b)/`,
+            options: [{ allowTop: "always" }],
+        },
+        `
+        const foo = /(?:a|b)/
+        const bar = new RegExp(foo.source + 'c')
+        `,
+        {
+            code: `
+            const foo = /(?:a|b)/
+            const bar = new RegExp(foo.source + 'c')
+            `,
+            options: [{ allowTop: "partial" }],
+        },
+        `
+        const foo = /(?:a|b)/
+        const bar = new RegExp(foo.source + 'c')
+        foo.exec('a')
+        `,
+        {
+            code: `
+            const foo = /(?:a|b)/
+            const bar = new RegExp(foo.source + 'c')
+            foo.exec('a')
+            `,
+            options: [{ allowTop: "partial" }],
+        },
         String.raw`/()\1(?:0)/`,
         String.raw`/\1(?:0)/`,
         String.raw`/\0(?:1)/`,
@@ -167,6 +195,36 @@ tester.run("no-useless-non-capturing-group", rule as any, {
         {
             code: String(/a|(?:b|c)/),
             output: String(/a|b|c/),
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: String(/a|(?:b|c)/),
+            output: String(/a|b|c/),
+            options: [{ allowTop: "always" }],
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: `
+            const foo = /(?:a|b)/
+            const bar = new RegExp('(?:a|b)' + 'c')
+            `,
+            output: `
+            const foo = /a|b/
+            const bar = new RegExp('(?:a|b)' + 'c')
+            `,
+            options: [{ allowTop: "partial" }],
+            errors: ["Unexpected quantifier Non-capturing group."],
+        },
+        {
+            code: `
+            const foo = /(?:a|b)/
+            const bar = new RegExp(foo.source + 'c')
+            `,
+            output: `
+            const foo = /a|b/
+            const bar = new RegExp(foo.source + 'c')
+            `,
+            options: [{ allowTop: "never" }],
             errors: ["Unexpected quantifier Non-capturing group."],
         },
     ],

--- a/tests/lib/rules/no-useless-non-capturing-group.ts
+++ b/tests/lib/rules/no-useless-non-capturing-group.ts
@@ -10,8 +10,8 @@ const tester = new RuleTester({
 
 tester.run("no-useless-non-capturing-group", rule as any, {
     valid: [
-        `/(?:abcd)?/`,
-        `/(?:)/`,
+        `/(?:abcd)?/.test(str)`,
+        `/(?:)/.test(str)`,
         `/(?:a|b)/`, // UsageOfPattern.unknown
         {
             code: `/(?:a|b)/.test(str)`,
@@ -24,11 +24,15 @@ tester.run("no-useless-non-capturing-group", rule as any, {
         `
         const foo = /(?:a|b)/
         const bar = new RegExp(foo.source + 'c')
+        foo.test(str)
+        bar.test(str)
         `,
         {
             code: `
             const foo = /(?:a|b)/
             const bar = new RegExp(foo.source + 'c')
+            foo.test(str)
+            bar.test(str)
             `,
             options: [{ allowTop: "partial" }],
         },
@@ -36,41 +40,42 @@ tester.run("no-useless-non-capturing-group", rule as any, {
         const foo = /(?:a|b)/
         const bar = new RegExp(foo.source + 'c')
         foo.exec('a')
+        bar.exec('a')
         `,
         {
             code: `
             const foo = /(?:a|b)/
             const bar = new RegExp(foo.source + 'c')
             foo.exec('a')
+            bar.exec('a')
             `,
             options: [{ allowTop: "partial" }],
         },
-        String.raw`/()\1(?:0)/`,
-        String.raw`/\1(?:0)/`,
-        String.raw`/\0(?:1)/`,
-        String.raw`/(\d)(?=(?:\d{3})+(?!\d))/g`,
+        String.raw`/()\1(?:0)/.test(str)`,
+        String.raw`/\1(?:0)/.test(str)`,
+        String.raw`/\0(?:1)/.test(str)`,
+        String.raw`/(\d)(?=(?:\d{3})+(?!\d))/g.test(str)`,
 
-        String(/(?:a{2})+/),
-        String(/{(?:2)}/),
-        String(/{(?:2,)}/),
-        String(/{(?:2,5)}/),
-        String(/{2,(?:5)}/),
-        String(/a{(?:5})/),
-        String(/\u{(?:41)}/),
-        String(/(.)\1(?:2\s)/),
-        String(/\0(?:2)/),
-        String(/\x4(?:1)*/),
-        String(/\x4(?:1)/),
-        String(/(?:\x4)1/),
-        String(/\x(?:4)1/),
-        String(/\x(?:41\w+)/),
-        String(/\u004(?:1)/),
-        String(/\u00(?:4)1/),
-        String(/\u0(?:0)41/),
-        String(/\u(?:0)041/),
-        String(/\c(?:A)/),
-        String(/(?:)/),
-        String(/(?:a|b)c/),
+        `/(?:a{2})+/.test(str)`,
+        `/{(?:2)}/.test(str)`,
+        `/{(?:2,)}/.test(str)`,
+        `/{(?:2,5)}/.test(str)`,
+        `/{2,(?:5)}/.test(str)`,
+        `/a{(?:5})/.test(str)`,
+        `/\\u{(?:41)}/.test(str)`,
+        String.raw`/(.)\1(?:2\s)/.test(str)`,
+        String.raw`/\0(?:2)/.test(str)`,
+        `/\\x4(?:1)*/.test(str)`,
+        `/\\x4(?:1)/.test(str)`,
+        `/(?:\\x4)1/.test(str)`,
+        `/\\x(?:4)1/.test(str)`,
+        `/\\x(?:41\\w+)/.test(str)`,
+        `/\\u004(?:1)/.test(str)`,
+        `/\\u00(?:4)1/.test(str)`,
+        `/\\u0(?:0)41/.test(str)`,
+        `/\\u(?:0)041/.test(str)`,
+        String.raw`/\c(?:A)/.test(str)`,
+        `/(?:a|b)c/.test(str)`,
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-useless-non-capturing-group.ts
+++ b/tests/lib/rules/no-useless-non-capturing-group.ts
@@ -126,9 +126,8 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             ],
         },
         {
-            code: String.raw`/(?:0)/; /\1(?:0)/; /(?:1)/; /\1(?:1)/`,
-            output: String.raw`/0/; /\1(?:0)/; /1/; /\1(?:1)/`,
-            options: [{ allowTop: "never" }],
+            code: String.raw`/(?:0)/.test(str); /\1(?:0)/.test(str); /(?:1)/.test(str); /\1(?:1)/.test(str)`,
+            output: String.raw`/0/.test(str); /\1(?:0)/.test(str); /1/.test(str); /\1(?:1)/.test(str)`,
             errors: [
                 {
                     message: "Unexpected quantifier Non-capturing group.",
@@ -138,7 +137,7 @@ tester.run("no-useless-non-capturing-group", rule as any, {
                 {
                     message: "Unexpected quantifier Non-capturing group.",
                     line: 1,
-                    column: 22,
+                    column: 42,
                 },
             ],
         },
@@ -236,13 +235,7 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             bar.exec(str)
             // { allowTop: "never" }
             `,
-            output: `
-            const foo = /a|b/
-            const bar = new RegExp(foo.source + 'c')
-            foo.exec(str)
-            bar.exec(str)
-            // { allowTop: "never" }
-            `,
+            output: null,
             options: [{ allowTop: "never" }],
             errors: ["Unexpected quantifier Non-capturing group."],
         },

--- a/tests/lib/rules/no-useless-non-capturing-group.ts
+++ b/tests/lib/rules/no-useless-non-capturing-group.ts
@@ -12,12 +12,13 @@ tester.run("no-useless-non-capturing-group", rule as any, {
     valid: [
         `/(?:abcd)?/`,
         `/(?:)/`,
+        `/(?:a|b)/`, // UsageOfPattern.unknown
         {
-            code: `/(?:a|b)/`,
-            options: [{ allowTop: true }],
+            code: `/(?:a|b)/.test(str)`,
+            options: [{ allowTop: true }], // backward compatibility
         },
         {
-            code: `/(?:a|b)/`,
+            code: `/(?:a|b)/.test(str)`,
             options: [{ allowTop: "always" }],
         },
         `
@@ -73,8 +74,8 @@ tester.run("no-useless-non-capturing-group", rule as any, {
     ],
     invalid: [
         {
-            code: `/(?:abcd)/`,
-            output: `/abcd/`,
+            code: `/(?:abcd)/.test(str)`,
+            output: `/abcd/.test(str)`,
             errors: [
                 {
                     message: "Unexpected quantifier Non-capturing group.",
@@ -86,8 +87,8 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             ],
         },
         {
-            code: `/(?:[abcd])/`,
-            output: `/[abcd]/`,
+            code: `/(?:[abcd])/.test(str)`,
+            output: `/[abcd]/.test(str)`,
             errors: [
                 {
                     message: "Unexpected quantifier Non-capturing group.",
@@ -99,8 +100,8 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             ],
         },
         {
-            code: `/(?:ab|cd)/`,
-            output: `/ab|cd/`,
+            code: `/(?:ab|cd)/.test(str)`,
+            output: `/ab|cd/.test(str)`,
             errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
@@ -109,8 +110,8 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
-            code: `/(?:[abcd]+?)/`,
-            output: `/[abcd]+?/`,
+            code: `/(?:[abcd]+?)/.test(str)`,
+            output: `/[abcd]+?/.test(str)`,
             errors: [
                 {
                     message: "Unexpected quantifier Non-capturing group.",
@@ -122,6 +123,7 @@ tester.run("no-useless-non-capturing-group", rule as any, {
         {
             code: String.raw`/(?:0)/; /\1(?:0)/; /(?:1)/; /\1(?:1)/`,
             output: String.raw`/0/; /\1(?:0)/; /1/; /\1(?:1)/`,
+            options: [{ allowTop: "never" }],
             errors: [
                 {
                     message: "Unexpected quantifier Non-capturing group.",
@@ -136,30 +138,30 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             ],
         },
         {
-            code: String.raw`/(?:a\n)/`,
-            output: String.raw`/a\n/`,
+            code: String.raw`/(?:a\n)/.test(str)`,
+            output: String.raw`/a\n/.test(str)`,
             errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
             code: String.raw`
             const s = "(?:a\\n)"
-            new RegExp(s)`,
+            ;(new RegExp(s)).test(str)`,
             output: String.raw`
             const s = "a\\n"
-            new RegExp(s)`,
+            ;(new RegExp(s)).test(str)`,
             errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
             code: String.raw`
             const s = "(?:a"+"\\n)"
-            new RegExp(s)`,
+            ;(new RegExp(s)).test(str)`,
             output: null,
             errors: ["Unexpected quantifier Non-capturing group."],
         },
 
         {
-            code: String(/(?:a)/),
-            output: String(/a/),
+            code: `/(?:a)/.test(str)`,
+            output: `/a/.test(str)`,
             errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
@@ -168,8 +170,8 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
-            code: String(/(?:\w)/),
-            output: String(/\w/),
+            code: String.raw`/(?:\w)/.test(str)`,
+            output: String.raw`/\w/.test(str)`,
             errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
@@ -188,8 +190,8 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
-            code: String(/(?:a|b)/),
-            output: String(/a|b/),
+            code: `/(?:a|b)/.test(str)`,
+            output: `/a|b/.test(str)`,
             errors: ["Unexpected quantifier Non-capturing group."],
         },
         {
@@ -207,10 +209,16 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             code: `
             const foo = /(?:a|b)/
             const bar = new RegExp('(?:a|b)' + 'c')
+            foo.exec(str)
+            bar.exec(str)
+            // { allowTop: "partial" }
             `,
             output: `
             const foo = /a|b/
             const bar = new RegExp('(?:a|b)' + 'c')
+            foo.exec(str)
+            bar.exec(str)
+            // { allowTop: "partial" }
             `,
             options: [{ allowTop: "partial" }],
             errors: ["Unexpected quantifier Non-capturing group."],
@@ -219,10 +227,16 @@ tester.run("no-useless-non-capturing-group", rule as any, {
             code: `
             const foo = /(?:a|b)/
             const bar = new RegExp(foo.source + 'c')
+            foo.exec(str)
+            bar.exec(str)
+            // { allowTop: "never" }
             `,
             output: `
             const foo = /a|b/
             const bar = new RegExp(foo.source + 'c')
+            foo.exec(str)
+            bar.exec(str)
+            // { allowTop: "never" }
             `,
             options: [{ allowTop: "never" }],
             errors: ["Unexpected quantifier Non-capturing group."],


### PR DESCRIPTION
Related to https://github.com/ota-meshi/eslint-plugin-regexp/issues/181#issuecomment-838271791.