### PR TITLE
Fix replacement escaping in string literals

### DIFF
--- a/tests/lib/rules/no-useless-character-class.ts
+++ b/tests/lib/rules/no-useless-character-class.ts
@@ -145,5 +145,11 @@ tester.run("no-useless-character-class", rule as any, {
             options: [{ ignores: [] }],
             errors: 18,
         },
+        {
+            code: String.raw`RegExp("[\"]" + '[\']')`,
+            output: String.raw`RegExp("\"" + '\'')`,
+            options: [{ ignores: [] }],
+            errors: 2,
+        },
     ],
 })


### PR DESCRIPTION
I noticed a little bug:

![image](https://user-images.githubusercontent.com/20878432/128866703-1e825405-1ede-4ce9-8380-16c5e4c1ba17.png)

and fixed it:

![image](https://user-images.githubusercontent.com/20878432/128866751-666e3c53-5f1b-4a13-b2a3-13ad27e7600d.png)
