### PR TITLE
Fix false positives for space in RegExp constructor in `regexp/no-invisible-character` rule

### DIFF
--- a/lib/rules/no-invisible-character.ts
+++ b/lib/rules/no-invisible-character.ts
@@ -68,6 +68,9 @@ export default createRule("no-invisible-character", {
 
             let index = 0
             for (const c of text) {
+                if (c === " ") {
+                    continue
+                }
                 const cp = c.codePointAt(0)!
                 if (isInvisible(cp)) {
                     const instead = toCharSetSource(cp, flags)

--- a/tests/lib/rules/no-invisible-character.ts
+++ b/tests/lib/rules/no-invisible-character.ts
@@ -19,6 +19,9 @@ tester.run("no-invisible-character", rule as any, {
         `
         const a = '' + '\t';
         new RegExp(a)`,
+        "new RegExp(' ')",
+        "new RegExp('a')",
+        "new RegExp('[ ]')",
     ],
     invalid: [
         {


### PR DESCRIPTION
close #243