### PR TITLE
Fixed `sort-alternatives` number regex

### DIFF
--- a/lib/rules/sort-alternatives.ts
+++ b/lib/rules/sort-alternatives.ts
@@ -204,7 +204,7 @@ function trySortNumberAlternatives(alternatives: Alternative[]): void {
     {
         let start = 0
         for (let i = 0; i < alternatives.length; i++) {
-            if (!/^0|[1-9]\d*$/.test(alternatives[i].raw)) {
+            if (!/^(?:0|[1-9]\d*)$/.test(alternatives[i].raw)) {
                 if (start < i) {
                     numberRanges.push([start, i])
                 }


### PR DESCRIPTION
#262 pointed out a bug in one of the regexes used in `sort-alternatives`.

The problem is obvious once you see it. The fix is also very simple.