### PR TITLE
Change `npm run update` to not run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "test:nyc": "nyc --reporter=lcov npm run test:base",
         "test:debug": "mocha --require ts-node/register/transpile-only \"tests/**/*.ts\" --reporter dot --timeout 60000",
         "test:watch": "npm run test:base -- --watch",
-        "update": "ts-node --transpile-only ./tools/update.ts && npm run eslint-fix && npm run test:nyc",
+        "update": "ts-node --transpile-only ./tools/update.ts && npm run eslint-fix",
         "new": "ts-node ./tools/new-rule.ts",
         "docs:watch": "vuepress dev --debug docs",
         "docs:build": "npm run build && vuepress build docs --no-cache",


### PR DESCRIPTION
This PR changes `npm run update` to not run the tests anymore.

While writing #254, I had to think through our current workflow. One thing I noticed is that it's very strange that `npm run update` runs all tests. Only a few tests are even affected by the changes `npm run update` makes.

With this PR, `npm run update` now only has a single function. This should make it easier for contributors to understand what it does. It even makes it more pleasant to use for me.

