### PR TITLE
Improve `optimal-quantifier-concatenation`

### DIFF
--- a/lib/utils/regexp-ast/index.ts
+++ b/lib/utils/regexp-ast/index.ts
@@ -1,8 +1,15 @@
-import type { RegExpLiteral, Pattern } from "regexpp/ast"
+import type { RegExpLiteral, Pattern, Element, Alternative } from "regexpp/ast"
 import type { Rule } from "eslint"
 import type { Expression } from "estree"
 import { parseRegExpLiteral, RegExpParser, visitRegExpAST } from "regexpp"
 import { getStaticValue } from "../ast-utils"
+import type { CharRange, CharSet } from "refa"
+import {
+    Chars,
+    hasSomeDescendant,
+    isEmptyBackreference,
+} from "regexp-ast-analysis"
+import type { RegExpContext } from ".."
 export { ShortCircuit } from "./common"
 export * from "./is-covered"
 export * from "./is-equals"
@@ -59,4 +66,65 @@ export function extractCaptures(
     })
 
     return { count, names }
+}
+
+export interface PossiblyConsumedChar {
+    char: CharSet
+    /**
+     * Whether `char` is exact.
+     *
+     * If `false`, then `char` is only guaranteed to be a superset of the
+     * actually possible characters.
+     */
+    exact: boolean
+}
+
+/**
+ * Returns the union of all characters that can possibly be consumed by the
+ * given element.
+ */
+export function getPossiblyConsumedChar(
+    element: Element | Pattern | Alternative,
+    context: RegExpContext,
+): PossiblyConsumedChar {
+    const ranges: CharRange[] = []
+    let exact = true
+
+    // we misuse hasSomeDescendant to iterate all relevant elements
+    hasSomeDescendant(
+        element,
+        (d) => {
+            if (
+                d.type === "Character" ||
+                d.type === "CharacterClass" ||
+                d.type === "CharacterSet"
+            ) {
+                const c = context.toCharSet(d)
+                ranges.push(...c.ranges)
+                exact = exact && !c.isEmpty
+            } else if (d.type === "Backreference" && !isEmptyBackreference(d)) {
+                const c = getPossiblyConsumedChar(d.resolved, context)
+                ranges.push(...c.char.ranges)
+                exact = exact && c.exact && c.char.size < 2
+            }
+
+            // always continue to the next element
+            return false
+        },
+        // don't go into assertions
+        (d) => {
+            if (d.type === "CharacterClass") {
+                return false
+            }
+            if (d.type === "Assertion") {
+                exact = false
+                return false
+            }
+            return true
+        },
+    )
+
+    const char = Chars.empty(context.flags).union(ranges)
+
+    return { char, exact }
 }

--- a/tests/lib/rules/optimal-quantifier-concatenation.ts
+++ b/tests/lib/rules/optimal-quantifier-concatenation.ts
@@ -16,6 +16,7 @@ tester.run("optimal-quantifier-concatenation", rule as any, {
         String.raw`/\w{3,5}\d*/`,
         String.raw`/a+b+c+d+[abc]+/`,
         String.raw`/(?:a|::)?\w+/`,
+        String.raw`/\d+(?:\w+|-\d+)/`,
         String.raw`/aa?/`,
         String.raw`/\w?\w/`,
     ],
@@ -168,6 +169,20 @@ tester.run("optimal-quantifier-concatenation", rule as any, {
             code: String.raw`/a.{1,3}.{2,4}c/`,
             output: String.raw`/a.{3,7}c/`,
             errors: ["'.{1,3}' and '.{2,4}' can be replaced with '.{3,7}'."],
+        },
+        {
+            code: String.raw`/\w+(?:foo|bar)?/`,
+            output: String.raw`/\w+/`,
+            errors: [
+                "'(?:foo|bar)?' can be removed because it is already included by '\\w+'.",
+            ],
+        },
+        {
+            code: String.raw`/[ab]*(?:a|bb)+/`,
+            output: String.raw`/[ab]*(?:a|bb)/`,
+            errors: [
+                "'[ab]*' and '(?:a|bb)+' can be replaced with '[ab]*(?:a|bb)'.",
+            ],
         },
 
         // careful with capturing groups

--- a/tests/lib/rules/optimal-quantifier-concatenation.ts
+++ b/tests/lib/rules/optimal-quantifier-concatenation.ts
@@ -184,6 +184,26 @@ tester.run("optimal-quantifier-concatenation", rule as any, {
                 "'[ab]*' and '(?:a|bb)+' can be replaced with '[ab]*(?:a|bb)'.",
             ],
         },
+        {
+            code: String.raw`/(?:\d+|abc)\w+/`,
+            output: String.raw`/(?:\d|abc)\w+/`,
+            errors: ["'\\d+' can be replaced with '\\d' because of '\\w+'."],
+        },
+        {
+            code: String.raw`/(^[ \t]*)[a-z\d].+(?::{2,4}|;;)(?=\s)/im`,
+            output: String.raw`/(^[ \t]*)[a-z\d].+(?::{2}|;;)(?=\s)/im`,
+            errors: ["':{2,4}' can be replaced with ':{2}' because of '.+'."],
+        },
+        {
+            code: String.raw`/(^[\t ]*)#(?:const|else(?:[\t ]+if)?|end[\t ]+if|error|if).*/im`,
+            output: String.raw`/(^[\t ]*)#(?:const|else|end[\t ]+if|error|if).*/im`,
+            errors: ["'(?:[\\t ]+if)?' can be removed because of '.*'."],
+        },
+        {
+            code: String.raw`/(&(?:\r\n?|\n)\s*)!.*/`,
+            output: String.raw`/(&(?:\r|\n)\s*)!.*/`,
+            errors: ["'\\n?' can be removed because of '\\s*'."],
+        },
 
         // careful with capturing groups
         {


### PR DESCRIPTION
This resolves #278.

This PR includes 2 things:

1. Improved handling of quantifiers as described in #278.
2. Support for nested quantifiers. In some case, we can simplify (or remove) a nested quantifier because of adjacent quantifiers (e.g. `(?:\d+|foo)\w+` -> `(?:\d|foo)\w+`). This is essentially a generalization of the approach we already had.