### PR TITLE
Changes `regexp/strict` to suggest octal fixes

### DIFF
--- a/lib/rules/strict.ts
+++ b/lib/rules/strict.ts
@@ -67,6 +67,10 @@ export default createRule("strict", {
 
             // validator
             regexMessage: "{{message}}.",
+
+            // suggestions
+            hexEscapeSuggestion:
+                "Replace the octal escape with a hexadecimal escape.",
         },
         type: "suggestion",
     },
@@ -97,19 +101,36 @@ export default createRule("strict", {
             function report(
                 messageId: string,
                 element: Element,
-                fix?: string | null,
+                fix?: string | null | { fix: string; messageId: string },
             ): void {
                 reported = true
 
-                context.report({
-                    node,
-                    loc: getRegexpLocation(element),
-                    messageId,
-                    data: {
-                        expr: element.raw,
-                    },
-                    fix: fix ? fixReplaceNode(element, fix) : null,
-                })
+                if (fix && typeof fix === "object") {
+                    context.report({
+                        node,
+                        loc: getRegexpLocation(element),
+                        messageId,
+                        data: {
+                            expr: element.raw,
+                        },
+                        suggest: [
+                            {
+                                messageId: fix.messageId,
+                                fix: fixReplaceNode(element, fix.fix),
+                            },
+                        ],
+                    })
+                } else {
+                    context.report({
+                        node,
+                        loc: getRegexpLocation(element),
+                        messageId,
+                        data: {
+                            expr: element.raw,
+                        },
+                        fix: fix ? fixReplaceNode(element, fix) : null,
+                    })
+                }
             }
 
             return {
@@ -132,11 +153,20 @@ export default createRule("strict", {
                     }
                     if (cNode.value !== 0 && isOctalEscape(cNode.raw)) {
                         // e.g. \023
-                        report(
-                            "octalEscape",
-                            cNode,
-                            `\\x${cNode.value.toString(16).padStart(2, "0")}`,
-                        )
+                        const fix = `\\x${cNode.value
+                            .toString(16)
+                            .padStart(2, "0")}`
+
+                        if (/^\\[1-9]\d*$/.test(cNode.raw)) {
+                            // this could be confused with a backreference
+                            // use a suggestion instead of a fix
+                            report("octalEscape", cNode, {
+                                fix,
+                                messageId: "hexEscapeSuggestion",
+                            })
+                        } else {
+                            report("octalEscape", cNode, fix)
+                        }
                         return
                     }
 

--- a/lib/rules/strict.ts
+++ b/lib/rules/strict.ts
@@ -152,21 +152,16 @@ export default createRule("strict", {
                         return
                     }
                     if (cNode.value !== 0 && isOctalEscape(cNode.raw)) {
-                        // e.g. \023
-                        const fix = `\\x${cNode.value
-                            .toString(16)
-                            .padStart(2, "0")}`
+                        // e.g. \023, \34
 
-                        if (/^\\[1-9]\d*$/.test(cNode.raw)) {
-                            // this could be confused with a backreference
-                            // use a suggestion instead of a fix
-                            report("octalEscape", cNode, {
-                                fix,
-                                messageId: "hexEscapeSuggestion",
-                            })
-                        } else {
-                            report("octalEscape", cNode, fix)
-                        }
+                        // this could be confused with a backreference
+                        // use a suggestion instead of a fix
+                        report("octalEscape", cNode, {
+                            fix: `\\x${cNode.value
+                                .toString(16)
+                                .padStart(2, "0")}`,
+                            messageId: "hexEscapeSuggestion",
+                        })
                         return
                     }
 

--- a/tests/lib/rules/strict.ts
+++ b/tests/lib/rules/strict.ts
@@ -142,6 +142,24 @@ tester.run("strict", rule as any, {
                 },
             ],
         },
+        {
+            code: "/\\12/",
+            output: null,
+            errors: [
+                {
+                    message:
+                        "Invalid legacy octal escape sequence '\\12'. Use a hexadecimal escape instead.",
+                    column: 2,
+                    suggestions: [
+                        {
+                            output: "/\\x0a/",
+                            desc:
+                                "Replace the octal escape with a hexadecimal escape.",
+                        },
+                    ],
+                },
+            ],
+        },
 
         // incomplete backreference
         {

--- a/tests/lib/rules/strict.ts
+++ b/tests/lib/rules/strict.ts
@@ -133,12 +133,19 @@ tester.run("strict", rule as any, {
         },
         {
             code: "/\\012/",
-            output: "/\\x0a/",
+            output: null,
             errors: [
                 {
                     message:
                         "Invalid legacy octal escape sequence '\\012'. Use a hexadecimal escape instead.",
                     column: 2,
+                    suggestions: [
+                        {
+                            output: "/\\x0a/",
+                            desc:
+                                "Replace the octal escape with a hexadecimal escape.",
+                        },
+                    ],
                 },
             ],
         },


### PR DESCRIPTION
While testing the rule on Prism, I found that it auto-fixes octal escapes. This can be a problem because they might be incorrectly used backreferences. `regexp/no-octal` also only suggests for this reason.

This changes the `regexp/strict` rule to only suggest octal escape fixes.