### PR TITLE
Update Playground

### DIFF
--- a/docs/.vuepress/components/components/RulesSettings.vue
+++ b/docs/.vuepress/components/components/RulesSettings.vue
@@ -1,73 +1,136 @@
 <template>
     <div class="rules-settings">
+        <div class="tools">
+            <label class="tool">
+                <span class="tool-label">Filter:</span>
+                <input
+                    v-model="filterValue"
+                    type="search"
+                    placeholder="Rule Filter"
+                    class="tool-form"
+                />
+            </label>
+            <label class="tool">
+                <input
+                    :checked="
+                        categories.every((category) =>
+                            category.rules.every((rule) =>
+                                isErrorState(rule.ruleId),
+                            ),
+                        )
+                    "
+                    type="checkbox"
+                    :indeterminate.prop="
+                        categories.some((category) =>
+                            category.rules.some((rule) =>
+                                isErrorState(rule.ruleId),
+                            ),
+                        ) &&
+                        categories.some((category) =>
+                            category.rules.some(
+                                (rule) => !isErrorState(rule.ruleId),
+                            ),
+                        )
+                    "
+                    @input="onAllClick($event)"
+                />
+                <span class="tool-label">All Rules</span>
+            </label>
+        </div>
         <ul class="categories">
-            <li
-                v-for="category in categories"
-                :key="category.title"
-                class="category"
-                :class="category.classes"
-            >
-                <div class="category-title-wrapper">
-                    <label class="category-title">
-                        <input
-                            :checked="
-                                category.rules.every((rule) =>
-                                    isErrorState(rule.ruleId),
-                                )
-                            "
-                            type="checkbox"
-                            :indeterminate.prop="
-                                !category.rules.every((rule) =>
-                                    isErrorState(rule.ruleId),
-                                ) &&
-                                !category.rules.every(
-                                    (rule) => !isErrorState(rule.ruleId),
-                                )
-                            "
-                            @input="onAllClick(category, $event)"
-                        />
-                        {{ category.title }}
-                    </label>
-                </div>
-
-                <ul class="rules">
-                    <li
-                        v-for="rule in category.rules"
-                        :key="rule.ruleId"
-                        class="rule"
-                        :class="rule.classes"
+            <template v-for="category in categories">
+                <li
+                    v-if="category.rules.length"
+                    :key="category.title"
+                    class="category"
+                    :class="category.classes"
+                >
+                    <button
+                        class="category-button"
+                        :class="{
+                            'category-button--close':
+                                categoryState[category.title].close,
+                        }"
+                        @click="
+                            categoryState[
+                                category.title
+                            ].close = !categoryState[category.title].close
+                        "
                     >
-                        <label>
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            height="10"
+                            viewBox="0 0 10 10"
+                            width="10"
+                        >
+                            <path d="M2.5 10l5-5-5-5v10z" fill="#ddd" />
+                        </svg>
+                    </button>
+                    <div class="category-title-wrapper">
+                        <label class="category-title">
                             <input
-                                :checked="isErrorState(rule.ruleId)"
+                                :checked="
+                                    category.rules.every((rule) =>
+                                        isErrorState(rule.ruleId),
+                                    )
+                                "
                                 type="checkbox"
-                                @input="onClick(rule.ruleId, $event)"
+                                :indeterminate.prop="
+                                    !category.rules.every((rule) =>
+                                        isErrorState(rule.ruleId),
+                                    ) &&
+                                    !category.rules.every(
+                                        (rule) => !isErrorState(rule.ruleId),
+                                    )
+                                "
+                                @input="onCategoryClick(category, $event)"
                             />
-                            {{ rule.ruleId }}
+                            {{ category.title }}
                         </label>
-                        <a :href="rule.url" target="_blank"
-                            ><svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                aria-hidden="true"
-                                x="0px"
-                                y="0px"
-                                viewBox="0 0 100 100"
-                                width="15"
-                                height="15"
-                                class="icon outbound"
-                            >
-                                <path
-                                    fill="currentColor"
-                                    d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z"
+                    </div>
+
+                    <ul
+                        v-show="!categoryState[category.title].close"
+                        class="rules"
+                    >
+                        <li
+                            v-for="rule in category.rules"
+                            :key="rule.ruleId"
+                            class="rule"
+                            :class="rule.classes"
+                        >
+                            <label>
+                                <input
+                                    :checked="isErrorState(rule.ruleId)"
+                                    type="checkbox"
+                                    @input="onClick(rule.ruleId, $event)"
                                 />
-                                <polygon
-                                    fill="currentColor"
-                                    points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9"
-                                /></svg
-                        ></a>
-                    </li>
-                </ul>
-            </li>
+                                {{ rule.ruleId }}
+                            </label>
+                            <a :href="rule.url" target="_blank"
+                                ><svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    aria-hidden="true"
+                                    x="0px"
+                                    y="0px"
+                                    viewBox="0 0 100 100"
+                                    width="15"
+                                    height="15"
+                                    class="icon outbound"
+                                >
+                                    <path
+                                        fill="currentColor"
+                                        d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z"
+                                    />
+                                    <polygon
+                                        fill="currentColor"
+                                        points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9"
+                                    /></svg
+                            ></a>
+                        </li>
+                    </ul>
+                </li>
+            </template>
         </ul>
     </div>
 </template>
@@ -85,18 +148,59 @@ export default {
     },
     data() {
         return {
-            categories,
+            categoryState: Object.fromEntries(
+                categories.map((c) => {
+                    return [
+                        c.title,
+                        {
+                            close: true,
+                        },
+                    ]
+                }),
+            ),
+            filterValue: "",
         }
     },
-    watch: {},
+    computed: {
+        categories() {
+            return categories.map((c) => {
+                return {
+                    ...c,
+                    rules: this.filterRules(c.rules),
+                }
+            })
+        },
+    },
     methods: {
-        onAllClick(category, e) {
+        filterRules(rules) {
+            let filteredRules = rules
+            if (this.filterValue) {
+                filteredRules = filteredRules.filter((r) =>
+                    r.ruleId.includes(this.filterValue),
+                )
+            }
+            return filteredRules
+        },
+        onCategoryClick(category, e) {
             const rules = Object.assign({}, this.rules)
             for (const rule of category.rules) {
                 if (e.target.checked) {
                     rules[rule.ruleId] = "error"
                 } else {
                     delete rules[rule.ruleId]
+                }
+            }
+            this.$emit("update:rules", rules)
+        },
+        onAllClick(e) {
+            const rules = Object.assign({}, this.rules)
+            for (const category of this.categories) {
+                for (const rule of category.rules) {
+                    if (e.target.checked) {
+                        rules[rule.ruleId] = "error"
+                    } else {
+                        delete rules[rule.ruleId]
+                    }
                 }
             }
             this.$emit("update:rules", rules)
@@ -118,13 +222,73 @@ export default {
 </script>
 
 <style scoped>
+.tools {
+    background-color: #222;
+}
+
+.tool {
+    display: flex;
+    padding: 4px;
+}
+
+.tool-label {
+    flex-shrink: 0;
+    padding: 0 4px;
+}
+
+.tool-form {
+    width: 100%;
+}
+
+.tools-button {
+    background-color: transparent;
+    color: #ddd;
+    border: none;
+    appearance: none;
+    cursor: pointer;
+    padding: 0;
+}
+
+.tools-button--close {
+    transform: rotate(90deg);
+}
+
 .categories {
     font-size: 14px;
+    list-style-type: none;
+}
+
+.category {
+    position: relative;
+}
+
+.category-button {
+    position: absolute;
+    left: -12px;
+    top: 2px;
+    background-color: transparent;
+    color: #ddd;
+    border: none;
+    appearance: none;
+    cursor: pointer;
+    padding: 0;
+}
+
+.category-button--close {
+    transform: rotate(90deg);
 }
 
 .category-title {
     font-size: 14px;
     font-weight: bold;
+}
+
+.eslint-plugin-regexp-category .category-title {
+    color: #f8c555;
+}
+
+.eslint-core-category .category-title {
+    color: #8080f2;
 }
 
 .rules {
@@ -147,11 +311,11 @@ a {
     text-decoration: none;
 }
 
-.category {
-    color: #fff;
+.eslint-core-rule a > svg {
+    color: #8080f2;
 }
 
-.eslint-plugin-regexp__category {
+.eslint-plugin-regexp-rule a > svg {
     color: #f8c555;
 }
 </style>

--- a/docs/.vuepress/components/playground-block.vue
+++ b/docs/.vuepress/components/playground-block.vue
@@ -28,10 +28,11 @@
                                 i
                             "
                             class="message"
+                            :class="getRule(msg.ruleId).classes"
                         >
                             [{{ msg.line }}:{{ msg.column }}]:
                             {{ msg.message }} (<a
-                                :href="getURL(msg.ruleId)"
+                                :href="getRule(msg.ruleId).url"
                                 target="_blank"
                             >
                                 {{ msg.ruleId }} </a
@@ -45,25 +46,13 @@
 </template>
 
 <script>
-import * as coreRules from "../../../node_modules/eslint4b/dist/core-rules"
-import plugin from "../../.."
 import PgEditor from "./components/PgEditor.vue"
 import RulesSettings from "./components/RulesSettings.vue"
 import SnsBar from "./components/SnsBar.vue"
 import { deserializeState, serializeState } from "./state"
-import { DEFAULT_RULES_CONFIG } from "./rules"
+import { DEFAULT_RULES_CONFIG, getRule } from "./rules"
 
 const DEFAULT_CODE = require("!!raw-loader!./demo/demo-code.js").default
-
-const ruleURLs = {}
-for (const k of Object.keys(plugin.rules)) {
-    const rule = plugin.rules[k]
-    ruleURLs[rule.meta.docs.ruleId] = rule.meta.docs.url
-}
-for (const k of Object.keys(coreRules)) {
-    const rule = coreRules[k]
-    ruleURLs[k] = rule.meta.docs.url
-}
 
 export default {
     name: "PlaygroundBlock",
@@ -115,8 +104,8 @@ export default {
         onChange({ messages }) {
             this.messages = messages
         },
-        getURL(ruleId) {
-            return ruleURLs[ruleId] || ""
+        getRule(ruleId) {
+            return getRule(ruleId)
         },
         onUrlHashChange() {
             const serializedString =
@@ -156,13 +145,13 @@ function equalsRules(a, b) {
     height: calc(100% - 100px);
     border: 1px solid #cfd4db;
     background-color: #282c34;
-    color: #f8c555;
+    color: #fff;
 }
 
 .main-content > .rules-settings {
     height: 100%;
     overflow: auto;
-    width: 25%;
+    width: 30%;
     box-sizing: border-box;
 }
 
@@ -189,5 +178,13 @@ function equalsRules(a, b) {
     border-top: 1px solid #cfd4db;
     padding: 8px;
     font-size: 12px;
+}
+
+.eslint-core-rule a {
+    color: #8080f2;
+}
+
+.eslint-plugin-regexp-rule a {
+    color: #f8c555;
 }
 </style>

--- a/docs/.vuepress/components/rules/index.js
+++ b/docs/.vuepress/components/rules/index.js
@@ -7,33 +7,26 @@ const CATEGORY_TITLES = {
     "Possible Errors": "Possible Errors",
     "Best Practices": "Best Practices",
     "Stylistic Issues": "Stylistic Issues",
-    "eslint-core-rules@Possible Errors": "ESLint core rules(Possible Errors)",
-    "eslint-core-rules@Best Practices": "ESLint core rules(Best Practices)",
-    "eslint-core-rules@Strict Mode": "ESLint core rules(Strict Mode)",
-    "eslint-core-rules@Variables": "ESLint core rules(Variables)",
-    "eslint-core-rules@Node.js and CommonJS":
-        "ESLint core rules(Node.js and CommonJS)",
-    "eslint-core-rules@Stylistic Issues": "ESLint core rules(Stylistic Issues)",
-    "eslint-core-rules@ECMAScript 6": "ESLint core rules(ECMAScript 6)",
+    "eslint-core-rules@problem": "ESLint core rules(Possible Errors)",
+    "eslint-core-rules@suggestion": "ESLint core rules(Suggestions)",
+    "eslint-core-rules@layout": "ESLint core rules(Layout & Formatting)",
 }
 const CATEGORY_INDEX = {
     "Possible Errors": 1,
     "Best Practices": 2,
     "Stylistic Issues": 3,
-    "eslint-plugin-vue": 10,
-    "eslint-core-rules@Possible Errors": 20,
-    "eslint-core-rules@Best Practices": 21,
-    "eslint-core-rules@Strict Mode": 22,
-    "eslint-core-rules@Variables": 23,
-    "eslint-core-rules@Node.js and CommonJS": 24,
-    "eslint-core-rules@Stylistic Issues": 25,
-    "eslint-core-rules@ECMAScript 6": 26,
+    "eslint-core-rules@problem": 20,
+    "eslint-core-rules@suggestion": 21,
+    "eslint-core-rules@layout": 22,
 }
 const CATEGORY_CLASSES = {
-    base: "eslint-plugin-regexp__category",
-    "Possible Errors": "eslint-plugin-regexp__category",
-    "Best Practices": "eslint-plugin-regexp__category",
-    "Stylistic Issues": "eslint-plugin-regexp__category",
+    base: "eslint-plugin-regexp-category",
+    "Possible Errors": "eslint-plugin-regexp-category",
+    "Best Practices": "eslint-plugin-regexp-category",
+    "Stylistic Issues": "eslint-plugin-regexp-category",
+    "eslint-core-rules@problem": "eslint-core-category",
+    "eslint-core-rules@suggestion": "eslint-core-category",
+    "eslint-core-rules@layout": "eslint-core-category",
 }
 
 const allRules = []
@@ -44,18 +37,21 @@ for (const k of Object.keys(plugin.rules)) {
         continue
     }
     allRules.push({
-        classes: "eslint-plugin-regexp__rule",
+        classes: "eslint-plugin-regexp-rule",
         category: rule.meta.docs.category,
         ruleId: rule.meta.docs.ruleId,
         url: rule.meta.docs.url,
-        init: "error", // CATEGORY_INDEX[rule.meta.docs.category] <= 3,
+        init: "error",
     })
 }
 for (const k of Object.keys(coreRules)) {
     const rule = coreRules[k]
+    if (rule.meta.deprecated) {
+        continue
+    }
     allRules.push({
-        category: `eslint-core-rules@${rule.meta.docs.category}`,
-        fallbackTitle: `ESLint core rules(${rule.meta.docs.category})`,
+        classes: "eslint-core-rule",
+        category: `eslint-core-rules@${rule.meta.type}`,
         ruleId: k,
         url: rule.meta.docs.url,
         init: plugin.configs.recommended.rules[k] || "off",
@@ -69,7 +65,7 @@ allRules.sort((a, b) =>
 export const categories = []
 
 for (const rule of allRules) {
-    const title = CATEGORY_TITLES[rule.category] || rule.fallbackTitle
+    const title = CATEGORY_TITLES[rule.category]
     let category = categories.find((c) => c.title === title)
     if (!category) {
         category = {
@@ -96,12 +92,26 @@ categories.sort((a, b) =>
 )
 
 export const DEFAULT_RULES_CONFIG = allRules.reduce((c, r) => {
-    if (r.ruleId === "vue/no-parsing-error") {
-        c[r.ruleId] = "error"
-    } else {
-        c[r.ruleId] = r.init
-    }
+    c[r.ruleId] = r.init
     return c
 }, {})
 
 export const rules = allRules
+
+export function getRule(ruleId) {
+    if (!ruleId) {
+        return null
+    }
+    for (const category of categories) {
+        for (const rule of category.rules) {
+            if (rule.ruleId === ruleId) {
+                return rule
+            }
+        }
+    }
+    return {
+        ruleId,
+        url: "",
+        classes: "",
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1586,9 +1586,9 @@
             "dev": true
         },
         "@types/minimist": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-            "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+            "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
             "dev": true
         },
         "@types/mocha": {
@@ -5115,9 +5115,9 @@
             "dev": true
         },
         "cosmiconfig": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-            "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
             "dev": true,
             "requires": {
                 "@types/parse-json": "^4.0.0",
@@ -10068,12 +10068,13 @@
             "dev": true
         },
         "log-symbols": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
             "requires": {
-                "chalk": "^4.0.0"
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10086,9 +10087,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
@@ -11128,15 +11129,26 @@
             }
         },
         "normalize-package-data": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-            "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
             "dev": true,
             "requires": {
                 "hosted-git-info": "^4.0.1",
-                "resolve": "^1.20.0",
+                "is-core-module": "^2.5.0",
                 "semver": "^7.3.4",
                 "validate-npm-package-license": "^3.0.1"
+            },
+            "dependencies": {
+                "is-core-module": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+                    "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+                    "dev": true,
+                    "requires": {
+                        "has": "^1.0.3"
+                    }
+                }
             }
         },
         "normalize-path": {
@@ -14766,16 +14778,16 @@
             }
         },
         "stylelint": {
-            "version": "13.12.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.12.0.tgz",
-            "integrity": "sha512-P8O1xDy41B7O7iXaSlW+UuFbE5+ZWQDb61ndGDxKIt36fMH50DtlQTbwLpFLf8DikceTAb3r6nPrRv30wBlzXw==",
+            "version": "13.13.1",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.13.1.tgz",
+            "integrity": "sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==",
             "dev": true,
             "requires": {
                 "@stylelint/postcss-css-in-js": "^0.37.2",
                 "@stylelint/postcss-markdown": "^0.36.2",
                 "autoprefixer": "^9.8.6",
-                "balanced-match": "^1.0.0",
-                "chalk": "^4.1.0",
+                "balanced-match": "^2.0.0",
+                "chalk": "^4.1.1",
                 "cosmiconfig": "^7.0.0",
                 "debug": "^4.3.1",
                 "execall": "^2.0.0",
@@ -14784,7 +14796,7 @@
                 "file-entry-cache": "^6.0.1",
                 "get-stdin": "^8.0.0",
                 "global-modules": "^2.0.0",
-                "globby": "^11.0.2",
+                "globby": "^11.0.3",
                 "globjoin": "^0.1.4",
                 "html-tags": "^3.1.0",
                 "ignore": "^5.1.8",
@@ -14792,10 +14804,10 @@
                 "imurmurhash": "^0.1.4",
                 "known-css-properties": "^0.21.0",
                 "lodash": "^4.17.21",
-                "log-symbols": "^4.0.0",
+                "log-symbols": "^4.1.0",
                 "mathml-tag-names": "^2.1.3",
                 "meow": "^9.0.0",
-                "micromatch": "^4.0.2",
+                "micromatch": "^4.0.4",
                 "normalize-selector": "^0.2.0",
                 "postcss": "^7.0.35",
                 "postcss-html": "^0.36.0",
@@ -14805,7 +14817,7 @@
                 "postcss-safe-parser": "^4.0.2",
                 "postcss-sass": "^0.4.4",
                 "postcss-scss": "^2.1.1",
-                "postcss-selector-parser": "^6.0.4",
+                "postcss-selector-parser": "^6.0.5",
                 "postcss-syntax": "^0.36.2",
                 "postcss-value-parser": "^4.1.0",
                 "resolve-from": "^5.0.0",
@@ -14816,11 +14828,23 @@
                 "style-search": "^0.1.0",
                 "sugarss": "^2.0.0",
                 "svg-tags": "^1.0.0",
-                "table": "^6.0.7",
-                "v8-compile-cache": "^2.2.0",
+                "table": "^6.6.0",
+                "v8-compile-cache": "^2.3.0",
                 "write-file-atomic": "^3.0.3"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "8.6.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+                    "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "ansi-styles": {
                     "version": "4.3.0",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -14830,10 +14854,16 @@
                         "color-convert": "^2.0.1"
                     }
                 },
+                "balanced-match": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+                    "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+                    "dev": true
+                },
                 "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
@@ -14861,6 +14891,22 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "6.0.6",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+                    "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                },
                 "resolve-from": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -14874,6 +14920,20 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
+                    }
+                },
+                "table": {
+                    "version": "6.7.1",
+                    "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+                    "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^8.0.1",
+                        "lodash.clonedeep": "^4.5.0",
+                        "lodash.truncate": "^4.4.2",
+                        "slice-ansi": "^4.0.0",
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0"
                     }
                 }
             }
@@ -15460,9 +15520,9 @@
             }
         },
         "trim-newlines": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-            "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+            "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
             "dev": true
         },
         "trough": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
         "raw-loader": "^4.0.1",
-        "stylelint": "^13.6.1",
+        "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
         "stylelint-plugin-stylus": "^0.11.0",
         "ts-node": "^10.0.0",


### PR DESCRIPTION
**Changes**

- Change to be able to collapse the rule category.
- Changed to be able to filter rules by the text of the rule name.  
   (I think it useful because the plugin rules are much more than before.)
- Changed to use `type` for the core rule category.  
  (The core rule `meta.docs.category` will be removed in v8.)

![image](https://user-images.githubusercontent.com/16508807/131987287-14e0f101-a8a7-443c-b831-3399d13e4f00.png)
