### PR TITLE
Fix `control-character-escape` false negatives

### DIFF
--- a/tests/lib/rules/control-character-escape.ts
+++ b/tests/lib/rules/control-character-escape.ts
@@ -108,5 +108,12 @@ tester.run("control-character-escape", rule as any, {
                 "Unexpected control character escape '\\u0009' (U+0009). Use '\\t' instead.",
             ],
         },
+        {
+            code: String.raw`RegExp("\t\r\n\0" + /	/.source)`,
+            output: String.raw`RegExp("\t\r\n\0" + /\t/.source)`,
+            errors: [
+                "Unexpected control character escape '\t' (U+0009). Use '\\t' instead.",
+            ],
+        },
     ],
 })


### PR DESCRIPTION
fixes #326.

I used `PatternSource`'s replace ranges to determine whether the control character is part of a RegExp literal or not.

![image](https://user-images.githubusercontent.com/20878432/133101846-29aa929f-c8cb-4aa2-b468-a926fa1176f0.png)
