### PR TITLE
Use `regexp-ast-analysis`'s `toCharSet` everywhere

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,21 +34,6 @@ module.exports = {
 
         "no-shadow": "off", // ts bug?
         "@typescript-eslint/no-shadow": "error",
-
-        // Rules for implementing this plugin.
-        "no-restricted-imports": [
-            "error",
-            {
-                paths: [
-                    {
-                        name: "regexp-ast-analysis",
-                        importNames: ["toCharSet"],
-                        message:
-                            "Please use toCharSet from RegExpContext instead.",
-                    },
-                ],
-            },
-        ],
     },
     overrides: [
         {

--- a/lib/rules/negation.ts
+++ b/lib/rules/negation.ts
@@ -1,3 +1,4 @@
+import { toCharSet } from "regexp-ast-analysis"
 import type {
     EscapeCharacterSet,
     UnicodePropertyCharacterSet,
@@ -29,7 +30,6 @@ export default createRule("negation", {
             node,
             getRegexpLocation,
             fixReplaceNode,
-            toCharSet,
             flags,
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
@@ -53,12 +53,15 @@ export default createRule("negation", {
                         // All other character sets are either case-invariant
                         // (/./, /\s/, /\d/) or inconsistent (/\w/).
 
-                        const ccSet = toCharSet(ccNode)
+                        const ccSet = toCharSet(ccNode, flags)
 
-                        const negatedElementSet = toCharSet({
-                            ...element,
-                            negate: !element.negate,
-                        })
+                        const negatedElementSet = toCharSet(
+                            {
+                                ...element,
+                                negate: !element.negate,
+                            },
+                            flags,
+                        )
 
                         if (!ccSet.equals(negatedElementSet)) {
                             // We cannot remove the negative

--- a/lib/rules/no-useless-flag.ts
+++ b/lib/rules/no-useless-flag.ts
@@ -22,6 +22,7 @@ import {
 import { createTypeTracker } from "../utils/type-tracker"
 import type { RuleListener } from "../types"
 import type { Rule } from "eslint"
+import { toCharSet } from "regexp-ast-analysis"
 
 type CodePathStack = {
     codePathId: string
@@ -191,7 +192,6 @@ function createUselessIgnoreCaseFlagVisitor(context: Rule.RuleContext) {
             const {
                 flags,
                 regexpNode,
-                toCharSet,
                 ownsFlags,
                 getFlagLocation,
             } = regExpContext
@@ -217,7 +217,7 @@ function createUselessIgnoreCaseFlagVisitor(context: Rule.RuleContext) {
                     if (unnecessary) {
                         // all characters only accept themselves except if they
                         // are case sensitive
-                        if (toCharSet(cNode).size > 1) {
+                        if (toCharSet(cNode, flags).size > 1) {
                             unnecessary = false
                         }
                     }
@@ -233,7 +233,7 @@ function createUselessIgnoreCaseFlagVisitor(context: Rule.RuleContext) {
                             unnecessary = false
                         }
                         if (cNode.kind === "property") {
-                            const caseInsensitive = toCharSet(cNode)
+                            const caseInsensitive = toCharSet(cNode, flags)
                             const caseSensitive = toCharSet(cNode, flagsNoI)
 
                             if (!caseInsensitive.equals(caseSensitive)) {

--- a/lib/rules/prefer-d.ts
+++ b/lib/rules/prefer-d.ts
@@ -6,7 +6,7 @@ import {
     CP_DIGIT_ZERO,
     CP_DIGIT_NINE,
 } from "../utils"
-import { Chars } from "regexp-ast-analysis"
+import { Chars, toCharSet } from "regexp-ast-analysis"
 import { mention } from "../utils/mention"
 
 export default createRule("prefer-d", {
@@ -33,13 +33,12 @@ export default createRule("prefer-d", {
             flags,
             getRegexpLocation,
             fixReplaceNode,
-            toCharSet,
         }: RegExpContext): RegExpVisitor.Handlers {
             let reportedCharacterClass = false
 
             return {
                 onCharacterClassEnter(ccNode) {
-                    const charSet = toCharSet(ccNode)
+                    const charSet = toCharSet(ccNode, flags)
 
                     let predefined: string | undefined = undefined
                     if (charSet.equals(Chars.digit(flags))) {

--- a/lib/rules/prefer-predefined-assertion.ts
+++ b/lib/rules/prefer-predefined-assertion.ts
@@ -11,6 +11,7 @@ import {
     getFirstCharAfter,
     getMatchingDirectionFromAssertionKind,
     invertMatchingDirection,
+    toCharSet,
 } from "regexp-ast-analysis"
 
 /**
@@ -62,7 +63,6 @@ export default createRule("prefer-predefined-assertion", {
                 node,
                 flags,
                 getRegexpLocation,
-                toCharSet,
                 fixReplaceNode,
             } = regexpContext
 
@@ -207,7 +207,7 @@ export default createRule("prefer-predefined-assertion", {
                         }
                     }
 
-                    const charSet = toCharSet(chars)
+                    const charSet = toCharSet(chars, flags)
                     if (charSet.isAll) {
                         replaceEdgeAssertion(aNode, false)
                     } else if (charSet.equals(word)) {

--- a/lib/rules/prefer-w.ts
+++ b/lib/rules/prefer-w.ts
@@ -13,7 +13,7 @@ import {
     CP_DIGIT_NINE,
     CP_LOW_LINE,
 } from "../utils"
-import { Chars } from "regexp-ast-analysis"
+import { Chars, toCharSet } from "regexp-ast-analysis"
 import { mention } from "../utils/mention"
 
 /**
@@ -86,11 +86,10 @@ export default createRule("prefer-w", {
             getRegexpLocation,
             fixReplaceNode,
             patternSource,
-            toCharSet,
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCharacterClassEnter(ccNode: CharacterClass) {
-                    const charSet = toCharSet(ccNode)
+                    const charSet = toCharSet(ccNode, flags)
 
                     let predefined: string | undefined = undefined
                     if (charSet.equals(Chars.word(flags))) {

--- a/lib/rules/sort-alternatives.ts
+++ b/lib/rules/sort-alternatives.ts
@@ -152,11 +152,11 @@ function compareCharSetStrings(
  */
 function sortAlternatives(
     alternatives: Alternative[],
-    context: RegExpContext,
+    flags: ReadonlyFlags,
 ): void {
     const firstChars = new Map<Alternative, number>()
     for (const a of alternatives) {
-        const chars = getFirstConsumedChar(a, "ltr", context.flags)
+        const chars = getFirstConsumedChar(a, "ltr", flags)
         const char =
             chars.empty || chars.char.isEmpty
                 ? Infinity
@@ -166,14 +166,14 @@ function sortAlternatives(
 
     alternatives.sort((a, b) => {
         const prefixDiff = compareCharSetStrings(
-            getLongestPrefix(a, "ltr", context.flags),
-            getLongestPrefix(b, "ltr", context.flags),
+            getLongestPrefix(a, "ltr", flags),
+            getLongestPrefix(b, "ltr", flags),
         )
         if (prefixDiff !== 0) {
             return prefixDiff
         }
 
-        if (context.flags.ignoreCase) {
+        if (flags.ignoreCase) {
             return (
                 compareByteOrder(a.raw.toUpperCase(), b.raw.toUpperCase()) ||
                 compareByteOrder(a.raw, b.raw)
@@ -308,7 +308,7 @@ export default createRule("sort-alternatives", {
             function getPossibleChars(a: Alternative): CharSet {
                 let chars = possibleCharsCache.get(a)
                 if (chars === undefined) {
-                    chars = getPossiblyConsumedChar(a, regexpContext).char
+                    chars = getPossiblyConsumedChar(a, flags).char
                     possibleCharsCache.set(a, chars)
                 }
                 return chars
@@ -318,9 +318,9 @@ export default createRule("sort-alternatives", {
             function trySortRun(run: Run<Alternative>): void {
                 const alternatives = run.elements
 
-                if (canReorder(alternatives, regexpContext)) {
+                if (canReorder(alternatives, flags)) {
                     // alternatives can be reordered freely
-                    sortAlternatives(alternatives, regexpContext)
+                    sortAlternatives(alternatives, flags)
                     trySortNumberAlternatives(alternatives)
                 } else {
                     const consumedChars = Chars.empty(flags).union(
@@ -335,7 +335,7 @@ export default createRule("sort-alternatives", {
                         for (const { startIndex: index, elements } of runs) {
                             if (
                                 elements.length > 1 &&
-                                canReorder(elements, regexpContext)
+                                canReorder(elements, flags)
                             ) {
                                 trySortNumberAlternatives(elements)
                                 alternatives.splice(

--- a/lib/utils/regexp-ast/alternative-prefix.ts
+++ b/lib/utils/regexp-ast/alternative-prefix.ts
@@ -6,7 +6,6 @@ import type {
 } from "regexp-ast-analysis"
 import {
     getFirstCharAfter,
-    // eslint-disable-next-line no-restricted-imports -- x
     toCharSet,
     getFirstConsumedChar,
     getFirstConsumedCharAfter,

--- a/lib/utils/regexp-ast/is-covered.ts
+++ b/lib/utils/regexp-ast/is-covered.ts
@@ -9,13 +9,12 @@ import type {
 } from "regexpp/ast"
 import { isEqualNodes } from "./is-equals"
 import type { ReadonlyFlags, ToCharSetElement } from "regexp-ast-analysis"
-import type { ToCharSet } from ".."
+import { toCharSet } from "regexp-ast-analysis"
 import type { CharSet } from "refa"
 
 type Options = {
     flags: ReadonlyFlags
     canOmitRight: boolean
-    toCharSet: ToCharSet
 }
 interface NormalizedNodeBase {
     readonly type: string
@@ -52,7 +51,7 @@ class NormalizedCharacter implements NormalizedNodeBase {
     public readonly charSet: CharSet
 
     public static fromElement(element: ToCharSetElement, options: Options) {
-        return new NormalizedCharacter(options.toCharSet(element))
+        return new NormalizedCharacter(toCharSet(element, options.flags))
     }
 
     private constructor(charSet: CharSet) {
@@ -379,7 +378,7 @@ function isCoveredForNormalizedNode(
             left.type === "NormalizedOther" &&
             right.type === "NormalizedOther"
         ) {
-            return isEqualNodes(left.node, right.node, options.toCharSet)
+            return isEqualNodes(left.node, right.node, options.flags)
         }
         return false
     }
@@ -399,7 +398,7 @@ function isCoveredForNormalizedNode(
                     isCoveredAnyNode(left.alternatives, r, options),
                 )
             }
-            return isEqualNodes(left.node, right.node, options.toCharSet)
+            return isEqualNodes(left.node, right.node, options.flags)
         }
         return false
     }

--- a/tests/lib/utils/regexp-ast.ts
+++ b/tests/lib/utils/regexp-ast.ts
@@ -1,8 +1,5 @@
 import assert from "assert"
-// eslint-disable-next-line no-restricted-imports -- it's fine
-import { toCharSet } from "regexp-ast-analysis"
 import { parseRegExpLiteral } from "regexpp"
-import { parseFlags } from "../../../lib/utils"
 import { isCoveredNode, isEqualNodes } from "../../../lib/utils/regexp-ast"
 type TestCase = {
     a: RegExp | string
@@ -217,7 +214,7 @@ describe("regexp-ast isEqualNodes", () => {
             const ast2 = parseRegExpLiteral(testCase.b)
 
             assert.deepStrictEqual(
-                isEqualNodes(ast1, ast2, (e) => toCharSet(e, ast1.flags)),
+                isEqualNodes(ast1, ast2, ast1.flags),
                 testCase.result,
             )
         })
@@ -536,9 +533,8 @@ describe("regexp-ast isCoveredNode", () => {
 
             assert.deepStrictEqual(
                 isCoveredNode(ast1, ast2, {
-                    flags: parseFlags(ast1.flags.raw),
+                    flags: ast1.flags,
                     canOmitRight: true,
-                    toCharSet: (e) => toCharSet(e, ast1.flags),
                 }),
                 testCase.result,
             )


### PR DESCRIPTION
This PR removes `RegexpContext.toCharSet` and the associated `ToCharSet` fn type.

A lot of functions only needed a `RegexpContext` parameter to parse characters. I changed these functions to require a `ReadonlyFlags` parameter instead.

---

This resolves #322.

