### PR TITLE
Add `strictTypes` option to `regexp/no-useless-flag` rule

### DIFF
--- a/docs/rules/no-useless-flag.md
+++ b/docs/rules/no-useless-flag.md
@@ -157,13 +157,16 @@ No other flags will be checked.
 {
   "regexp/no-useless-flag": ["error",
     {
-      "ignore": [] // An array of "i", "m", "s", "g" and "y".
+      "ignore": [], // An array of "i", "m", "s", "g" and "y".
+      "strictTypes": true
     }
   ]
 }
 ```
 
 - `ignore` ... An array of flags to ignore from the check.
+- `strictTypes` ... If `true`, strictly check the type of object to determine if the regex instance was used in `search()` and `split()`. Default is `true`. This option is only effective for verifying the `g` and `y` flags.  
+  You cannot off of this option if you are using TypeScript.
 
 ### `"ignore": ["s", "g"]`
 
@@ -179,6 +182,32 @@ var foo = /\w/s;
 /* ✗ BAD */
 var foo = /\w/i;
 var foo = /\w/m;
+```
+
+</eslint-code-block>
+
+### `"strictTypes": false`
+
+<eslint-code-block fix>
+
+```js
+/* eslint regexp/no-useless-flag: ["error", { "strictTypes": false }] */
+
+/* ✓ GOOD */
+const notStr = {}
+notStr.split(/foo/g);
+
+/** @param {object} obj */
+function fn1 (obj) {
+    obj.search(/foo/g);
+}
+
+/* ✗ BAD */
+maybeStr.split(/foo/g); // The type of "maybeStr" cannot be tracked.
+
+function fn2 (maybeStr) {
+    maybeStr.search(/foo/g);
+}
 ```
 
 </eslint-code-block>

--- a/docs/rules/no-useless-flag.md
+++ b/docs/rules/no-useless-flag.md
@@ -166,7 +166,7 @@ No other flags will be checked.
 
 - `ignore` ... An array of flags to ignore from the check.
 - `strictTypes` ... If `true`, strictly check the type of object to determine if the regex instance was used in `search()` and `split()`. Default is `true`. This option is only effective for verifying the `g` and `y` flags.  
-  You cannot off of this option if you are using TypeScript.
+  This option is always on when using TypeScript.
 
 ### `"ignore": ["s", "g"]`
 

--- a/lib/rules/no-useless-flag.ts
+++ b/lib/rules/no-useless-flag.ts
@@ -776,10 +776,12 @@ function createRegExpReferenceExtractVisitor(
  * Parse option
  */
 function parseOption(
-    userOption: {
-        ignore?: ("i" | "m" | "s" | "g" | "y")[]
-        strictTypes?: boolean
-    } | undefined,
+    userOption:
+        | {
+              ignore?: ("i" | "m" | "s" | "g" | "y")[]
+              strictTypes?: boolean
+          }
+        | undefined,
 ) {
     const ignore = new Set<"i" | "m" | "s" | "g" | "y">()
     let strictTypes = true

--- a/lib/rules/no-useless-flag.ts
+++ b/lib/rules/no-useless-flag.ts
@@ -341,7 +341,10 @@ function createUselessDotAllFlagVisitor(context: Rule.RuleContext) {
 /**
  * Create visitor for verify unnecessary g flag
  */
-function createUselessGlobalFlagVisitor(context: Rule.RuleContext) {
+function createUselessGlobalFlagVisitor(
+    context: Rule.RuleContext,
+    strictTypes: boolean,
+) {
     const enum ReportKind {
         // It is used only in "split".
         usedOnlyInSplit,
@@ -469,13 +472,17 @@ function createUselessGlobalFlagVisitor(context: Rule.RuleContext) {
                 "replaceAll",
             ])
         },
+        strictTypes,
     })
 }
 
 /**
  * Create visitor for verify unnecessary y flag
  */
-function createUselessStickyFlagVisitor(context: Rule.RuleContext) {
+function createUselessStickyFlagVisitor(
+    context: Rule.RuleContext,
+    strictTypes: boolean,
+) {
     type ReportData = { fixable?: boolean }
 
     /**
@@ -551,6 +558,7 @@ function createUselessStickyFlagVisitor(context: Rule.RuleContext) {
                 "replaceAll",
             ])
         },
+        strictTypes,
     })
 }
 
@@ -563,10 +571,12 @@ function createRegExpReferenceExtractVisitor(
         flag,
         exit,
         isUsedShortCircuit,
+        strictTypes,
     }: {
         flag: "global" | "sticky"
         exit: (list: RegExpReference[]) => void
         isUsedShortCircuit: (regExpReference: RegExpReference) => boolean
+        strictTypes: boolean
     },
 ) {
     const typeTracer = createTypeTracker(context)
@@ -585,7 +595,11 @@ function createRegExpReferenceExtractVisitor(
         if (regExpReference == null || isUsedShortCircuit(regExpReference)) {
             return
         }
-        if (!typeTracer.isString(node.callee.object)) {
+        if (
+            strictTypes
+                ? !typeTracer.isString(node.callee.object)
+                : !typeTracer.maybeString(node.callee.object)
+        ) {
             regExpReference.markAsCannotTrack()
             return
         }
@@ -758,6 +772,32 @@ function createRegExpReferenceExtractVisitor(
     )
 }
 
+/**
+ * Parse option
+ */
+function parseOption(
+    userOption: {
+        ignore?: ("i" | "m" | "s" | "g" | "y")[]
+        strictTypes?: boolean
+    } | void,
+) {
+    const ignore = new Set<"i" | "m" | "s" | "g" | "y">()
+    let strictTypes = true
+    if (userOption) {
+        for (const i of userOption.ignore ?? []) {
+            ignore.add(i)
+        }
+        if (userOption.strictTypes != null) {
+            strictTypes = userOption.strictTypes
+        }
+    }
+
+    return {
+        ignore,
+        strictTypes,
+    }
+}
+
 export default createRule("no-useless-flag", {
     meta: {
         docs: {
@@ -780,6 +820,7 @@ export default createRule("no-useless-flag", {
                         },
                         uniqueItems: true,
                     },
+                    strictTypes: { type: "boolean" },
                 },
                 additionalProperties: false,
             },
@@ -807,9 +848,7 @@ export default createRule("no-useless-flag", {
         type: "suggestion", // "problem",
     },
     create(context) {
-        const ignore = new Set<"i" | "m" | "s" | "g" | "y">(
-            context.options[0]?.ignore ?? [],
-        )
+        const { ignore, strictTypes } = parseOption(context.options[0])
 
         let visitor: RuleListener = {}
         if (!ignore.has("i")) {
@@ -833,13 +872,13 @@ export default createRule("no-useless-flag", {
         if (!ignore.has("g")) {
             visitor = compositingVisitors(
                 visitor,
-                createUselessGlobalFlagVisitor(context),
+                createUselessGlobalFlagVisitor(context, strictTypes),
             )
         }
         if (!ignore.has("y")) {
             visitor = compositingVisitors(
                 visitor,
-                createUselessStickyFlagVisitor(context),
+                createUselessStickyFlagVisitor(context, strictTypes),
             )
         }
         return visitor

--- a/lib/rules/no-useless-flag.ts
+++ b/lib/rules/no-useless-flag.ts
@@ -779,7 +779,7 @@ function parseOption(
     userOption: {
         ignore?: ("i" | "m" | "s" | "g" | "y")[]
         strictTypes?: boolean
-    } | void,
+    } | undefined,
 ) {
     const ignore = new Set<"i" | "m" | "s" | "g" | "y">()
     let strictTypes = true

--- a/lib/utils/type-tracker/index.ts
+++ b/lib/utils/type-tracker/index.ts
@@ -46,6 +46,7 @@ const ts: typeof import("typescript") = (() => {
 
 type TypeTracker = {
     isString: (node: ES.Expression) => boolean
+    maybeString: (node: ES.Expression) => boolean
     isRegExp: (node: ES.Expression) => boolean
     getTypes: (node: ES.Expression) => string[]
 }
@@ -73,6 +74,7 @@ export function createTypeTracker(context: Rule.RuleContext): TypeTracker {
 
     const tracker: TypeTracker = {
         isString,
+        maybeString,
         isRegExp,
         getTypes,
     }
@@ -84,6 +86,19 @@ export function createTypeTracker(context: Rule.RuleContext): TypeTracker {
      */
     function isString(node: ES.Expression): boolean {
         return hasType(getType(node), "String")
+    }
+
+    /**
+     * Checks if the given node is maybe string.
+     */
+    function maybeString(node: ES.Expression): boolean {
+        if (isString(node)) {
+            return true
+        }
+        if (availableTS) {
+            return false
+        }
+        return getType(node) == null
     }
 
     /**

--- a/tests/lib/rules/no-useless-flag.ts
+++ b/tests/lib/rules/no-useless-flag.ts
@@ -106,6 +106,12 @@ tester.run("no-useless-flag", rule as any, {
         const regex = /foo/g;
         unknown.exec(regex)
         `,
+        `
+        const notStr = {}
+        notStr.split(/foo/g);
+        
+        maybeStr.split(/foo/g);
+        `,
 
         // y
         `
@@ -551,6 +557,48 @@ tester.run("no-useless-flag", rule as any, {
                 "The 'g' flag is unnecessary because 'String.prototype.split' ignores the 'g' flag.",
             ],
         },
+        {
+            code: `
+            const notStr = {}
+            notStr.split(/foo/g);
+
+            maybeStr.split(/foo/g);
+            `,
+            output: `
+            const notStr = {}
+            notStr.split(/foo/g);
+
+            maybeStr.split(/foo/);
+            `,
+            options: [{ strictTypes: false }],
+            errors: [
+                "The 'g' flag is unnecessary because 'String.prototype.split' ignores the 'g' flag.",
+            ],
+        },
+        {
+            code: `
+            /** @param {object} obj */
+            function fn1 (obj) {
+                obj.search(/foo/g);
+            }
+            function fn2 (maybeStr) {
+                maybeStr.split(/foo/g);
+            }
+            `,
+            output: `
+            /** @param {object} obj */
+            function fn1 (obj) {
+                obj.search(/foo/g);
+            }
+            function fn2 (maybeStr) {
+                maybeStr.split(/foo/);
+            }
+            `,
+            options: [{ strictTypes: false }],
+            errors: [
+                "The 'g' flag is unnecessary because 'String.prototype.split' ignores the 'g' flag.",
+            ],
+        },
 
         // y
         {
@@ -651,6 +699,24 @@ tester.run("no-useless-flag", rule as any, {
                     line: 2,
                     column: 28,
                 },
+            ],
+        },
+        {
+            code: `
+            const notStr = {}
+            notStr.split(/foo/y);
+
+            maybeStr.split(/foo/y);
+            `,
+            output: `
+            const notStr = {}
+            notStr.split(/foo/y);
+
+            maybeStr.split(/foo/);
+            `,
+            options: [{ strictTypes: false }],
+            errors: [
+                "The 'y' flag is unnecessary because 'String.prototype.split' ignores the 'y' flag.",
             ],
         },
 


### PR DESCRIPTION
This PR adds the `strictTypes` option to the `regexp/no-useless-flag` rule.
The user can loosen the type check by specifying `false` for `strictTypes`.

close #205