### PR TITLE
Improve `sort-alternatives`

### DIFF
--- a/tests/lib/rules/sort-alternatives.ts
+++ b/tests/lib/rules/sort-alternatives.ts
@@ -9,7 +9,7 @@ const tester = new RuleTester({
 })
 
 tester.run("sort-alternatives", rule as any, {
-    valid: [String.raw`/\b(?:a|\d+|c|b)\b/`],
+    valid: [String.raw`/\b(?:a|\d+|c|b)\b/`, String.raw`/\b(?:\^|c|b)\b/`],
     invalid: [
         {
             code: String.raw`/c|b|a/`,
@@ -99,6 +99,16 @@ tester.run("sort-alternatives", rule as any, {
         {
             code: String.raw`/\((?:TM|R|C)\)/`,
             output: String.raw`/\((?:C|R|TM)\)/`,
+            errors: [
+                "The alternatives of this group can be sorted without affecting the regex.",
+            ],
+        },
+
+        // sorting slices
+
+        {
+            code: String.raw`/\b(?:\^|c|b|a)\b/`,
+            output: String.raw`/\b(?:\^|a|b|c)\b/`,
             errors: [
                 "The alternatives of this group can be sorted without affecting the regex.",
             ],


### PR DESCRIPTION
This improves `sort-alternatives` in 2 ways:

1) I added a few more punctuation characters to the list of allowed characters. This will allow the rule for sort more alternatives.

2) The rule can now sort slices. A slice is a continuous section of alternatives (basically the result of calling `alternatives.slice(start, end)`).

   One of the problems of this rule was that adding even one alternative containing forbidden characters meant that the whole group couldn't be sorted anymore. This has now been addressed using slices. Instead of trying to sort the group, the rule will now try to find slices within the group and sort those.

    This has the nice consequence that you can now add alternatives with forbidden characters to a group and most of the group will still be sortable.

   ![image](https://user-images.githubusercontent.com/20878432/129257475-12c60e36-e5c3-4733-8b3d-f9a5baa2a12c.png)
