### PR TITLE
Add `ignorePartial` option to `regexp/no-lazy-ends` rule

### DIFF
--- a/docs/rules/no-lazy-ends.md
+++ b/docs/rules/no-lazy-ends.md
@@ -47,7 +47,64 @@ var foo = /a(?:c|ab+?)?/
 
 ## :wrench: Options
 
-Nothing.
+```json5
+{
+  "regexp/no-lazy-ends": [
+    "error",
+    {
+      "ignorePartial": true,
+    }
+  ]
+}
+```
+
+- `ignorePartial`:
+
+  Some regexes are used as fragments to build more complex regexes. Example:
+
+  ```js
+  const any = /[\s\S]*?/.source;
+  const pattern = RegExp(`<script(\\s${any})?>(${any})<\\/script>`, "g");
+  ```
+
+  In these fragments, seemingly ignored quantifier might not actually be ignored depending on how the fragment is used.
+
+  - `true`:
+    The rule does not check the regexp used as a fragment. This is default.
+
+    <eslint-code-block>
+
+    ```js
+    /* eslint regexp/no-lazy-ends: ["error", { ignorePartial: true }] */
+
+    /* ✓ GOOD */
+    const any = /[\s\S]*?/.source;
+    const pattern = RegExp(`<script(\\s${any})?>(${any})<\\/script>`, "g");
+
+    /* ✗ BAD */
+    const foo = /[\s\S]*?/
+    foo.exec(str)
+    ```
+
+    </eslint-code-block>
+
+  - `false`:
+    This rule checks all regular expressions, including those used as fragments.
+
+    <eslint-code-block>
+
+    ```js
+    /* eslint regexp/no-lazy-ends: ["error", { ignorePartial: false }] */
+
+    /* ✗ BAD */
+    const any = /[\s\S]*?/.source;
+    const pattern = RegExp(`<script(\\s${any})?>(${any})<\\/script>`, "g");
+
+    const foo = /[\s\S]*?/
+    foo.exec(str)
+    ```
+
+    </eslint-code-block>
 
 ## :heart: Compatibility
 

--- a/docs/rules/no-lazy-ends.md
+++ b/docs/rules/no-lazy-ends.md
@@ -33,14 +33,14 @@ greedy quantifier. E.g. `a+b{2,4}?` and `a+b{2}` behave the same.
 /* eslint regexp/no-lazy-ends: "error" */
 
 /* ✓ GOOD */
-var foo = /a+?b*/
-var foo = /a??(?:ba+?|c)*/
-var foo = /ba*?$/
+var foo = /a+?b*/.test(str)
+var foo = /a??(?:ba+?|c)*/.test(str)
+var foo = /ba*?$/.test(str)
 
 /* ✗ BAD */
-var foo = /a??/
-var foo = /a+b+?/
-var foo = /a(?:c|ab+?)?/
+var foo = /a??/.test(str)
+var foo = /a+b+?/.test(str)
+var foo = /a(?:c|ab+?)?/.test(str)
 ```
 
 </eslint-code-block>

--- a/lib/rules/no-lazy-ends.ts
+++ b/lib/rules/no-lazy-ends.ts
@@ -85,10 +85,7 @@ export default createRule("no-lazy-ends", {
         }: RegExpContext): RegExpVisitor.Handlers {
             if (ignorePartial) {
                 const usageOfPattern = getUsageOfPattern()
-                if (
-                    usageOfPattern === UsageOfPattern.partial ||
-                    usageOfPattern === UsageOfPattern.mixed
-                ) {
+                if (usageOfPattern !== UsageOfPattern.whole) {
                     // ignore
                     return {}
                 }

--- a/tests/lib/rules/no-lazy-ends.ts
+++ b/tests/lib/rules/no-lazy-ends.ts
@@ -95,5 +95,69 @@ tester.run("no-lazy-ends", rule as any, {
                 },
             ],
         },
+        {
+            code: `
+            /* ✓ GOOD */
+            const any = /[\\s\\S]*?/.source;
+            const pattern = RegExp(\`<script(\\\\s\${any})?>(\${any})<\\/script>\`, "g");
+
+            /* ✗ BAD */
+            const foo = /[\\s\\S]*?/
+            foo.exec(str)
+            `,
+            errors: [
+                {
+                    message:
+                        "The quantifier and the quantified element can be removed because the quantifier is lazy and has a minimum of 0.",
+                    line: 7,
+                    column: 26,
+                },
+            ],
+        },
+        {
+            code: `
+            /* ✓ GOOD */
+            const any = /[\\s\\S]*?/.source;
+            const pattern = RegExp(\`<script(\\\\s\${any})?>(\${any})<\\/script>\`, "g");
+
+            /* ✗ BAD */
+            const foo = /[\\s\\S]*?/
+            foo.exec(str)
+            `,
+            options: [{ ignorePartial: true }],
+            errors: [
+                {
+                    message:
+                        "The quantifier and the quantified element can be removed because the quantifier is lazy and has a minimum of 0.",
+                    line: 7,
+                    column: 26,
+                },
+            ],
+        },
+        {
+            code: `
+            /* ✗ BAD */
+            const any = /[\\s\\S]*?/.source;
+            const pattern = RegExp(\`<script(\\\\s\${any})?>(\${any})<\\/script>\`, "g");
+
+            const foo = /[\\s\\S]*?/
+            foo.exec(str)
+            `,
+            options: [{ ignorePartial: false }],
+            errors: [
+                {
+                    message:
+                        "The quantifier and the quantified element can be removed because the quantifier is lazy and has a minimum of 0.",
+                    line: 3,
+                    column: 26,
+                },
+                {
+                    message:
+                        "The quantifier and the quantified element can be removed because the quantifier is lazy and has a minimum of 0.",
+                    line: 6,
+                    column: 26,
+                },
+            ],
+        },
     ],
 })

--- a/tests/lib/rules/no-lazy-ends.ts
+++ b/tests/lib/rules/no-lazy-ends.ts
@@ -10,15 +10,16 @@ const tester = new RuleTester({
 
 tester.run("no-lazy-ends", rule as any, {
     valid: [
-        `/a+?b*/`,
-        `/a??(?:ba+?|c)*/`,
-        `/ba*?$/`,
+        `/a+?b*/.test(str)`,
+        `/a??(?:ba+?|c)*/.test(str)`,
+        `/ba*?$/.test(str)`,
+        `/a??/`, // UsageOfPattern.unknown
 
-        `/a{3}?/`, // uselessly lazy but that's not for this rule to correct
+        `/a{3}?/.test(str)`, // uselessly lazy but that's not for this rule to correct
     ],
     invalid: [
         {
-            code: `/a??/`,
+            code: `/a??/.test(str)`,
             errors: [
                 {
                     message:
@@ -29,7 +30,7 @@ tester.run("no-lazy-ends", rule as any, {
             ],
         },
         {
-            code: `/a*?/`,
+            code: `/a*?/.test(str)`,
             errors: [
                 {
                     message:
@@ -40,7 +41,7 @@ tester.run("no-lazy-ends", rule as any, {
             ],
         },
         {
-            code: `/a+?/`,
+            code: `/a+?/.test(str)`,
             errors: [
                 {
                     message:
@@ -51,7 +52,7 @@ tester.run("no-lazy-ends", rule as any, {
             ],
         },
         {
-            code: `/a{3,7}?/`,
+            code: `/a{3,7}?/.test(str)`,
             errors: [
                 {
                     message:
@@ -62,7 +63,7 @@ tester.run("no-lazy-ends", rule as any, {
             ],
         },
         {
-            code: `/a{3,}?/`,
+            code: `/a{3,}?/.test(str)`,
             errors: [
                 {
                     message:
@@ -74,7 +75,7 @@ tester.run("no-lazy-ends", rule as any, {
         },
 
         {
-            code: `/(?:a|b(c+?))/`,
+            code: `/(?:a|b(c+?))/.test(str)`,
             errors: [
                 {
                     message:
@@ -85,7 +86,7 @@ tester.run("no-lazy-ends", rule as any, {
             ],
         },
         {
-            code: `/a(?:c|ab+?)?/`,
+            code: `/a(?:c|ab+?)?/.test(str)`,
             errors: [
                 {
                     message:


### PR DESCRIPTION
This PR adds an `ignorePartial` option to the `regexp/no-lazy-ends` rule.

If user specify `true` for the `ignorePartial` option, the rule ignores regular expressions that are partially used as fragments.

Related to #181.

