### PR TITLE
Remove unnecessary `plugins` option for the recommended config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install --save-dev eslint eslint-plugin-regexp
 <!--USAGE_SECTION_START-->
 
 Add `regexp` to the plugins section of your `.eslintrc` configuration file (you can omit the `eslint-plugin-` prefix)
-and either use one of the two configurations available (`recommended` or `all`) or configure the rules you want:
+and configure the rules you want or either use one of the two configurations available (`recommended` or `all`):
 
 ### The recommended configuration
 
@@ -56,9 +56,6 @@ The `plugin:regexp/recommended` config enables a subset of [the rules](#white_ch
 ```js
 // .eslintrc.js
 module.exports = {
-    "plugins": [
-        "regexp"
-    ],
     "extends": [
          // add more generic rulesets here, such as:
          // 'eslint:recommended',

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -18,7 +18,7 @@ npm install --save-dev eslint eslint-plugin-regexp
 <!--USAGE_SECTION_START-->
 
 Add `regexp` to the plugins section of your `.eslintrc` configuration file (you can omit the `eslint-plugin-` prefix)
-and either use one of the two configurations available (`recommended` or `all`) or configure the rules you want:
+and configure the rules you want or either use one of the two configurations available (`recommended` or `all`):
 
 ### The recommended configuration
 
@@ -28,9 +28,6 @@ The `plugin:regexp/recommended` config enables a subset of [the rules](../rules/
 ```js
 // .eslintrc.js
 module.exports = {
-    "plugins": [
-        "regexp"
-    ],
     "extends": [
          // add more generic rulesets here, such as:
          // 'eslint:recommended',


### PR DESCRIPTION
The `plugins` option can be removed from the example since it is already included in the sharable configs. But please feel free to close this if it is intentionally left in.