### PR TITLE
Improve `no-dupe-disjunctions` by reordering alternatives

### DIFF
--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -530,7 +530,6 @@ function* findDuplicationNfa(
                     const reorder = canReorder(
                         [alternative, ...others],
                         context,
-                        { ignoreCapturingGroups: true },
                     )
 
                     if (reorder) {

--- a/tests/lib/rules/no-dupe-disjunctions.ts
+++ b/tests/lib/rules/no-dupe-disjunctions.ts
@@ -365,6 +365,21 @@ tester.run("no-dupe-disjunctions", rule as any, {
         },
         {
             code: String(/\b(?:\d|foo|\w+)\b/),
+            errors: [
+                {
+                    message:
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\w+' and can be removed.",
+                    column: 7,
+                },
+                {
+                    message:
+                        "Unexpected useless alternative. This alternative is a strict subset of '\\w+' and can be removed.",
+                    column: 10,
+                },
+            ],
+        },
+        {
+            code: String(/(?:\d|foo|\w+)a/),
             options: [{ report: "interesting" }],
             errors: [
                 "Unexpected superset. This alternative is a superset of '\\d|foo'. It might be possible to remove the other alternative(s).",


### PR DESCRIPTION
This resolves #251.