### PR TITLE
Updated refa, regexp-ast-analysis, and scslre

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6287,6 +6287,17 @@
                 "regexp-ast-analysis": "^0.2.2",
                 "regexpp": "^3.2.0",
                 "scslre": "^0.1.5"
+            },
+            "dependencies": {
+                "refa": {
+                    "version": "0.8.0",
+                    "resolved": "https://registry.npmjs.org/refa/-/refa-0.8.0.tgz",
+                    "integrity": "sha512-qOf9zk1McAuGPtQ16nzuWCUg9zx3Quc48i6oD6nxWJdrFeh3Do0vCpIGYLij/1ysAbh5rxdUNg+YzSVBRycX5g==",
+                    "dev": true,
+                    "requires": {
+                        "regexpp": "^3.1.0"
+                    }
+                }
             }
         },
         "eslint-plugin-vue": {
@@ -12144,11 +12155,11 @@
             }
         },
         "refa": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/refa/-/refa-0.8.0.tgz",
-            "integrity": "sha512-qOf9zk1McAuGPtQ16nzuWCUg9zx3Quc48i6oD6nxWJdrFeh3Do0vCpIGYLij/1ysAbh5rxdUNg+YzSVBRycX5g==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/refa/-/refa-0.9.0.tgz",
+            "integrity": "sha512-Ll5rwWmr+qBxyhuBDYSLX8pS7N92ecRAWF0CGWuGdIzvEK7v4RFDHmfSZNYQjIG3xcBZw3vAa0pf2i119vUjBQ==",
             "requires": {
-                "regexpp": "^3.1.0"
+                "regexpp": "^3.2.0"
             }
         },
         "regenerate": {
@@ -12192,12 +12203,12 @@
             }
         },
         "regexp-ast-analysis": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.2.tgz",
-            "integrity": "sha512-inLIbwizLLAZkpC9/8zp8CeSkJJPsRaqXGDVpxEbNRZD10E+OP6vRDHt7OS9JjWECQLvOI2EmHx7DgdpyAvdrQ==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.3.tgz",
+            "integrity": "sha512-K/6d90dP1DI68HHdHORj9vVxV5oWkLB8F7LeGs70EdA/h5BIqkrK8SdGy+O9Ii+AVVPprF0Ia6f5UwgI+ahIcw==",
             "requires": {
-                "refa": "^0.8.0",
-                "regexpp": "^3.1.0"
+                "refa": "^0.9.0",
+                "regexpp": "^3.2.0"
             }
         },
         "regexp.prototype.flags": {
@@ -12576,13 +12587,13 @@
             }
         },
         "scslre": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.1.5.tgz",
-            "integrity": "sha512-PUWMog0DhV8dYB9zWV/YDDS9AT8pBbR12cWbqqzwRrhFpOGwu0OOFafFpUFD0Iw0+ZY5D4EpU4VWJai0SGwOCQ==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.1.6.tgz",
+            "integrity": "sha512-JORxVRlQTfjvlOAaiQKebgFElyAm5/W8b50lgaZ0OkEnKnagJW2ufDh3xRfU75UD9z3FGIu1gL1IyR3Poa6Qmw==",
             "requires": {
-                "refa": "^0.8.0",
-                "regexp-ast-analysis": "^0.2.2",
-                "regexpp": "^3.1.0"
+                "refa": "^0.9.0",
+                "regexp-ast-analysis": "^0.2.3",
+                "regexpp": "^3.2.0"
             }
         },
         "section-matter": {

--- a/package.json
+++ b/package.json
@@ -91,9 +91,9 @@
         "comment-parser": "^1.1.2",
         "eslint-utils": "^3.0.0",
         "jsdoctypeparser": "^9.0.0",
-        "refa": "^0.8.0",
-        "regexp-ast-analysis": "^0.2.2",
+        "refa": "^0.9.0",
+        "regexp-ast-analysis": "^0.2.3",
         "regexpp": "^3.2.0",
-        "scslre": "^0.1.5"
+        "scslre": "^0.1.6"
     }
 }


### PR DESCRIPTION
I just released a new version of refa.

This includes the bug fix necessary to fix #266.

This also includes an update for regexp-ast-analysis and scslre so we don't require two incompatible versions of refa.