### PR TITLE
Update `regexp-ast-analysis@0.2.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13226,9 +13226,9 @@
             }
         },
         "regexp-ast-analysis": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.3.tgz",
-            "integrity": "sha512-K/6d90dP1DI68HHdHORj9vVxV5oWkLB8F7LeGs70EdA/h5BIqkrK8SdGy+O9Ii+AVVPprF0Ia6f5UwgI+ahIcw==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.4.tgz",
+            "integrity": "sha512-8L7kOZQaKPxKKAwGuUZxTQtlO3WZ+tiXy4s6G6PKL6trbOXcZoumwC3AOHHFtI/xoSbNxt7jgLvCnP1UADLWqg==",
             "requires": {
                 "refa": "^0.9.0",
                 "regexpp": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "eslint-utils": "^3.0.0",
         "jsdoctypeparser": "^9.0.0",
         "refa": "^0.9.0",
-        "regexp-ast-analysis": "^0.2.3",
+        "regexp-ast-analysis": "^0.2.4",
         "regexpp": "^3.2.0",
         "scslre": "^0.1.6"
     }


### PR DESCRIPTION
I found and fixed a nasty bug in `regexp-ast-analysis` today. All `getFirst*Char*` functions could potentially take a long time to when (directly or indirectly) dealing with word boundary assertions. So one call to `getFirstCharAfter` would take a second or longer for the right regex.