### PR TITLE
Avoid double reporting + flags API improvements

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -330,10 +330,12 @@ function buildRegexpVisitor(
         visitRegExpAST(parsedPattern, createVisitor(helpers))
     }
 
+    const ownedRegExpLiterals = new Set<ESTree.RegExpLiteral>()
+
     return {
         "Program:exit": programExit,
         Literal(node: ESTree.Literal) {
-            if (!isRegexpLiteral(node)) {
+            if (!isRegexpLiteral(node) || ownedRegExpLiterals.has(node)) {
                 return
             }
             const flagsString = node.regex.flags
@@ -374,6 +376,11 @@ function buildRegexpVisitor(
                     context,
                     patternNode,
                 )
+
+                // avoid double reporting
+                patternSource
+                    ?.getOwnedRegExpLiterals()
+                    .forEach((n) => ownedRegExpLiterals.add(n))
 
                 let flagsString = null
                 let ownsFlags = false

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -13,7 +13,11 @@ import type { CharSet } from "refa"
 import { JS } from "refa"
 import type { UsageOfPattern } from "./get-usage-of-pattern"
 import { getUsageOfPattern } from "./get-usage-of-pattern"
-import { isRegexpLiteral, isStringLiteral } from "./ast-utils/utils"
+import {
+    getStringValueRange,
+    isRegexpLiteral,
+    isStringLiteral,
+} from "./ast-utils/utils"
 import type { PatternRange } from "./ast-utils/pattern-source"
 import { PatternSource } from "./ast-utils/pattern-source"
 export * from "./unicode"
@@ -40,11 +44,14 @@ type RegExpContextBase = {
     ) => AST.SourceLocation
 
     /**
-     * Creates SourceLocation from the regexp flags
-     *
-     * @returns The SourceLocation
+     * Creates SourceLocation of the regexp flags
      */
     getFlagsLocation: () => AST.SourceLocation
+
+    /**
+     * Creates SourceLocation of the regexp flag
+     */
+    getFlagLocation: (flag: string) => AST.SourceLocation
 
     /**
      * Creates a new fix that replaces the given node with a given string.
@@ -107,11 +114,14 @@ type UnparsableRegExpContextBase = {
     ownsFlags: boolean
 
     /**
-     * Creates SourceLocation from the regexp flags
-     *
-     * @returns The SourceLocation
+     * Creates SourceLocation of the regexp flags
      */
     getFlagsLocation: () => AST.SourceLocation
+
+    /**
+     * Creates SourceLocation of the regexp flag
+     */
+    getFlagLocation: (flag: string) => AST.SourceLocation
 
     fixReplaceFlags: (
         newFlags: string | (() => string | null),
@@ -263,6 +273,7 @@ function buildRegexpVisitor(
      */
     function verify(
         patternNode: ESTree.Expression,
+        flagsNode: ESTree.Expression | null,
         regexpNode: ESTree.RegExpLiteral | ESTree.CallExpression,
         patternSource: PatternSource | null,
         flagsString: string | null,
@@ -283,6 +294,7 @@ function buildRegexpVisitor(
                     context,
                     flags,
                     flagsString,
+                    flagsNode,
                     ownsFlags,
                 }),
             })
@@ -312,6 +324,7 @@ function buildRegexpVisitor(
                         context,
                         flags,
                         flagsString,
+                        flagsNode,
                         ownsFlags,
                     }),
                 })
@@ -322,6 +335,7 @@ function buildRegexpVisitor(
         const helpers = buildRegExpContextBase({
             patternSource,
             regexpNode,
+            flagsNode,
             context,
             flags,
             parsedPattern,
@@ -340,15 +354,23 @@ function buildRegexpVisitor(
             }
             const flagsString = node.regex.flags
             const patternSource = PatternSource.fromRegExpLiteral(context, node)
-            verify(node, node, patternSource, flagsString, true, (base) => {
-                return createLiteralVisitorFromRules(rules, {
-                    node,
-                    flagsString,
-                    ownsFlags: true,
-                    regexpNode: node,
-                    ...base,
-                })
-            })
+            verify(
+                node,
+                node,
+                node,
+                patternSource,
+                flagsString,
+                true,
+                (base) => {
+                    return createLiteralVisitorFromRules(rules, {
+                        node,
+                        flagsString,
+                        ownsFlags: true,
+                        regexpNode: node,
+                        ...base,
+                    })
+                },
+            )
         },
         Program() {
             const tracker = new ReferenceTracker(context.getScope())
@@ -360,6 +382,7 @@ function buildRegexpVisitor(
                 call: ESTree.CallExpression
                 patternNode: ESTree.Expression
                 patternSource: PatternSource | null
+                flagsNode: ESTree.Expression | null
                 flagsString: string | null
                 ownsFlags: boolean
             }[] = []
@@ -367,14 +390,19 @@ function buildRegexpVisitor(
                 RegExp: { [CALL]: true, [CONSTRUCT]: true },
             })) {
                 const newOrCall = node as ESTree.CallExpression
-                const [patternNode, flagsNode] = newOrCall.arguments
-                if (!patternNode || patternNode.type === "SpreadElement") {
+                const args = newOrCall.arguments as (
+                    | ESTree.Expression
+                    | ESTree.SpreadElement
+                    | undefined
+                )[]
+                const [patternArg, flagsArg] = args
+                if (!patternArg || patternArg.type === "SpreadElement") {
                     continue
                 }
 
                 const patternSource = PatternSource.fromExpression(
                     context,
-                    patternNode,
+                    patternArg,
                 )
 
                 // avoid double reporting
@@ -382,20 +410,26 @@ function buildRegexpVisitor(
                     ?.getOwnedRegExpLiterals()
                     .forEach((n) => ownedRegExpLiterals.add(n))
 
+                let flagsNode = null
                 let flagsString = null
                 let ownsFlags = false
-                if (flagsNode && flagsNode.type !== "SpreadElement") {
-                    flagsString = getStringIfConstant(context, flagsNode)
-                    ownsFlags = isStringLiteral(flagsNode)
+                if (flagsArg) {
+                    if (flagsArg.type !== "SpreadElement") {
+                        flagsNode = flagsArg
+                        flagsString = getStringIfConstant(context, flagsArg)
+                        ownsFlags = isStringLiteral(flagsArg)
+                    }
                 } else if (patternSource && patternSource.regexpValue) {
                     flagsString = patternSource.regexpValue.flags
                     ownsFlags = Boolean(patternSource.regexpValue.ownedNode)
+                    flagsNode = patternSource.regexpValue.ownedNode
                 }
 
                 regexpDataList.push({
                     call: newOrCall,
-                    patternNode,
+                    patternNode: patternArg,
                     patternSource,
+                    flagsNode,
                     flagsString,
                     ownsFlags,
                 })
@@ -405,11 +439,13 @@ function buildRegexpVisitor(
                 call,
                 patternNode,
                 patternSource,
+                flagsNode,
                 flagsString,
                 ownsFlags,
             } of regexpDataList) {
                 verify(
                     patternNode,
+                    flagsNode,
                     call,
                     patternSource,
                     flagsString,
@@ -540,12 +576,14 @@ export function compositingVisitors(
 function buildRegExpContextBase({
     patternSource,
     regexpNode,
+    flagsNode,
     context,
     flags,
     parsedPattern,
 }: {
     patternSource: PatternSource
     regexpNode: ESTree.CallExpression | ESTree.RegExpLiteral
+    flagsNode: ESTree.Expression | null
     context: Rule.RuleContext
     flags: ReadonlyFlags
     parsedPattern: Pattern
@@ -578,7 +616,10 @@ function buildRegExpContextBase({
             }
             return patternSource.getAstLocation(range)
         },
-        getFlagsLocation: () => getFlagsLocation(sourceCode, regexpNode),
+        getFlagsLocation: () =>
+            getFlagsLocation(sourceCode, regexpNode, flagsNode),
+        getFlagLocation: (flag) =>
+            getFlagLocation(sourceCode, regexpNode, flagsNode, flag),
         fixReplaceNode: (node, replacement) => {
             return fixReplaceNode(patternSource, node, replacement)
         },
@@ -586,7 +627,12 @@ function buildRegExpContextBase({
             return fixReplaceQuant(patternSource, qNode, replacement)
         },
         fixReplaceFlags: (newFlags) => {
-            return fixReplaceFlags(patternSource, regexpNode, newFlags)
+            return fixReplaceFlags(
+                patternSource,
+                regexpNode,
+                flagsNode,
+                newFlags,
+            )
         },
         getUsageOfPattern: () =>
             (cacheUsageOfPattern ??= getUsageOfPattern(regexpNode, context)),
@@ -608,6 +654,7 @@ function buildUnparsableRegExpContextBase({
     context,
     flags,
     flagsString,
+    flagsNode,
     ownsFlags,
 }: {
     patternSource: PatternSource | null
@@ -616,6 +663,7 @@ function buildUnparsableRegExpContextBase({
     context: Rule.RuleContext
     flags: ReadonlyFlags
     flagsString: string | null
+    flagsNode: ESTree.Expression | null
     ownsFlags: boolean
 }): UnparsableRegExpContextBase {
     const sourceCode = context.getSourceCode()
@@ -628,42 +676,48 @@ function buildUnparsableRegExpContextBase({
         flagsString,
         ownsFlags,
 
-        getFlagsLocation: () => getFlagsLocation(sourceCode, regexpNode),
+        getFlagsLocation: () =>
+            getFlagsLocation(sourceCode, regexpNode, flagsNode),
+        getFlagLocation: (flag) =>
+            getFlagLocation(sourceCode, regexpNode, flagsNode, flag),
 
         fixReplaceFlags: (newFlags) => {
             if (!patternSource) {
                 return () => null
             }
-            return fixReplaceFlags(patternSource, regexpNode, newFlags)
+            return fixReplaceFlags(
+                patternSource,
+                regexpNode,
+                flagsNode,
+                newFlags,
+            )
         },
     }
 }
 
-function getFlagsRange(regexpNode: ESTree.RegExpLiteral): AST.Range
-function getFlagsRange(
-    regexpNode: ESTree.CallExpression | ESTree.RegExpLiteral,
+export function getFlagsRange(flagsNode: ESTree.RegExpLiteral): AST.Range
+export function getFlagsRange(
+    flagsNode: ESTree.Expression | null,
 ): AST.Range | null
 /**
  * Creates source range of the flags of the given regexp node
- * @param regexpNode The regexp node to report.
- * @returns The SourceLocation
+ * @param flagsNode The expression that contributes the flags.
  */
-function getFlagsRange(
-    regexpNode: ESTree.CallExpression | ESTree.RegExpLiteral,
+export function getFlagsRange(
+    flagsNode: ESTree.Expression | null,
 ): AST.Range | null {
-    if (isRegexpLiteral(regexpNode)) {
+    if (!flagsNode) {
+        return null
+    }
+
+    if (isRegexpLiteral(flagsNode)) {
         return [
-            regexpNode.range![1] - regexpNode.regex.flags.length,
-            regexpNode.range![1],
+            flagsNode.range![1] - flagsNode.regex.flags.length,
+            flagsNode.range![1],
         ]
     }
-    const flagsArg = regexpNode.arguments[1]
-    if (
-        flagsArg &&
-        flagsArg.type === "Literal" &&
-        typeof flagsArg.value === "string"
-    ) {
-        return [flagsArg.range![0] + 1, flagsArg.range![1] - 1]
+    if (isStringLiteral(flagsNode)) {
+        return [flagsNode.range![0] + 1, flagsNode.range![1] - 1]
     }
 
     return null
@@ -673,15 +727,67 @@ function getFlagsRange(
  * Creates SourceLocation of the flags of the given regexp node
  * @param sourceCode The ESLint source code instance.
  * @param regexpNode The node to report.
- * @returns The SourceLocation
  */
-function getFlagsLocation(
+export function getFlagsLocation(
     sourceCode: SourceCode,
     regexpNode: ESTree.CallExpression | ESTree.RegExpLiteral,
+    flagsNode: ESTree.Expression | null,
 ): AST.SourceLocation {
-    const range = getFlagsRange(regexpNode)
+    const range = getFlagsRange(flagsNode)
     if (range == null) {
-        return regexpNode.loc!
+        return flagsNode?.loc ?? regexpNode.loc!
+    }
+    return {
+        start: sourceCode.getLocFromIndex(range[0]),
+        end: sourceCode.getLocFromIndex(range[1]),
+    }
+}
+
+/**
+ * Creates source range of the given flag in the given flags node
+ * @param flagsNode The expression that contributes the flags.
+ */
+function getFlagRange(
+    sourceCode: SourceCode,
+    flagsNode: ESTree.Expression | null,
+    flag: string,
+): AST.Range | null {
+    if (!flagsNode || !flag) {
+        return null
+    }
+
+    if (isRegexpLiteral(flagsNode)) {
+        const index = flagsNode.regex.flags.indexOf(flag)
+        if (index === -1) {
+            return null
+        }
+        const start = flagsNode.range![1] - flagsNode.regex.flags.length + index
+        return [start, start + 1]
+    }
+    if (isStringLiteral(flagsNode)) {
+        const index = flagsNode.value.indexOf(flag)
+        if (index === -1) {
+            return null
+        }
+        return getStringValueRange(sourceCode, flagsNode, index, index + 1)
+    }
+
+    return null
+}
+
+/**
+ * Creates source location of the given flag in the given flags node
+ * @param flagsNode The expression that contributes the flags.
+ */
+function getFlagLocation(
+    sourceCode: SourceCode,
+    regexpNode: ESTree.CallExpression | ESTree.RegExpLiteral,
+    flagsNode: ESTree.Expression | null,
+    flag: string,
+): AST.SourceLocation {
+    const range = getFlagRange(sourceCode, flagsNode, flag)
+    if (range == null) {
+        return flagsNode?.loc ?? regexpNode.loc!
     }
     return {
         start: sourceCode.getLocFromIndex(range[0]),
@@ -772,6 +878,7 @@ function fixReplaceQuant(
 function fixReplaceFlags(
     patternSource: PatternSource,
     regexpNode: ESTree.CallExpression | ESTree.RegExpLiteral,
+    flagsNode: ESTree.Expression | null,
     replacement: string | (() => string | null),
 ) {
     return (fixer: Rule.RuleFixer): Rule.Fix[] | Rule.Fix | null => {
@@ -800,7 +907,7 @@ function fixReplaceFlags(
             )
         }
 
-        const range = getFlagsRange(regexpNode)
+        const range = getFlagsRange(flagsNode)
         if (range == null) {
             return null
         }

--- a/tests/lib/rules/no-dupe-characters-character-class.ts
+++ b/tests/lib/rules/no-dupe-characters-character-class.ts
@@ -79,6 +79,16 @@ tester.run("no-dupe-characters-character-class", rule as any, {
             ],
         },
         {
+            code: "RegExp(/[bb]/)",
+            output: "RegExp(/[b]/)",
+            errors: [
+                {
+                    message: "Unexpected duplicate 'b' (U+0062).",
+                    column: 11,
+                },
+            ],
+        },
+        {
             code:
                 "/[\\s \\f\\n\\r\\t\\v\\u00a0\\u1680\\u180e\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff]/",
             output: "/[\\s\\f\\r\\v\\u1680\\u180e\\u2028\\u202f\\u3000]/",

--- a/tests/lib/rules/no-useless-flag.ts
+++ b/tests/lib/rules/no-useless-flag.ts
@@ -109,7 +109,7 @@ tester.run("no-useless-flag", rule as any, {
         `
         const notStr = {}
         notStr.split(/foo/g);
-        
+
         maybeStr.split(/foo/g);
         `,
 
@@ -214,6 +214,10 @@ tester.run("no-useless-flag", rule as any, {
         { code: String.raw`/\w/m`, options: [{ ignore: ["m"] }] },
         { code: String.raw`/\w/s`, options: [{ ignore: ["s"] }] },
         { code: `/foo/g.test(string)`, options: [{ ignore: ["g"] }] },
+        String.raw`
+        const orig = /\w/i; // eslint-disable-line
+        const clone = new RegExp(orig);
+        `,
     ],
     invalid: [
         // i
@@ -401,9 +405,9 @@ tester.run("no-useless-flag", rule as any, {
                     message:
                         "The 'g' flag is unnecessary because the regex is used only once in 'RegExp.prototype.test'.",
                     line: 25,
-                    column: 31,
+                    column: 32,
                     endLine: 25,
-                    endColumn: 34,
+                    endColumn: 33,
                 },
                 {
                     message:
@@ -459,7 +463,7 @@ tester.run("no-useless-flag", rule as any, {
                     message:
                         "The 'g' flag is unnecessary because the regex is used only once in 'RegExp.prototype.test'.",
                     line: 2,
-                    column: 31,
+                    column: 32,
                 },
             ],
         },
@@ -608,17 +612,17 @@ tester.run("no-useless-flag", rule as any, {
             const str = 'table football, foosball';
             regex1.lastIndex = 6
             var array = regex1.exec(str)
-            
+
             const regex2 = /foo/y;
             regex2.test(string);
             regex2.test(string);
-            
+
             str.replace(/foo/y, 'bar');
             str.replaceAll(/foo/gy, 'bar');
 
             const regexp3 = /foo/y
             str.search(regexp3)
-            
+
             /* ✗ BAD */
             str.split(/foo/y);
             `,
@@ -628,17 +632,17 @@ tester.run("no-useless-flag", rule as any, {
             const str = 'table football, foosball';
             regex1.lastIndex = 6
             var array = regex1.exec(str)
-            
+
             const regex2 = /foo/y;
             regex2.test(string);
             regex2.test(string);
-            
+
             str.replace(/foo/y, 'bar');
             str.replaceAll(/foo/gy, 'bar');
 
             const regexp3 = /foo/y
             str.search(regexp3)
-            
+
             /* ✗ BAD */
             str.split(/foo/);
             `,
@@ -679,7 +683,7 @@ tester.run("no-useless-flag", rule as any, {
                     message:
                         "The 'y' flag is unnecessary because 'String.prototype.split' ignores the 'y' flag.",
                     line: 2,
-                    column: 43,
+                    column: 44,
                 },
             ],
         },
@@ -724,21 +728,6 @@ tester.run("no-useless-flag", rule as any, {
         {
             code: String.raw`
             const orig = /\w/i; // eslint-disable-line
-            const clone = new RegExp(orig);
-            `,
-            output: null,
-            errors: [
-                {
-                    message:
-                        "The 'i' flag is unnecessary because the pattern only contains case-invariant characters.",
-                    line: 3,
-                    column: 42,
-                },
-            ],
-        },
-        {
-            code: String.raw`
-            const orig = /\w/i; // eslint-disable-line
             const clone = new RegExp(orig, 'i');
             `,
             output: String.raw`
@@ -750,18 +739,36 @@ tester.run("no-useless-flag", rule as any, {
                     message:
                         "The 'i' flag is unnecessary because the pattern only contains case-invariant characters.",
                     line: 3,
-                    column: 44,
+                    column: 45,
+                },
+            ],
+        },
+        {
+            code: String.raw`
+            const orig = /\w/iy;
+            const clone = new RegExp(orig, '');
+            `,
+            output: String.raw`
+            const orig = /\w/;
+            const clone = new RegExp(orig, '');
+            `,
+            errors: [
+                {
+                    message:
+                        "The flags of this RegExp literal are useless because only the source of the regex is used.",
+                    line: 2,
+                    column: 30,
                 },
             ],
         },
         {
             code: String.raw`
             const orig = /\w/i;
-            const clone = new RegExp(orig, '');
+            const clone = new RegExp(orig);
             `,
             output: String.raw`
             const orig = /\w/;
-            const clone = new RegExp(orig, '');
+            const clone = new RegExp(orig);
             `,
             errors: [
                 {
@@ -773,6 +780,18 @@ tester.run("no-useless-flag", rule as any, {
             ],
         },
         {
+            code: String.raw`RegExp(/\w/i);`,
+            output: String.raw`RegExp(/\w/);`,
+            errors: [
+                {
+                    message:
+                        "The 'i' flag is unnecessary because the pattern only contains case-invariant characters.",
+                    line: 1,
+                    column: 12,
+                },
+            ],
+        },
+        {
             code: String.raw`
             const orig = /\w/;
             const clone = new RegExp(orig, 'i');
@@ -786,7 +805,19 @@ tester.run("no-useless-flag", rule as any, {
                     message:
                         "The 'i' flag is unnecessary because the pattern only contains case-invariant characters.",
                     line: 3,
-                    column: 44,
+                    column: 45,
+                },
+            ],
+        },
+        {
+            code: String.raw`RegExp(/\w/imu.source);`,
+            output: String.raw`RegExp(/\w/u.source);`,
+            errors: [
+                {
+                    message:
+                        "The flags of this RegExp literal are useless because only the source of the regex is used.",
+                    line: 1,
+                    column: 12,
                 },
             ],
         },


### PR DESCRIPTION
Fixes #304.

---

This turned out to be more difficult than I thought. Avoiding double reporting was easy enough (you can see that in the first commit). But changing `no-useless-flag` wasn't.

### Changes

Double reporting is now fixed:
![image](https://user-images.githubusercontent.com/20878432/129450838-11578552-3734-4c2d-83a9-3611bd64e09a.png)


As for `no-useless-flag`:

- Added a new category of useless flags: The flags of regexp literals that are only used by source. E.g. `/foo/i.source`, `RegExp(/foo/i, '')`

     ![image](https://user-images.githubusercontent.com/20878432/129450806-6eff2e71-727a-4228-9bb7-320405ac75aa.png)


- Improved `getFlagsLocation`. The function now has access to the flags argument directly which makes the whole thing easier to implement.
- Added `getFlagLocation`. This replaces the logic `no-useless-flag` formerly implemented in a private function. It's error locations are more precise because it has access to more information.
 
    Old:
    ![image](https://user-images.githubusercontent.com/20878432/129450785-45cd56b3-2834-45a9-a52e-997ef8efe5a2.png)

    New:
    ![image](https://user-images.githubusercontent.com/20878432/129450788-17a498e8-e5be-4d09-ab7e-20eccf0e6051.png)
