### PR TITLE
Fix `no-useless-lazy` for quantifiers with min=0

### DIFF
--- a/lib/rules/no-useless-lazy.ts
+++ b/lib/rules/no-useless-lazy.ts
@@ -94,7 +94,7 @@ export default createRule("no-useless-lazy", {
 
                     const matchingDir = getMatchingDirection(qNode)
                     const firstChar = getFirstConsumedChar(
-                        qNode,
+                        qNode.element,
                         matchingDir,
                         flags,
                     )

--- a/tests/lib/rules/no-useless-lazy.ts
+++ b/tests/lib/rules/no-useless-lazy.ts
@@ -73,6 +73,11 @@ tester.run("no-useless-lazy", rule as any, {
             errors: [{ messageId: "possessive" }],
         },
         {
+            code: `/a*?b+/`,
+            output: `/a*b+/`,
+            errors: [{ messageId: "possessive" }],
+        },
+        {
             code: `/(?:a|cd)+?(?:b+|zzz)/`,
             output: `/(?:a|cd)+(?:b+|zzz)/`,
             errors: [{ messageId: "possessive" }],


### PR DESCRIPTION
`no-useless-lazy` did not report uselessly lazy quantifiers with a minimum of 0 because the first consumed character was determined for the quantifier and not for the quantified element.