### PR TITLE
Update to `regexp-ast-analysis@0.2.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12116,9 +12116,9 @@
             }
         },
         "regexp-ast-analysis": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.0.tgz",
-            "integrity": "sha512-ZVNwBF65Gn4CbRdPNYle8NAPFSDbbJ83svYUk4Mpqmr1QTUx2M06my9x7o8Hw/oFXDwXrJo/7W+ijLfFM5oG2Q==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.2.tgz",
+            "integrity": "sha512-inLIbwizLLAZkpC9/8zp8CeSkJJPsRaqXGDVpxEbNRZD10E+OP6vRDHt7OS9JjWECQLvOI2EmHx7DgdpyAvdrQ==",
             "requires": {
                 "refa": "^0.8.0",
                 "regexpp": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "eslint-utils": "^3.0.0",
         "jsdoctypeparser": "^9.0.0",
         "refa": "^0.8.0",
-        "regexp-ast-analysis": "^0.2.0",
+        "regexp-ast-analysis": "^0.2.2",
         "regexpp": "^3.1.0"
     }
 }


### PR DESCRIPTION
While working on #214, I noticed that I could drastically simplify the code if only `getFirstCharAfter` was able to properly handle word boundary assertions. So I added that.

regexp-ast-analysis now supports word boundary assertions properly in all `getFirst*Char*` functions.

This will help me implement #214 but it also immediately improves our existing rules that use the `getFirst*Char*` functions. Right now, these are `no-useless-assertions`, `no-useless-lazy`, `prefer-character-class`, and `prefer-predefined-assertion`.

---

regexp-ast-analysis@0.2.1 added support for the `d` flag, so this update also works towards #217.