### PR TITLE
Fixed `prefer-range` for adjacent bot not-allowed ranges

### DIFF
--- a/lib/rules/prefer-range.ts
+++ b/lib/rules/prefer-range.ts
@@ -103,11 +103,25 @@ export default createRule("prefer-range", {
                         } else {
                             continue
                         }
-                        const group = groups.find(
-                            (gp) =>
+
+                        const group = groups.find((gp) => {
+                            const adjacent =
                                 gp.min.value - 1 <= data.max.value &&
-                                data.min.value <= gp.max.value + 1,
-                        )
+                                data.min.value <= gp.max.value + 1
+
+                            if (!adjacent) {
+                                // the ranges have to be adjacent
+                                return false
+                            }
+
+                            // the bounds of the union of the two ranges
+                            const min = Math.min(gp.min.value, data.min.value)
+                            const max = Math.max(gp.max.value, data.max.value)
+
+                            // the union has to be an allowed range as well
+                            return inRange(allowedRanges, min, max)
+                        })
+
                         if (group) {
                             if (data.min.value < group.min.value) {
                                 group.min = data.min

--- a/tests/lib/rules/prefer-range.ts
+++ b/tests/lib/rules/prefer-range.ts
@@ -51,6 +51,11 @@ tester.run("prefer-range", rule as any, {
             code: `/[0123456789 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ]/`,
             options: [{ target: ["😀-😏"] }],
         },
+        {
+            // issue #218
+            code: `/[а-яА-Я][А-Яа-я]/`,
+            options: [{ target: ["alphanumeric", "а-я", "А-Я"] }],
+        },
     ],
     invalid: [
         {
@@ -91,6 +96,20 @@ tester.run("prefer-range", rule as any, {
         },
         {
             code: `/[a-cd-f]/`,
+            output: `/[a-f]/`,
+            errors: [
+                {
+                    message:
+                        "Unexpected multiple adjacent characters. Use 'a-f' instead.",
+                    line: 1,
+                    column: 3,
+                    endLine: 1,
+                    endColumn: 9,
+                },
+            ],
+        },
+        {
+            code: `/[d-fa-c]/`,
             output: `/[a-f]/`,
             errors: [
                 {


### PR DESCRIPTION
This fixes #218.