### PR TITLE
Add `regexp/no-empty-capturing-group` rule that same `regexp/no-assertion-capturing-group` rule 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
-| [regexp/no-assertion-capturing-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-assertion-capturing-group.html) | disallow capturing group that captures assertions. | :star: |
+| [regexp/no-assertion-capturing-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-assertion-capturing-group.html) | disallow capturing group that captures empty. | :star: |
 | [regexp/no-dupe-disjunctions](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-dupe-disjunctions.html) | disallow duplicate disjunctions |  |
 | [regexp/no-empty-alternative](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-alternative.html) | disallow alternatives without elements |  |
+| [regexp/no-empty-capturing-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-capturing-group.html) | disallow capturing group that captures empty. |  |
 | [regexp/no-empty-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-group.html) | disallow empty group | :star: |
 | [regexp/no-empty-lookarounds-assertion](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-lookarounds-assertion.html) | disallow empty lookahead assertion or empty lookbehind assertion | :star: |
 | [regexp/no-escape-backspace](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-escape-backspace.html) | disallow escape backspace (`[\b]`) | :star: |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -13,9 +13,10 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
-| [regexp/no-assertion-capturing-group](./no-assertion-capturing-group.md) | disallow capturing group that captures assertions. | :star: |
+| [regexp/no-assertion-capturing-group](./no-assertion-capturing-group.md) | disallow capturing group that captures empty. | :star: |
 | [regexp/no-dupe-disjunctions](./no-dupe-disjunctions.md) | disallow duplicate disjunctions |  |
 | [regexp/no-empty-alternative](./no-empty-alternative.md) | disallow alternatives without elements |  |
+| [regexp/no-empty-capturing-group](./no-empty-capturing-group.md) | disallow capturing group that captures empty. |  |
 | [regexp/no-empty-group](./no-empty-group.md) | disallow empty group | :star: |
 | [regexp/no-empty-lookarounds-assertion](./no-empty-lookarounds-assertion.md) | disallow empty lookahead assertion or empty lookbehind assertion | :star: |
 | [regexp/no-escape-backspace](./no-escape-backspace.md) | disallow escape backspace (`[\b]`) | :star: |

--- a/docs/rules/no-assertion-capturing-group.md
+++ b/docs/rules/no-assertion-capturing-group.md
@@ -2,42 +2,21 @@
 pageClass: "rule-details"
 sidebarDepth: 0
 title: "regexp/no-assertion-capturing-group"
-description: "disallow capturing group that captures assertions."
+description: "disallow capturing group that captures empty."
 since: "v0.1.0"
 ---
 # regexp/no-assertion-capturing-group
 
-> disallow capturing group that captures assertions.
+> disallow capturing group that captures empty.
 
 - :gear: This rule is included in `"plugin:regexp/recommended"`.
 
 ## :book: Rule Details
 
-This rule reports capturing group that captures assertions.
+This rule is the same as the [regexp/no-empty-capturing-group] rule. Use [regexp/no-empty-capturing-group] instead.
+Replaced by [regexp/no-empty-capturing-group] in v1.0.0, this rule will be marked as **deprecated**.
 
-<eslint-code-block>
-
-```js
-/* eslint regexp/no-assertion-capturing-group: "error" */
-
-/* ✓ GOOD */
-var foo = /(a)/;
-var foo = /a(?:\b)/;
-var foo = /a(?:$)/;
-var foo = /(?:^)a/;
-var foo = /(?:^|b)a/;
-
-/* ✗ BAD */
-var foo = /a(\b)/;
-var foo = /a($)/;
-var foo = /(^)a/;
-```
-
-</eslint-code-block>
-
-## :wrench: Options
-
-Nothing.
+[regexp/no-empty-capturing-group]: no-empty-capturing-group.md
 
 ## :rocket: Version
 

--- a/docs/rules/no-empty-capturing-group.md
+++ b/docs/rules/no-empty-capturing-group.md
@@ -1,0 +1,44 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "regexp/no-empty-capturing-group"
+description: "disallow capturing group that captures empty."
+---
+# regexp/no-empty-capturing-group
+
+> disallow capturing group that captures empty.
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+
+## :book: Rule Details
+
+This rule reports capturing group that captures assertions.
+
+<eslint-code-block>
+
+```js
+/* eslint regexp/no-empty-capturing-group: "error" */
+
+/* ✓ GOOD */
+var foo = /(a)/;
+var foo = /a(?:\b)/;
+var foo = /a(?:$)/;
+var foo = /(?:^)a/;
+var foo = /(?:^|b)a/;
+
+/* ✗ BAD */
+var foo = /a(\b)/;
+var foo = /a($)/;
+var foo = /(^)a/;
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/lib/rules/no-empty-capturing-group.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/tests/lib/rules/no-empty-capturing-group.ts)

--- a/lib/rules/no-assertion-capturing-group.ts
+++ b/lib/rules/no-assertion-capturing-group.ts
@@ -1,44 +1,21 @@
-import { isZeroLength } from "regexp-ast-analysis"
-import type { RegExpVisitor } from "regexpp/visitor"
-import type { RegExpContext } from "../utils"
-import { createRule, defineRegexpVisitor } from "../utils"
+import { createRule } from "../utils"
+
+import noEmptyCapturingGroup from "./no-empty-capturing-group"
 
 export default createRule("no-assertion-capturing-group", {
     meta: {
+        ...noEmptyCapturingGroup.meta,
         docs: {
-            description: "disallow capturing group that captures assertions.",
-            category: "Possible Errors",
+            ...noEmptyCapturingGroup.meta.docs,
+            // TODO Switch to recommended in the major version.
+            // recommended: false,
             recommended: true,
+            replacedBy: ["no-empty-capturing-group"],
         },
-        schema: [],
-        messages: {
-            unexpected: "Unexpected capture assertions.",
-        },
-        type: "suggestion",
+        // TODO Switch to deprecated in the major version.
+        // deprecated: true,
     },
     create(context) {
-        /**
-         * Create visitor
-         */
-        function createVisitor({
-            node,
-            getRegexpLocation,
-        }: RegExpContext): RegExpVisitor.Handlers {
-            return {
-                onCapturingGroupEnter(cgNode) {
-                    if (isZeroLength(cgNode)) {
-                        context.report({
-                            node,
-                            loc: getRegexpLocation(cgNode),
-                            messageId: "unexpected",
-                        })
-                    }
-                },
-            }
-        }
-
-        return defineRegexpVisitor(context, {
-            createVisitor,
-        })
+        return noEmptyCapturingGroup.create(context)
     },
 })

--- a/lib/rules/no-empty-capturing-group.ts
+++ b/lib/rules/no-empty-capturing-group.ts
@@ -1,0 +1,46 @@
+import { isZeroLength } from "regexp-ast-analysis"
+import type { RegExpVisitor } from "regexpp/visitor"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
+
+export default createRule("no-empty-capturing-group", {
+    meta: {
+        docs: {
+            description: "disallow capturing group that captures empty.",
+            category: "Possible Errors",
+            // TODO Switch to recommended in the major version.
+            // recommended: true,
+            recommended: false,
+        },
+        schema: [],
+        messages: {
+            unexpected: "Unexpected capture empty.",
+        },
+        type: "suggestion",
+    },
+    create(context) {
+        /**
+         * Create visitor
+         */
+        function createVisitor({
+            node,
+            getRegexpLocation,
+        }: RegExpContext): RegExpVisitor.Handlers {
+            return {
+                onCapturingGroupEnter(cgNode) {
+                    if (isZeroLength(cgNode)) {
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(cgNode),
+                            messageId: "unexpected",
+                        })
+                    }
+                },
+            }
+        }
+
+        return defineRegexpVisitor(context, {
+            createVisitor,
+        })
+    },
+})

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -9,6 +9,7 @@ import noAssertionCapturingGroup from "../rules/no-assertion-capturing-group"
 import noDupeCharactersCharacterClass from "../rules/no-dupe-characters-character-class"
 import noDupeDisjunctions from "../rules/no-dupe-disjunctions"
 import noEmptyAlternative from "../rules/no-empty-alternative"
+import noEmptyCapturingGroup from "../rules/no-empty-capturing-group"
 import noEmptyGroup from "../rules/no-empty-group"
 import noEmptyLookaroundsAssertion from "../rules/no-empty-lookarounds-assertion"
 import noEscapeBackspace from "../rules/no-escape-backspace"
@@ -70,6 +71,7 @@ export const rules = [
     noDupeCharactersCharacterClass,
     noDupeDisjunctions,
     noEmptyAlternative,
+    noEmptyCapturingGroup,
     noEmptyGroup,
     noEmptyLookaroundsAssertion,
     noEscapeBackspace,

--- a/tests/lib/rules/no-assertion-capturing-group.ts
+++ b/tests/lib/rules/no-assertion-capturing-group.ts
@@ -9,51 +9,11 @@ const tester = new RuleTester({
 })
 
 tester.run("no-assertion-capturing-group", rule as any, {
-    valid: ["/(a)/", "/a(\\bb)/", "/a(\\b|b)/"],
+    valid: ["/(a)/"],
     invalid: [
         {
-            code: "/a(\\b)/",
-            errors: [
-                {
-                    message: "Unexpected capture assertions.",
-                    column: 3,
-                    endColumn: 7,
-                },
-            ],
-        },
-        {
-            code: "/a($)/",
-            errors: [
-                {
-                    message: "Unexpected capture assertions.",
-                    column: 3,
-                    endColumn: 6,
-                },
-            ],
-        },
-        {
-            code: "/(^)a/",
-            errors: [
-                {
-                    message: "Unexpected capture assertions.",
-                    column: 2,
-                    endColumn: 5,
-                },
-            ],
-        },
-        {
-            code: "/()a/",
-            errors: [
-                {
-                    message: "Unexpected capture assertions.",
-                    column: 2,
-                    endColumn: 4,
-                },
-            ],
-        },
-        {
-            code: "/(\\b\\b|(?:\\B|$))a/",
-            errors: ["Unexpected capture assertions."],
+            code: String.raw`/(\b)a/`,
+            errors: ["Unexpected capture empty."],
         },
     ],
 })

--- a/tests/lib/rules/no-empty-capturing-group.ts
+++ b/tests/lib/rules/no-empty-capturing-group.ts
@@ -1,0 +1,59 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-empty-capturing-group"
+
+const tester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+})
+
+tester.run("no-empty-capturing-group", rule as any, {
+    valid: ["/(a)/", "/a(\\bb)/", "/a(\\b|b)/"],
+    invalid: [
+        {
+            code: "/a(\\b)/",
+            errors: [
+                {
+                    message: "Unexpected capture empty.",
+                    column: 3,
+                    endColumn: 7,
+                },
+            ],
+        },
+        {
+            code: "/a($)/",
+            errors: [
+                {
+                    message: "Unexpected capture empty.",
+                    column: 3,
+                    endColumn: 6,
+                },
+            ],
+        },
+        {
+            code: "/(^)a/",
+            errors: [
+                {
+                    message: "Unexpected capture empty.",
+                    column: 2,
+                    endColumn: 5,
+                },
+            ],
+        },
+        {
+            code: "/()a/",
+            errors: [
+                {
+                    message: "Unexpected capture empty.",
+                    column: 2,
+                    endColumn: 4,
+                },
+            ],
+        },
+        {
+            code: "/(\\b\\b|(?:\\B|$))a/",
+            errors: ["Unexpected capture empty."],
+        },
+    ],
+})


### PR DESCRIPTION
This PR adds the `regexp/no-empty-capturing-group` rule that has the same functionality as the `regexp/no-assertion-capturing-group` rule.

related to #194.
