### PR TITLE
Make `no-useless-escape` fixable

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/hexadecimal-escape](https://ota-meshi.github.io/eslint-plugin-regexp/rules/hexadecimal-escape.html) | enforce consistent usage of hexadecimal escape | :wrench: |
 | [regexp/letter-case](https://ota-meshi.github.io/eslint-plugin-regexp/rules/letter-case.html) | enforce into your favorite case | :wrench: |
 | [regexp/match-any](https://ota-meshi.github.io/eslint-plugin-regexp/rules/match-any.html) | enforce match any character style | :star::wrench: |
-| [regexp/no-useless-escape](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-escape.html) | disallow unnecessary escape characters in RegExp |  |
+| [regexp/no-useless-escape](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-escape.html) | disallow unnecessary escape characters in RegExp | :wrench: |
 | [regexp/no-useless-non-capturing-group](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-non-capturing-group.html) | disallow unnecessary Non-capturing group | :wrench: |
 | [regexp/order-in-character-class](https://ota-meshi.github.io/eslint-plugin-regexp/rules/order-in-character-class.html) | enforces elements order in character class | :wrench: |
 | [regexp/prefer-character-class](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-character-class.html) | enforce using character class | :wrench: |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -68,7 +68,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/hexadecimal-escape](./hexadecimal-escape.md) | enforce consistent usage of hexadecimal escape | :wrench: |
 | [regexp/letter-case](./letter-case.md) | enforce into your favorite case | :wrench: |
 | [regexp/match-any](./match-any.md) | enforce match any character style | :star::wrench: |
-| [regexp/no-useless-escape](./no-useless-escape.md) | disallow unnecessary escape characters in RegExp |  |
+| [regexp/no-useless-escape](./no-useless-escape.md) | disallow unnecessary escape characters in RegExp | :wrench: |
 | [regexp/no-useless-non-capturing-group](./no-useless-non-capturing-group.md) | disallow unnecessary Non-capturing group | :wrench: |
 | [regexp/order-in-character-class](./order-in-character-class.md) | enforces elements order in character class | :wrench: |
 | [regexp/prefer-character-class](./prefer-character-class.md) | enforce using character class | :wrench: |

--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -9,12 +9,14 @@ since: "v0.4.0"
 
 > disallow unnecessary escape characters in RegExp
 
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 ## :book: Rule Details
 
 This rule reports unnecessary escape characters in RegExp.  
 You may be able to find another mistake by finding unnecessary escapes.
 
-<eslint-code-block>
+<eslint-code-block fix>
 
 ```js
 /* eslint regexp/no-useless-escape: "error" */
@@ -34,7 +36,7 @@ var foo = /\u{[41]}/
 
 This rule checks for unnecessary escapes with deeper regular expression parsing than the ESLint core's [no-useless-escape] rule.
 
-<eslint-code-block>
+<eslint-code-block fix>
 
 ```js
 /* eslint no-useless-escape: "error" */

--- a/lib/rules/no-useless-escape.ts
+++ b/lib/rules/no-useless-escape.ts
@@ -46,7 +46,7 @@ const REGEX_ESCAPES = new Set([
     CP_CLOSING_PAREN, // )
 ])
 
-const POTENTIAL_ESCAPE_SEQUENCE = new Set("uxkpP".split(""))
+const POTENTIAL_ESCAPE_SEQUENCE = new Set("uxkpP")
 
 export default createRule("no-useless-escape", {
     meta: {

--- a/tests/lib/rules/no-useless-escape.ts
+++ b/tests/lib/rules/no-useless-escape.ts
@@ -69,6 +69,7 @@ tester.run("no-useless-escape", rule as any, {
     invalid: [
         {
             code: String.raw`/\a/`,
+            output: String.raw`/a/`,
             errors: [
                 {
                     message: "Unnecessary escape character: \\a.",
@@ -81,18 +82,22 @@ tester.run("no-useless-escape", rule as any, {
         },
         {
             code: `/\\x7/`,
+            output: null,
             errors: ["Unnecessary escape character: \\x."],
         },
         {
             code: `/\\u41/`,
+            output: null,
             errors: ["Unnecessary escape character: \\u."],
         },
         {
             code: `/\\u{[41]}/`,
+            output: null,
             errors: ["Unnecessary escape character: \\u."],
         },
         {
             code: String.raw`/[ \^ \/ \. \$ \* \+ \? \[ \{ \} \| \( \) \k<title> \B \8 \9]/`,
+            output: String.raw`/[ ^ / . $ * + ? [ { } | ( ) \k<title> B 8 9]/`,
             errors: [
                 "Unnecessary escape character: \\^.",
                 "Unnecessary escape character: \\/.",
@@ -115,6 +120,7 @@ tester.run("no-useless-escape", rule as any, {
         },
         {
             code: String.raw`/\p{ASCII}/; /[\p{ASCII}]/; /\P{ASCII}/; /[\P{ASCII}]/`, // Missing u flag
+            output: null,
             errors: [
                 "Unnecessary escape character: \\p.",
                 "Unnecessary escape character: \\p.",


### PR DESCRIPTION
I made the `no-useless-escape` rule fixable. All [stylistic rules](https://ota-meshi.github.io/eslint-plugin-regexp/rules/#stylistic-issues) are now fixable.

Reports for potential escape sequences (e.g. `\x;`) will not be fixed. Invalid escape sequences are a potential error and not a stylistic issue, so they shouldn't be auto-fixable.