### PR TITLE
Fix `mergeOverlappingSets` implementation

### DIFF
--- a/tests/lib/utils/__snapshots__/reorder-alternatives.ts.snap
+++ b/tests/lib/utils/__snapshots__/reorder-alternatives.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getDeterminismEqClasses /(?:script|source)_foo|sample/ 1`] = `
+Object {
+  "(?:script|source)": Array [
+    "script",
+    "source",
+  ],
+  "(?:script|source)_foo|sample": Array [
+    "(?:script|source)_foo",
+    "sample",
+  ],
+}
+`;
+
 exports[`getDeterminismEqClasses /(int|integer)\\b/ 1`] = `
 Object {
   "(int|integer)": Array [

--- a/tests/lib/utils/reorder-alternatives.ts
+++ b/tests/lib/utils/reorder-alternatives.ts
@@ -70,6 +70,7 @@ describe(getDeterminismEqClasses.name, function () {
         /aaaaaaaaaaaaaaaaaaaa|bbbbbbbbbbbbbbbbbbbb|[^][^][^][^][^][^][^][^][^][^][^][^][^][^][^][^][^][^][^][^]/,
         /a{20}|b{20}|[^]{20}/,
         /a{20}c|b{20}a|[^]{20}b/,
+        /(?:script|source)_foo|sample/,
     ]
     const directionalRegexes: RegExp[] = [
         /abc|a/,


### PR DESCRIPTION
This fixes a bug in `mergeOverlappingSets`. The function returned more elements than it was supposed to.

I took this chance and reimplemented the function using a simpler and a lot more efficient approach. 

Further, I changed the function's interface to take and return arrays instead of sets. This make a lot of copying and array-to-set conversions unnecessary.

---

This is a branch of #320 because the new test case only reproduces the bug I fixed with the new and improved `getLongestPrefix`.