### PR TITLE
Improve pattern source information

### DIFF
--- a/lib/rules/control-character-escape.ts
+++ b/lib/rules/control-character-escape.ts
@@ -8,8 +8,8 @@ import {
     CP_TAB,
     createRule,
     defineRegexpVisitor,
-    isRegexpLiteral,
 } from "../utils"
+import { isRegexpLiteral } from "../utils/ast-utils/utils"
 
 const CONTROL_CHARS = new Map<number, string>([
     [0, "\\0"],

--- a/lib/rules/match-any.ts
+++ b/lib/rules/match-any.ts
@@ -70,7 +70,7 @@ export default createRule("match-any", {
             { node, flags, patternSource }: RegExpContext,
             regexpNode: RegExpNode,
         ): null | Rule.Fix | Rule.Fix[] {
-            if (!preference || !patternSource) {
+            if (!preference) {
                 return null
             }
 

--- a/lib/rules/no-empty-alternative.ts
+++ b/lib/rules/no-empty-alternative.ts
@@ -38,10 +38,24 @@ export default createRule("no-empty-alternative", {
                     // the parser and one alternative is already handled by other rules.
                     for (let i = 0; i < regexpNode.alternatives.length; i++) {
                         const alt = regexpNode.alternatives[i]
+                        const last = i === regexpNode.alternatives.length - 1
                         if (alt.elements.length === 0) {
+                            // Since empty alternative have a width of 0, it's hard to underline their location.
+                            // So we will report the location of the `|` that causes the empty alternative.
+                            const index = alt.start
+                            const loc = last
+                                ? getRegexpLocation({
+                                      start: index - 1,
+                                      end: index,
+                                  })
+                                : getRegexpLocation({
+                                      start: index,
+                                      end: index + 1,
+                                  })
+
                             context.report({
                                 node,
-                                loc: getRegexpLocation(alt),
+                                loc,
                                 messageId: "empty",
                             })
                             // don't report the same node multiple times

--- a/lib/rules/no-invisible-character.ts
+++ b/lib/rules/no-invisible-character.ts
@@ -33,7 +33,7 @@ export default createRule("no-invisible-character", {
             node,
             flags,
             getRegexpLocation,
-            getRegexpRange,
+            fixReplaceNode,
         }: RegExpContextForLiteral): RegExpVisitor.Handlers {
             return {
                 onCharacterEnter(cNode) {
@@ -49,11 +49,7 @@ export default createRule("no-invisible-character", {
                             data: {
                                 instead,
                             },
-                            fix(fixer) {
-                                const range = getRegexpRange(cNode)
-
-                                return fixer.replaceTextRange(range, instead)
-                            },
+                            fix: fixReplaceNode(cNode, instead),
                         })
                     }
                 },

--- a/lib/rules/no-useless-lazy.ts
+++ b/lib/rules/no-useless-lazy.ts
@@ -19,7 +19,7 @@ function makeGreedy({ patternSource }: RegExpContext, qNode: Quantifier) {
             return null
         }
 
-        const range = patternSource?.getReplaceRange({
+        const range = patternSource.getReplaceRange({
             start: qNode.end - 1,
             end: qNode.end,
         })

--- a/lib/rules/no-useless-lazy.ts
+++ b/lib/rules/no-useless-lazy.ts
@@ -13,13 +13,20 @@ import { createRule, defineRegexpVisitor } from "../utils"
 /**
  * Returns a fix that makes the given quantifier greedy.
  */
-function makeGreedy({ getRegexpRange }: RegExpContext, qNode: Quantifier) {
+function makeGreedy({ patternSource }: RegExpContext, qNode: Quantifier) {
     return (fixer: Rule.RuleFixer): Rule.Fix | null => {
-        const range = getRegexpRange(qNode)
-        if (range == null) {
+        if (qNode.greedy) {
             return null
         }
-        return fixer.removeRange([range[1] - 1, range[1]])
+
+        const range = patternSource?.getReplaceRange({
+            start: qNode.end - 1,
+            end: qNode.end,
+        })
+        if (!range) {
+            return null
+        }
+        return range.remove(fixer)
     }
 }
 

--- a/lib/rules/optimal-quantifier-concatenation.ts
+++ b/lib/rules/optimal-quantifier-concatenation.ts
@@ -13,7 +13,7 @@ import type {
     QuantifiableElement,
     Quantifier,
 } from "regexpp/ast"
-import type { AST, SourceCode } from "eslint"
+import type { AST } from "eslint"
 import type { RegExpContext, Quant } from "../utils"
 import { createRule, defineRegexpVisitor, quantToString } from "../utils"
 import { Chars, hasSomeDescendant } from "regexp-ast-analysis"
@@ -489,20 +489,12 @@ function getReplacement(
 function getLoc(
     left: Element,
     right: Element,
-    sourceCode: SourceCode,
-    { getRegexpRange }: RegExpContext,
+    { patternSource }: RegExpContext,
 ): AST.SourceLocation | undefined {
-    const firstRange = getRegexpRange(left)
-    const lastRange = getRegexpRange(right)
-
-    if (firstRange && lastRange) {
-        return {
-            start: sourceCode.getLocFromIndex(firstRange[0]),
-            end: sourceCode.getLocFromIndex(lastRange[1]),
-        }
-    }
-
-    return undefined
+    return patternSource?.getAstLocation({
+        start: Math.min(left.start, right.start),
+        end: Math.max(left.end, right.end),
+    })
 }
 
 export default createRule("optimal-quantifier-concatenation", {
@@ -568,12 +560,8 @@ export default createRule("optimal-quantifier-concatenation", {
                             context.report({
                                 node,
                                 loc:
-                                    getLoc(
-                                        left,
-                                        right,
-                                        context.getSourceCode(),
-                                        regexpContext,
-                                    ) ?? getRegexpLocation(aNode),
+                                    getLoc(left, right, regexpContext) ??
+                                    getRegexpLocation(aNode),
                                 messageId: replacement.messageId,
                                 data: {
                                     left: left.raw,

--- a/lib/rules/optimal-quantifier-concatenation.ts
+++ b/lib/rules/optimal-quantifier-concatenation.ts
@@ -490,8 +490,8 @@ function getLoc(
     left: Element,
     right: Element,
     { patternSource }: RegExpContext,
-): AST.SourceLocation | undefined {
-    return patternSource?.getAstLocation({
+): AST.SourceLocation {
+    return patternSource.getAstLocation({
         start: Math.min(left.start, right.start),
         end: Math.max(left.end, right.end),
     })
@@ -559,9 +559,7 @@ export default createRule("optimal-quantifier-concatenation", {
                         if (replacement.type === "Both") {
                             context.report({
                                 node,
-                                loc:
-                                    getLoc(left, right, regexpContext) ??
-                                    getRegexpLocation(aNode),
+                                loc: getLoc(left, right, regexpContext),
                                 messageId: replacement.messageId,
                                 data: {
                                     left: left.raw,

--- a/lib/rules/prefer-quantifier.ts
+++ b/lib/rules/prefer-quantifier.ts
@@ -158,7 +158,7 @@ export default createRule("prefer-quantifier", {
 
                         context.report({
                             node,
-                            loc: patternSource?.getAstLocation(bufferRange),
+                            loc: patternSource.getAstLocation(bufferRange),
                             messageId: "unexpected",
                             data: {
                                 type:
@@ -170,7 +170,7 @@ export default createRule("prefer-quantifier", {
                                 quantifier: buffer.getQuantifier(),
                             },
                             fix(fixer) {
-                                const range = patternSource?.getReplaceRange(
+                                const range = patternSource.getReplaceRange(
                                     bufferRange,
                                 )
                                 if (!range) {

--- a/lib/rules/prefer-range.ts
+++ b/lib/rules/prefer-range.ts
@@ -61,7 +61,7 @@ export default createRule("prefer-range", {
             ): PatternReplaceRange[] | null {
                 const ranges: PatternReplaceRange[] = []
                 for (const reportNode of nodes) {
-                    const reportRange = patternSource?.getReplaceRange(
+                    const reportRange = patternSource.getReplaceRange(
                         reportNode,
                     )
                     if (!reportRange) {

--- a/lib/rules/prefer-w.ts
+++ b/lib/rules/prefer-w.ts
@@ -164,7 +164,7 @@ export default createRule("prefer-w", {
                             fix(fixer: Rule.RuleFixer) {
                                 const fixes: Rule.Fix[] = []
                                 for (const element of unexpectedElements) {
-                                    const range = patternSource?.getReplaceRange(
+                                    const range = patternSource.getReplaceRange(
                                         element,
                                     )
                                     if (!range) {

--- a/lib/rules/sort-character-class-elements.ts
+++ b/lib/rules/sort-character-class-elements.ts
@@ -84,9 +84,8 @@ export default createRule("sort-character-class-elements", {
          */
         function createVisitor({
             node,
-            fixerApplyEscape,
             getRegexpLocation,
-            getRegexpRange,
+            patternSource,
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCharacterClassEnter(ccNode) {
@@ -112,22 +111,23 @@ export default createRule("sort-character-class-elements", {
                                         prev: moveTarget.raw,
                                     },
                                     *fix(fixer) {
-                                        const nextRange = getRegexpRange(next)
-                                        const targetRange = getRegexpRange(
+                                        const nextRange = patternSource?.getReplaceRange(
+                                            next,
+                                        )
+                                        const targetRange = patternSource?.getReplaceRange(
                                             moveTarget,
                                         )
+
                                         if (!targetRange || !nextRange) {
                                             return
                                         }
 
-                                        yield fixer.insertTextBeforeRange(
-                                            targetRange,
-                                            fixerApplyEscape(
-                                                escapeRaw(next, moveTarget),
-                                            ),
+                                        yield targetRange.insertBefore(
+                                            fixer,
+                                            escapeRaw(next, moveTarget),
                                         )
 
-                                        yield fixer.removeRange(nextRange)
+                                        yield nextRange.remove(fixer)
                                     },
                                 })
                             }

--- a/lib/rules/sort-character-class-elements.ts
+++ b/lib/rules/sort-character-class-elements.ts
@@ -111,10 +111,10 @@ export default createRule("sort-character-class-elements", {
                                         prev: moveTarget.raw,
                                     },
                                     *fix(fixer) {
-                                        const nextRange = patternSource?.getReplaceRange(
+                                        const nextRange = patternSource.getReplaceRange(
                                             next,
                                         )
-                                        const targetRange = patternSource?.getReplaceRange(
+                                        const targetRange = patternSource.getReplaceRange(
                                             moveTarget,
                                         )
 

--- a/lib/utils/ast-utils/pattern-source.ts
+++ b/lib/utils/ast-utils/pattern-source.ts
@@ -383,7 +383,7 @@ function dereferenceOwnedConstant(
             return expression
         }
 
-        return def.node.init
+        return dereferenceOwnedConstant(context, def.node.init)
     }
 
     return expression

--- a/lib/utils/ast-utils/pattern-source.ts
+++ b/lib/utils/ast-utils/pattern-source.ts
@@ -1,0 +1,390 @@
+import type { Expression, Literal, RegExpLiteral } from "estree"
+import type { Rule, AST, SourceCode } from "eslint"
+import { getStaticValue } from "."
+import {
+    findVariable,
+    getParent,
+    getPropertyName,
+    getStringValueRange,
+    isRegexpLiteral,
+    isStringLiteral,
+} from "./utils"
+
+/**
+ * The range of a node/construct within a regexp pattern.
+ */
+export interface PatternRange {
+    readonly start: number
+    readonly end: number
+}
+
+export class PatternReplaceRange {
+    public range: AST.Range
+
+    public type: "RegExp" | "String"
+
+    public constructor(range: AST.Range, type: PatternReplaceRange["type"]) {
+        if (!range || range[0] < 0 || range[0] > range[1]) {
+            throw new Error(`Invalid range: ${JSON.stringify(range)}`)
+        }
+
+        this.range = range
+        this.type = type
+    }
+
+    public static fromLiteral(
+        node: Literal,
+        sourceCode: SourceCode,
+        nodeRange: PatternRange,
+        range: PatternRange,
+    ): PatternReplaceRange | null {
+        if (!node.range) {
+            return null
+        }
+
+        const start = range.start - nodeRange.start
+        const end = range.end - nodeRange.start
+
+        if (isRegexpLiteral(node)) {
+            const nodeStart = node.range[0] + "/".length
+            return new PatternReplaceRange(
+                [nodeStart + start, nodeStart + end],
+                "RegExp",
+            )
+        }
+
+        if (isStringLiteral(node)) {
+            const astRange = getStringValueRange(sourceCode, node, start, end)
+
+            if (astRange) {
+                return new PatternReplaceRange(astRange, "String")
+            }
+        }
+        return null
+    }
+
+    public getAstLocation(sourceCode: SourceCode): AST.SourceLocation {
+        return astRangeToLocation(sourceCode, this.range)
+    }
+
+    public escape(text: string): string {
+        if (this.type === "String") {
+            return text
+                .replace(/\\/g, "\\\\")
+                .replace(/\n/g, "\\n")
+                .replace(/\r/g, "\\r")
+                .replace(/\t/g, "\\t")
+        }
+
+        return text
+    }
+
+    public replace(fixer: Rule.RuleFixer, text: string): Rule.Fix {
+        return fixer.replaceTextRange(this.range, this.escape(text))
+    }
+
+    public remove(fixer: Rule.RuleFixer): Rule.Fix {
+        return fixer.removeRange(this.range)
+    }
+
+    public insertAfter(fixer: Rule.RuleFixer, text: string): Rule.Fix {
+        return fixer.insertTextAfterRange(this.range, this.escape(text))
+    }
+
+    public insertBefore(fixer: Rule.RuleFixer, text: string): Rule.Fix {
+        return fixer.insertTextBeforeRange(this.range, this.escape(text))
+    }
+}
+
+class PatternSegment implements PatternRange {
+    private readonly sourceCode: SourceCode
+
+    public readonly node: Expression
+
+    public readonly value: string
+
+    public readonly start: number
+
+    public readonly end: number
+
+    public constructor(
+        sourceCode: SourceCode,
+        node: Expression,
+        value: string,
+        start: number,
+    ) {
+        this.sourceCode = sourceCode
+        this.node = node
+        this.value = value
+        this.start = start
+        this.end = start + value.length
+    }
+
+    public contains(range: PatternRange): boolean {
+        return this.start <= range.start && range.end <= this.end
+    }
+
+    public getReplaceRange(range: PatternRange): PatternReplaceRange | null {
+        if (!this.contains(range)) {
+            return null
+        }
+
+        if (this.node.type === "Literal") {
+            // This will cover string literals and RegExp literals
+            return PatternReplaceRange.fromLiteral(
+                this.node,
+                this.sourceCode,
+                this,
+                range,
+            )
+        }
+
+        // e.g. /foo/.source
+        if (
+            this.node.type === "MemberExpression" &&
+            this.node.object.type !== "Super" &&
+            isRegexpLiteral(this.node.object) &&
+            getPropertyName(this.node) === "source"
+        ) {
+            return PatternReplaceRange.fromLiteral(
+                this.node.object,
+                this.sourceCode,
+                this,
+                range,
+            )
+        }
+
+        return null
+    }
+
+    public getAstRange(range: PatternRange): AST.Range {
+        const replaceRange = this.getReplaceRange(range)
+        if (replaceRange) {
+            return replaceRange.range
+        }
+
+        return this.node.range!
+    }
+}
+
+export class PatternSource {
+    private readonly sourceCode: SourceCode
+
+    public readonly node: Expression
+
+    public readonly value: string
+
+    private readonly segments: readonly PatternSegment[]
+
+    private constructor(
+        sourceCode: SourceCode,
+        node: Expression,
+        value: string,
+        items: readonly PatternSegment[],
+    ) {
+        this.sourceCode = sourceCode
+        this.node = node
+        this.value = value
+        this.segments = items
+    }
+
+    public static fromExpression(
+        context: Rule.RuleContext,
+        expression: Expression,
+    ): PatternSource | null {
+        // eslint-disable-next-line no-param-reassign -- x
+        expression = dereferenceOwnedConstant(context, expression)
+
+        if (isRegexpLiteral(expression)) {
+            return PatternSource.fromRegExpLiteral(context, expression)
+        }
+
+        const sourceCode = context.getSourceCode()
+
+        const items: PatternSegment[] = []
+        let value = ""
+
+        for (const e of flattenPlus(context, expression)) {
+            const staticValue = getStaticValue(context, e)
+            if (!staticValue || typeof staticValue.value !== "string") {
+                return null
+            }
+
+            items.push(
+                new PatternSegment(
+                    sourceCode,
+                    e,
+                    staticValue.value,
+                    value.length,
+                ),
+            )
+            value += staticValue.value
+        }
+
+        return new PatternSource(sourceCode, expression, value, items)
+    }
+
+    public static fromRegExpLiteral(
+        context: Rule.RuleContext,
+        expression: RegExpLiteral,
+    ): PatternSource {
+        const sourceCode = context.getSourceCode()
+
+        return new PatternSource(
+            sourceCode,
+            expression,
+            expression.regex.pattern,
+            [
+                new PatternSegment(
+                    sourceCode,
+                    expression,
+                    expression.regex.pattern,
+                    0,
+                ),
+            ],
+        )
+    }
+
+    private getSegment(range: PatternRange): PatternSegment | null {
+        const segments = this.getSegments(range)
+        if (segments.length === 1) {
+            return segments[0]
+        }
+        return null
+    }
+
+    private getSegments(range: PatternRange): PatternSegment[] {
+        return this.segments.filter(
+            (item) => item.start < range.end && range.start < item.end,
+        )
+    }
+
+    public getReplaceRange(range: PatternRange): PatternReplaceRange | null {
+        const segment = this.getSegment(range)
+        if (segment) {
+            return segment.getReplaceRange(range)
+        }
+        return null
+    }
+
+    public getAstRange(range: PatternRange): AST.Range {
+        const overlapping = this.getSegments(range)
+
+        if (overlapping.length === 1) {
+            return overlapping[0].getAstRange(range)
+        }
+
+        // the input range comes from multiple sources
+        // union all their ranges
+        let min = Infinity
+        let max = -Infinity
+        for (const item of overlapping) {
+            min = Math.min(min, item.node.range![0])
+            max = Math.max(max, item.node.range![1])
+        }
+
+        if (min > max) {
+            return this.node.range!
+        }
+
+        return [min, max]
+    }
+
+    public getAstLocation(range: PatternRange): AST.SourceLocation {
+        return astRangeToLocation(this.sourceCode, this.getAstRange(range))
+    }
+}
+
+/**
+ * Flattens binary + expressions into an array.
+ *
+ * This will automatically dereference owned constants.
+ */
+function flattenPlus(context: Rule.RuleContext, e: Expression): Expression[] {
+    if (e.type === "BinaryExpression" && e.operator === "+") {
+        return [
+            ...flattenPlus(context, e.left),
+            ...flattenPlus(context, e.right),
+        ]
+    }
+
+    const deRef = dereferenceOwnedConstant(context, e)
+    if (deRef !== e) {
+        return flattenPlus(context, deRef)
+    }
+
+    return [e]
+}
+
+/**
+ * Converts an range into a source location.
+ */
+function astRangeToLocation(
+    sourceCode: SourceCode,
+    range: AST.Range,
+): AST.SourceLocation {
+    return {
+        start: sourceCode.getLocFromIndex(range[0]),
+        end: sourceCode.getLocFromIndex(range[1]),
+    }
+}
+
+/**
+ * If the given expression is a variables, this will dereference the variables
+ * if the variable is constant and only referenced by this expression.
+ *
+ * This means that only variables that are owned by this expression are
+ * dereferenced.
+ *
+ * In all other cases, the given expression will be returned as is.
+ *
+ * @param expression
+ */
+function dereferenceOwnedConstant(
+    context: Rule.RuleContext,
+    expression: Expression,
+): Expression {
+    if (expression.type === "Identifier") {
+        const variable = findVariable(context, expression)
+        if (!variable || variable.defs.length !== 1) {
+            // we want a variable with 1 definition
+            return expression
+        }
+
+        const def = variable.defs[0]
+        if (def.type !== "Variable") {
+            // we want a variable
+            return expression
+        }
+
+        const grandParent = getParent(def.parent)
+        if (grandParent && grandParent.type === "ExportNamedDeclaration") {
+            // exported variables are not owned because they can be referenced
+            // by modules that import this module
+            return expression
+        }
+
+        // we expect there two be exactly 2 references:
+        //  1. for initializing the variable
+        //  2. the reference given to this function
+        if (variable.references.length !== 2) {
+            return expression
+        }
+
+        const [initRef, thisRef] = variable.references
+        if (
+            !(
+                initRef.init &&
+                initRef.writeExpr &&
+                initRef.writeExpr === def.node.init
+            ) ||
+            thisRef.identifier !== expression
+        ) {
+            return expression
+        }
+
+        return def.node.init
+    }
+
+    return expression
+}

--- a/lib/utils/ast-utils/pattern-source.ts
+++ b/lib/utils/ast-utils/pattern-source.ts
@@ -18,6 +18,9 @@ export interface PatternRange {
     readonly end: number
 }
 
+/**
+ * A range in source code that can be edited.
+ */
 export class PatternReplaceRange {
     public range: AST.Range
 
@@ -267,6 +270,12 @@ export class PatternSource {
         return null
     }
 
+    /**
+     * Returns an approximate AST range for the given pattern range.
+     *
+     * DO NOT use this in fixes to edit source code. Use
+     * {@link PatternSource.getReplaceRange} instead.
+     */
     public getAstRange(range: PatternRange): AST.Range {
         const overlapping = this.getSegments(range)
 
@@ -290,6 +299,12 @@ export class PatternSource {
         return [min, max]
     }
 
+    /**
+     * Returns an approximate AST source location for the given pattern range.
+     *
+     * DO NOT use this in fixes to edit source code. Use
+     * {@link PatternSource.getReplaceRange} instead.
+     */
     public getAstLocation(range: PatternRange): AST.SourceLocation {
         return astRangeToLocation(this.sourceCode, this.getAstRange(range))
     }

--- a/tests/lib/rules/match-any.ts
+++ b/tests/lib/rules/match-any.ts
@@ -162,7 +162,10 @@ tester.run("match-any", rule as any, {
             const s = "[\\s\\S]"+"[\\S\\s][^]."
             new RegExp(s, 's')
             `,
-            output: null,
+            output: String.raw`
+            const s = "[^]"+"[^][^][^]"
+            new RegExp(s, 's')
+            `,
             options: [{ allows: ["[^]"] }],
             errors: [
                 "Unexpected using '[\\s\\S]' to match any character.",

--- a/tests/lib/rules/negation.ts
+++ b/tests/lib/rules/negation.ts
@@ -117,9 +117,7 @@ tester.run("negation", rule as any, {
             code: String.raw`const s ="[^\\w]"
             new RegExp(s)
             new RegExp(s)`,
-            output: String.raw`const s ="\\W"
-            new RegExp(s)
-            new RegExp(s)`,
+            output: null,
             errors: [
                 "Unexpected negated character class. Use '\\W' instead.",
                 "Unexpected negated character class. Use '\\W' instead.",

--- a/tests/lib/rules/no-empty-alternative.ts
+++ b/tests/lib/rules/no-empty-alternative.ts
@@ -27,7 +27,7 @@ tester.run("no-empty-alternative", rule as any, {
                 {
                     message: "No empty alternatives. Use quantifiers instead.",
                     line: 1,
-                    column: 9,
+                    column: 8,
                 },
             ],
         },

--- a/tests/lib/rules/no-useless-character-class.ts
+++ b/tests/lib/rules/no-useless-character-class.ts
@@ -140,8 +140,8 @@ tester.run("no-useless-character-class", rule as any, {
             errors: 18,
         },
         {
-            code: String.raw`new RegExp("[.] [*] [+] [?] [\\^] [=] [!] [:]"+" [$] [{] [}] [(] [)] [|] [[] [\\]] [/] [\\\\]")`,
-            output: null,
+            code: String.raw`new RegExp("[.] [*] [+] [?] [\\^] [=] [!] [:]" + " [$] [{] [}] [(] [)] [|] [[] [\\]] [/] [\\\\]")`,
+            output: String.raw`new RegExp("\\. \\* \\+ \\? \\^ = ! :" + " \\$ \\{ } \\( \\) \\| \\[ \\] \\/ \\\\")`,
             options: [{ ignores: [] }],
             errors: 18,
         },

--- a/tests/lib/rules/no-useless-lazy.ts
+++ b/tests/lib/rules/no-useless-lazy.ts
@@ -62,7 +62,8 @@ tester.run("no-useless-lazy", rule as any, {
         {
             code: String.raw`const s = "\\d"+"{1}?"
             new RegExp(s)`,
-            output: null,
+            output: String.raw`const s = "\\d"+"{1}"
+            new RegExp(s)`,
             errors: [{ messageId: "constant" }],
         },
 

--- a/tests/lib/rules/sort-character-class-elements.ts
+++ b/tests/lib/rules/sort-character-class-elements.ts
@@ -219,7 +219,8 @@ tester.run("sort-character-class-elements", rule as any, {
         {
             code: String.raw`const s = "[\\d"+"\\w]"
             new RegExp(s, 'u')`,
-            output: null,
+            output: String.raw`const s = "[\\w\\d"+"]"
+            new RegExp(s, 'u')`,
             options: [{ order: [] }],
             errors: [
                 "Expected character class elements to be in ascending order. '\\w' should be before '\\d'.",

--- a/tests/lib/utils/ast-utils/extract-expression-references.ts
+++ b/tests/lib/utils/ast-utils/extract-expression-references.ts
@@ -5,7 +5,7 @@ import type * as ESTree from "estree"
 import { CALL, CONSTRUCT, ReferenceTracker } from "eslint-utils"
 import type { ExpressionReference } from "../../../../lib/utils/ast-utils"
 import { extractExpressionReferences } from "../../../../lib/utils/ast-utils"
-import { isRegexpLiteral } from "../../../../lib/utils"
+import { isRegexpLiteral } from "../../../../lib/utils/ast-utils/utils"
 
 type ExpressionReferenceResult = { type: string; [key: string]: any }
 
@@ -81,7 +81,7 @@ const TESTCASES: TestCase[] = [
     {
         code: `const a = /a/
         fn(a)
-        
+
         function fn(b) { b.source }`,
         results: [
             [{ type: "member", node: "b", memberExpression: "b.source" }],

--- a/tests/lib/utils/ast-utils/extract-property-references.ts
+++ b/tests/lib/utils/ast-utils/extract-property-references.ts
@@ -4,7 +4,7 @@ import type * as ESTree from "estree"
 import { CALL, CONSTRUCT, ReferenceTracker } from "eslint-utils"
 import type { PropertyReference } from "../../../../lib/utils/ast-utils"
 import { extractPropertyReferences } from "../../../../lib/utils/ast-utils"
-import { isRegexpLiteral } from "../../../../lib/utils"
+import { isRegexpLiteral } from "../../../../lib/utils/ast-utils/utils"
 
 type PropertyReferenceResult = {
     [key: string]: { type: string; refs?: PropertyReferenceResult }

--- a/tests/lib/utils/get-usage-of-pattern.ts
+++ b/tests/lib/utils/get-usage-of-pattern.ts
@@ -1,7 +1,7 @@
 import { Linter } from "eslint"
 import assert from "assert"
 import type * as ESTree from "estree"
-import { isRegexpLiteral } from "../../../lib/utils"
+import { isRegexpLiteral } from "../../../lib/utils/ast-utils/utils"
 import {
     getUsageOfPattern,
     UsageOfPattern,
@@ -106,7 +106,7 @@ const TESTCASES: TestCase[] = [
         code: `
         getSource(/a/)
         toString(/b/)
-        
+
         function getSource(p) {
             return p.source
         }
@@ -142,7 +142,7 @@ const TESTCASES: TestCase[] = [
         code: `
         getSource(42, /a/)
         getSource(/b/, 42)
-        
+
         function getSource(p, p2) {
             return p2.source
         }
@@ -152,7 +152,7 @@ const TESTCASES: TestCase[] = [
     {
         code: `
         fn(/a/)
-        
+
         function fn(p) {
             return fn(p)
         }
@@ -164,7 +164,7 @@ const TESTCASES: TestCase[] = [
         const fn = getSource
         fn(42, /a/)
         fn(/b/, 42)
-        
+
         function getSource(p, p2) {
             return p2.source
         }
@@ -174,7 +174,7 @@ const TESTCASES: TestCase[] = [
     {
         code: `
         getSource(42, /a/)
-        
+
         function getSource(p) {
             return p.source
         }


### PR DESCRIPTION
This PR changes how rules determine the position of RegExpp nodes in the original JS source code.

Instead of analyzing the AST in each call of `getRegexpRange`, we now store the information about how the pattern string is constructed in a `PatternSource` instead.

## `PatternSource`

A `PatternSource` is essentially just an array of all parts (concatenated) that make up the pattern string.  Examples:

- `/foo/i`: the instance is `[/foo/i]`
- `RegExp(/foo/i, "m")`: the instance is `[/foo/i]`
- `RegExp("foo")`: the instance is `["foo"]`
- `RegExp("foo" + "bar")`: the instance is `["foo", "bar"]`

Each segment that makes up the pattern has information about its AST node, its string value, and its range within the complete pattern string.

Here is a complete instance for the code:

```js
const space = "\t\n\r ";
new RegExp("([" + space + "]+)");
```

![image](https://user-images.githubusercontent.com/20878432/128637131-c67265f3-03f3-4d96-87bd-c3354f3f25b5.png)

Since we know exactly what AST node contributed in what way to the final pattern string, we pinpoint the location of RegExpp AST nodes. This is great for error messages but it also allows us to fix a lot more.

## Comparison

Old:
(nothing is fixable)

![image](https://user-images.githubusercontent.com/20878432/128637281-073259d6-60c7-41b4-8a1c-47d7cbc35d03.png)

New:
(everything is fixable)

![image](https://user-images.githubusercontent.com/20878432/128637293-04c559c9-6503-4f64-9af4-fa758cff5177.png)

## Semantic differences

The old `getRegexpRange` had 2 porpuses:

1. Get AST ranges for error reports.
2. Get AST ranges for fixes.

The new API by `PatternSoruce` explicitly differentiates these 2 use cases. 

This is important because AST ranges for fixes have to be exact and they have to map to exactly one AST node that we can change. However, AST ranges for error reports don't have to be exact, they just have to be good enough for humans.

The new API:

1. `PatternSoruce#getAstRange` for error reports. This implements a best-effort approach to provide an AST range that is useful to humans.
2. `PatternSoruce#getReplaceRange` for fixes. The returned `PatternReplaceRange` contains all the information to edit source code. 
    `PatternReplaceRange` also has methods to create fixes. These methods will automatically handle escaping (if necessary) and should be used instead of `fixer.replaceTextRange`.

By differentiating these to use cases, we can provide exact ranges for fixes and good approximate ranges for error reporting. This should improve the user experience a lot.

## Rule changes

The above-mentioned semantic changes broke a few rules. All rules now use the new API.

This is quite nice because it means that all rules now benefit from `PatternSource`. This improvement can be seen in the test cases. A few test cases changed because they can now be fixed. The report range also changed on 1 test case.

---

This fixes half of #231.