### PR TITLE
Add `mention` function

### DIFF
--- a/lib/rules/control-character-escape.ts
+++ b/lib/rules/control-character-escape.ts
@@ -10,6 +10,7 @@ import {
     defineRegexpVisitor,
 } from "../utils"
 import { isRegexpLiteral } from "../utils/ast-utils/utils"
+import { mentionChar } from "../utils/mention"
 
 const CONTROL_CHARS = new Map<number, string>([
     [0, "\\0"],
@@ -33,7 +34,7 @@ export default createRule("control-character-escape", {
         schema: [],
         messages: {
             unexpected:
-                "Unexpected control character escape '{{actual}}' ({{cp}}). Use '{{expected}}' instead.",
+                "Unexpected control character escape {{actual}}. Use '{{expected}}' instead.",
         },
         type: "suggestion", // "problem",
     },
@@ -77,10 +78,7 @@ export default createRule("control-character-escape", {
                         loc: getRegexpLocation(cNode),
                         messageId: "unexpected",
                         data: {
-                            actual: cNode.raw,
-                            cp: `U+${cNode.value
-                                .toString(16)
-                                .padStart(4, "0")}`,
+                            actual: mentionChar(cNode),
                             expected: expectedRaw,
                         },
                         fix: fixReplaceNode(cNode, expectedRaw),

--- a/lib/rules/no-dupe-characters-character-class.ts
+++ b/lib/rules/no-dupe-characters-character-class.ts
@@ -21,6 +21,7 @@ import { JS } from "refa"
 // eslint-disable-next-line no-restricted-imports -- there's no way around it
 import { toCharSet as uncachedToCharSet } from "regexp-ast-analysis"
 import type { Rule } from "eslint"
+import { mentionChar } from "../utils/mention"
 
 interface Grouping {
     duplicates: {
@@ -160,25 +161,6 @@ function fixRemove(
     })
 }
 
-/**
- * Creates a string that mentions the given element.
- */
-function mention(element: CharacterClassElement): string {
-    /** Creates a "U+FFFF" string */
-    function unicode(value: number): string {
-        return `U+${value.toString(16).padStart(4, "0")}`
-    }
-
-    if (element.type === "Character") {
-        return `'${element.raw}' (${unicode(element.value)})`
-    } else if (element.type === "CharacterClassRange") {
-        return `'${element.raw}' (${unicode(element.min.value)} - ${unicode(
-            element.max.value,
-        )})`
-    }
-    return `'${element.raw}'`
-}
-
 export default createRule("no-dupe-characters-character-class", {
     meta: {
         type: "suggestion",
@@ -218,7 +200,7 @@ export default createRule("no-dupe-characters-character-class", {
                     loc: getRegexpLocation(duplicate),
                     messageId: "duplicate",
                     data: {
-                        duplicate: mention(duplicate),
+                        duplicate: mentionChar(duplicate),
                     },
                     fix: fixRemove(regexpContext, duplicate),
                 })
@@ -228,8 +210,8 @@ export default createRule("no-dupe-characters-character-class", {
                     loc: getRegexpLocation(duplicate),
                     messageId: "duplicateNonObvious",
                     data: {
-                        duplicate: mention(duplicate),
-                        element: mention(element),
+                        duplicate: mentionChar(duplicate),
+                        element: mentionChar(element),
                     },
                     fix: fixRemove(regexpContext, duplicate),
                 })
@@ -250,8 +232,8 @@ export default createRule("no-dupe-characters-character-class", {
                 loc: getRegexpLocation(element),
                 messageId: "overlap",
                 data: {
-                    elementA: mention(element),
-                    elementB: mention(intersectElement),
+                    elementA: mentionChar(element),
+                    elementB: mentionChar(intersectElement),
                     overlap,
                 },
             })
@@ -274,8 +256,8 @@ export default createRule("no-dupe-characters-character-class", {
                 loc: getRegexpLocation(subsetElement),
                 messageId: "subset",
                 data: {
-                    subsetElement: mention(subsetElement),
-                    element: mention(element),
+                    subsetElement: mentionChar(subsetElement),
+                    element: mentionChar(element),
                 },
                 fix: fixRemove(regexpContext, subsetElement),
             })
@@ -296,10 +278,10 @@ export default createRule("no-dupe-characters-character-class", {
                 loc: getRegexpLocation(subsetElement),
                 messageId: "subsetOfMany",
                 data: {
-                    subsetElement: mention(subsetElement),
+                    subsetElement: mentionChar(subsetElement),
                     elements: `'${elements
                         .map((e) => e.raw)
-                        .join("")}' (${elements.map(mention).join(", ")})`,
+                        .join("")}' (${elements.map(mentionChar).join(", ")})`,
                 },
                 fix: fixRemove(regexpContext, subsetElement),
             })

--- a/lib/rules/no-obscure-range.ts
+++ b/lib/rules/no-obscure-range.ts
@@ -13,6 +13,7 @@ import {
     isUseHexEscape,
     isOctalEscape,
 } from "../utils"
+import { mentionChar } from "../utils/mention"
 
 export default createRule("no-obscure-range", {
     meta: {
@@ -34,7 +35,7 @@ export default createRule("no-obscure-range", {
         ],
         messages: {
             unexpected:
-                "Unexpected obscure character range. The characters of '{{range}}' ({{unicode}}) are not obvious.",
+                "Unexpected obscure character range. The characters of {{range}} are not obvious.",
         },
         type: "suggestion", // "problem",
     },
@@ -84,16 +85,12 @@ export default createRule("no-obscure-range", {
                         return
                     }
 
-                    const uMin = `U+${min.value.toString(16).padStart(4, "0")}`
-                    const uMax = `U+${max.value.toString(16).padStart(4, "0")}`
-
                     context.report({
                         node,
                         loc: getRegexpLocation(rNode),
                         messageId: "unexpected",
                         data: {
-                            range: rNode.raw,
-                            unicode: `${uMin} - ${uMax}`,
+                            range: mentionChar(rNode),
                         },
                     })
                 },

--- a/lib/rules/sort-character-class-elements.ts
+++ b/lib/rules/sort-character-class-elements.ts
@@ -11,6 +11,7 @@ import {
     createRule,
     defineRegexpVisitor,
 } from "../utils"
+import { mention } from "../utils/mention"
 
 type CharacterClassElementKind = "\\w" | "\\d" | "\\s" | "\\p" | "*"
 const DEFAULT_ORDER: CharacterClassElementKind[] = [
@@ -61,7 +62,7 @@ export default createRule("sort-character-class-elements", {
         ],
         messages: {
             sortElements:
-                "Expected character class elements to be in ascending order. '{{next}}' should be before '{{prev}}'.",
+                "Expected character class elements to be in ascending order. {{next}} should be before {{prev}}.",
         },
         type: "layout",
     },
@@ -107,8 +108,8 @@ export default createRule("sort-character-class-elements", {
                                     loc: getRegexpLocation(next),
                                     messageId: "sortElements",
                                     data: {
-                                        next: next.raw,
-                                        prev: moveTarget.raw,
+                                        next: mention(next),
+                                        prev: mention(moveTarget),
                                     },
                                     *fix(fixer) {
                                         const nextRange = patternSource.getReplaceRange(

--- a/lib/utils/mention.ts
+++ b/lib/utils/mention.ts
@@ -1,0 +1,64 @@
+import type { CharacterClassElement, Node } from "regexpp/ast"
+
+/** Formats the given Unicode code point as `U+0000`. */
+function formatCodePoint(value: number): string {
+    return `U+${value.toString(16).padStart(4, "0")}`
+}
+
+/**
+ * Creates a string that mentions the given character class element.
+ *
+ * This is a specialized version of {@link mention} that will add
+ * character-related information if possible.
+ */
+export function mentionChar(element: CharacterClassElement): string {
+    if (element.type === "Character") {
+        const value = formatCodePoint(element.value)
+        return `'${escape(element.raw)}' (${value})`
+    }
+    if (element.type === "CharacterClassRange") {
+        const min = formatCodePoint(element.min.value)
+        const max = formatCodePoint(element.max.value)
+        return `'${escape(element.raw)}' (${min} - ${max})`
+    }
+
+    return mention(element)
+}
+
+/**
+ * Creates a string that mentions the given character class element.
+ */
+export function mention(element: Node): string {
+    return `'${escape(element.raw)}'`
+}
+
+/** Escape control characters in the given string */
+function escape(value: string): string {
+    // Escaping has to be done in 2 phases:
+    //  1. Escape all backslash-escaped control characters
+    //  2. Escape all non-escape control character
+    return (
+        value
+            .replace(/\\([\s\S])/g, (m, char) => {
+                if (char.charCodeAt(0) < 0x20) {
+                    return escapeControl(char)
+                }
+                return m
+            })
+            // eslint-disable-next-line no-control-regex -- x
+            .replace(/[\0-\x1f]/g, escapeControl)
+    )
+}
+
+/**
+ * Assuming that the given character is a control character, this function will
+ * return an escape sequence for that character.
+ */
+function escapeControl(control: string): string {
+    // we will allow tabs
+    if (control === "\t") return control
+
+    if (control === "\n") return "\\n"
+    if (control === "\r") return "\\r"
+    return `\\x${control.charCodeAt(0).toString(16).padStart(2, "0")}`
+}

--- a/tests/lib/rules/sort-character-class-elements.ts
+++ b/tests/lib/rules/sort-character-class-elements.ts
@@ -217,13 +217,17 @@ tester.run("sort-character-class-elements", rule as any, {
             ],
         },
         {
-            code: String.raw`const s = "[\\d"+"\\w]"
-            new RegExp(s, 'u')`,
-            output: String.raw`const s = "[\\w\\d"+"]"
-            new RegExp(s, 'u')`,
-            options: [{ order: [] }],
+            code: String.raw`
+            const jsxWhitespaceChars = " \n\r\t";
+            const matchJsxWhitespaceRegex = new RegExp("([" + jsxWhitespaceChars + "]+)");
+            `,
+            output: String.raw`
+            const jsxWhitespaceChars = "\n \r\t";
+            const matchJsxWhitespaceRegex = new RegExp("([" + jsxWhitespaceChars + "]+)");
+            `,
             errors: [
-                "Expected character class elements to be in ascending order. '\\w' should be before '\\d'.",
+                "Expected character class elements to be in ascending order. '\\n' should be before ' '.",
+                "Expected character class elements to be in ascending order. '\t' should be before ' '.",
             ],
         },
     ],


### PR DESCRIPTION
This fixes #231.

This adds 2 new util functions `mention` and `mentionChar`. These functions have the goal of escaping the raw of RegExp AST nodes. 

The escaping follows similar rules as the [`RegExp.prototype.source` escaping](https://tc39.es/ecma262/multipage/text-processing.html#sec-escaperegexppattern). The rules are:

- Escape `\r` and `\n` just like `RegExp.prototype.source`.
- Don't escape tabs.
- Escape all other control characters as hexadecimal.

This escaping is necessary so we don't have awkward line breaks in error messages and so we don't send control characters to the console/terminal.

Right now, I only used these new functions in a few rules. 

@ota-meshi Should we use them within the entire code base? I think we should. What about you?