### PR TITLE
Support unknown and invalid patterns

### DIFF
--- a/lib/rules/sort-flags.ts
+++ b/lib/rules/sort-flags.ts
@@ -1,5 +1,4 @@
-import type { RegExpVisitor } from "regexpp/visitor"
-import type { RegExpContext } from "../utils"
+import type { RegExpContext, UnparsableRegExpContext } from "../utils"
 import { createRule, defineRegexpVisitor } from "../utils"
 
 export default createRule("sort-flags", {
@@ -15,7 +14,7 @@ export default createRule("sort-flags", {
         schema: [],
         messages: {
             sortFlags:
-                "The flags '{{flags}}' should in the order '{{sortedFlags}}'.",
+                "The flags '{{flags}}' should be in the order '{{sortedFlags}}'.",
         },
         type: "suggestion", // "problem",
     },
@@ -29,16 +28,14 @@ export default createRule("sort-flags", {
                 .join("")
         }
 
-        /**
-         * Create visitor
-         */
-        function createVisitor({
+        /** The logic of this rule */
+        function visit({
             regexpNode,
             flagsString,
             ownsFlags,
             getFlagsLocation,
             fixReplaceFlags,
-        }: RegExpContext): RegExpVisitor.Handlers {
+        }: RegExpContext | UnparsableRegExpContext) {
             if (flagsString && ownsFlags) {
                 const sortedFlags = sortFlags(flagsString)
                 if (flagsString !== sortedFlags) {
@@ -51,12 +48,15 @@ export default createRule("sort-flags", {
                     })
                 }
             }
-
-            return {} // not visit RegExpNodes
         }
 
         return defineRegexpVisitor(context, {
-            createVisitor,
+            createVisitor(regexpContext) {
+                visit(regexpContext)
+                return {}
+            },
+            visitInvalid: visit,
+            visitUnknown: visit,
         })
     },
 })

--- a/tests/lib/rules/no-non-standard-flag.ts
+++ b/tests/lib/rules/no-non-standard-flag.ts
@@ -24,5 +24,34 @@ tester.run("no-non-standard-flag", rule as any, {
                 },
             ],
         },
+        {
+            code: `RegExp("foo", "l")`,
+            errors: [
+                {
+                    message: "Unexpected non-standard flag 'l'.",
+                    column: 16,
+                },
+            ],
+        },
+        {
+            // unknown pattern
+            code: `RegExp(someVariable, "l")`,
+            errors: [
+                {
+                    message: "Unexpected non-standard flag 'l'.",
+                    column: 23,
+                },
+            ],
+        },
+        {
+            // invalid pattern
+            code: `RegExp("(", "l")`,
+            errors: [
+                {
+                    message: "Unexpected non-standard flag 'l'.",
+                    column: 14,
+                },
+            ],
+        },
     ],
 })

--- a/tests/lib/rules/sort-flags.ts
+++ b/tests/lib/rules/sort-flags.ts
@@ -31,7 +31,8 @@ tester.run("sort-flags", rule as any, {
             output: String.raw`/\w/gimsuy`,
             errors: [
                 {
-                    message: "The flags 'yusimg' should in the order 'gimsuy'.",
+                    message:
+                        "The flags 'yusimg' should be in the order 'gimsuy'.",
                     column: 5,
                 },
             ],
@@ -41,7 +42,8 @@ tester.run("sort-flags", rule as any, {
             output: String.raw`new RegExp("\\w", "gimsuy")`,
             errors: [
                 {
-                    message: "The flags 'yusimg' should in the order 'gimsuy'.",
+                    message:
+                        "The flags 'yusimg' should be in the order 'gimsuy'.",
                     column: 20,
                 },
             ],
@@ -52,8 +54,19 @@ tester.run("sort-flags", rule as any, {
             errors: [
                 {
                     message:
-                        "The flags 'yusimgd' should in the order 'dgimsuy'.",
+                        "The flags 'yusimgd' should be in the order 'dgimsuy'.",
                     column: 20,
+                },
+            ],
+        },
+        {
+            // sort flags even on invalid patterns
+            code: String.raw`new RegExp("\\w)", "ui")`,
+            output: String.raw`new RegExp("\\w)", "iu")`,
+            errors: [
+                {
+                    message: "The flags 'ui' should be in the order 'iu'.",
+                    column: 21,
                 },
             ],
         },


### PR DESCRIPTION
This is the first step for #283.

This PR adds the API for unknown and invalid patterns. `defineRegexpVisitor` now accepts two now functions in addition to the existing `create*Visitor` functions:

```ts
    visitInvalid?: (context: RegExpContextForInvalid) => void
    visitUnknown?: (context: RegExpContextForUnknown) => void
```


2 existing rules benefit from this: 

- `no-non-standard-flag` can now report flags even if we can't parse the pattern of a regex.
- Same for `sort-flags`. The rule is even fixable in some of those cases.

I also slightly changed both rules:

- `no-non-standard-flag` will now report on the `regexpNode` instead of the `patternNode` if the location of the flags is unavailable. I think doesn't change anything right now.
- Fixed a slight grammatical error in the error message of `sort-flags`.