### PR TITLE
Add test for ESLint v8

### DIFF
--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -44,7 +44,7 @@ jobs:
                   node-version: 12.13.x
             - name: Install Target Packages
               run: |+
-                  npm install
+                  npm ci
                   npm i -D eslint@6
             - name: Test
               run: npm test
@@ -55,7 +55,7 @@ jobs:
             - uses: actions/setup-node@v2
             - name: Install Target Packages
               run: |+
-                  npm install
+                  npm ci
                   npm i -D eslint@^8.0.0-0
             - name: Test
               run: npm test

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -49,6 +49,18 @@ jobs:
                   npm install
             - name: Test
               run: npm test
+    test-with-eslint8:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+            - name: Install Target Packages
+              run: |+
+                  npm i -D eslint@^8.0.0-0
+                  npx rimraf node_modules
+                  npm install
+            - name: Test
+              run: npm test
     test-and-coverage:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -44,9 +44,8 @@ jobs:
                   node-version: 12.13.x
             - name: Install Target Packages
               run: |+
-                  npm i -D eslint@6
-                  npx rimraf node_modules
                   npm install
+                  npm i -D eslint@6
             - name: Test
               run: npm test
     test-with-eslint8:
@@ -56,9 +55,8 @@ jobs:
             - uses: actions/setup-node@v2
             - name: Install Target Packages
               run: |+
-                  npm i -D eslint@^8.0.0-0
-                  npx rimraf node_modules
                   npm install
+                  npm i -D eslint@^8.0.0-0
             - name: Test
               run: npm test
     test-and-coverage:


### PR DESCRIPTION
If eslint v8 is released early, we will change this PR to without draft.
However, if the eslint v8 support PR for typescript-eslint and vscode-eslint is released early, I will consider closing this PR and opening a PR that modifies devDependencies.