### PR TITLE
Add `regexp/no-misleading-unicode-character` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-escape-backspace](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-escape-backspace.html) | disallow escape backspace (`[\b]`) | :star: |
 | [regexp/no-invalid-regexp](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-invalid-regexp.html) | disallow invalid regular expression strings in `RegExp` constructors | :star: |
 | [regexp/no-lazy-ends](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-lazy-ends.html) | disallow lazy quantifiers at the end of an expression | :star: |
+| [regexp/no-misleading-unicode-character](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-misleading-unicode-character.html) | disallow multi-code-point characters in character classes and quantifiers | :wrench: |
 | [regexp/no-optional-assertion](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-optional-assertion.html) | disallow optional assertions | :star: |
 | [regexp/no-potentially-useless-backreference](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-potentially-useless-backreference.html) | disallow backreferences that reference a group that might not be matched | :star: |
 | [regexp/no-super-linear-backtracking](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-super-linear-backtracking.html) | disallow exponential and polynomial backtracking | :star::wrench: |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -22,6 +22,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/no-escape-backspace](./no-escape-backspace.md) | disallow escape backspace (`[\b]`) | :star: |
 | [regexp/no-invalid-regexp](./no-invalid-regexp.md) | disallow invalid regular expression strings in `RegExp` constructors | :star: |
 | [regexp/no-lazy-ends](./no-lazy-ends.md) | disallow lazy quantifiers at the end of an expression | :star: |
+| [regexp/no-misleading-unicode-character](./no-misleading-unicode-character.md) | disallow multi-code-point characters in character classes and quantifiers | :wrench: |
 | [regexp/no-optional-assertion](./no-optional-assertion.md) | disallow optional assertions | :star: |
 | [regexp/no-potentially-useless-backreference](./no-potentially-useless-backreference.md) | disallow backreferences that reference a group that might not be matched | :star: |
 | [regexp/no-super-linear-backtracking](./no-super-linear-backtracking.md) | disallow exponential and polynomial backtracking | :star::wrench: |

--- a/docs/rules/no-misleading-unicode-character.md
+++ b/docs/rules/no-misleading-unicode-character.md
@@ -1,0 +1,58 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "regexp/no-misleading-unicode-character"
+description: "disallow multi-code-point characters in character classes and quantifiers"
+---
+# regexp/no-misleading-unicode-character
+
+> disallow multi-code-point characters in character classes and quantifiers
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule reports misleading Unicode characters.
+
+Some Unicode characters like '❇️', '🏳️‍🌈', and '👨‍👩‍👦' consist of multiple code points. This causes problems in character classes and around quantifiers. E.g.
+
+```js
+> /^[❇️🏳️‍🌈]$/.test("🏳️‍🌈")
+false
+> /^👨‍👩‍👦{2,4}$/.test("👨‍👩‍👦👨‍👩‍👦")
+false
+```
+
+This rule is inspired by the [no-misleading-character-class] rule.
+
+<eslint-code-block fix>
+
+```js
+/* eslint regexp/no-misleading-unicode-character: "error" */
+
+/* ✓ GOOD */
+var foo = /👍+/u;
+var foo = /👨‍👩‍👦/;
+
+/* ✗ BAD */
+var foo = /👍+/;
+var foo = /[❇️🏳️‍🌈👨‍👩‍👦]❤️/;
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :books: Further reading
+
+- [no-misleading-character-class]
+
+[no-misleading-character-class]: https://eslint.org/docs/rules/no-misleading-character-class
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/lib/rules/no-misleading-unicode-character.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/tests/lib/rules/no-misleading-unicode-character.ts)

--- a/docs/rules/no-misleading-unicode-character.md
+++ b/docs/rules/no-misleading-unicode-character.md
@@ -44,7 +44,19 @@ var foo = /[❇️🏳️‍🌈👨‍👩‍👦]❤️/;
 
 ## :wrench: Options
 
-Nothing.
+```json
+{
+  "regexp/no-unused-capturing-group": ["error", {
+    "fixable": true
+  }]
+}
+```
+
+- `fixable: true | false`
+
+  This option controls whether the rule is fixable. Defaults to `false`.
+
+  This rule is not fixable by default. Misleading Unicode characters can typically be fixed automatically by assuming that users want to treat one displayed character as one regex character. However, this assumption is not useful in all languages, so this rule provides suggestions instead of fixes by default.
 
 ## :books: Further reading
 

--- a/lib/rules/no-misleading-unicode-character.ts
+++ b/lib/rules/no-misleading-unicode-character.ts
@@ -1,0 +1,276 @@
+import type { RegExpVisitor } from "regexpp/visitor"
+import type { RegExpContext } from "../utils"
+import { isEscapeSequence, createRule, defineRegexpVisitor } from "../utils"
+import GraphemeSplitter from "grapheme-splitter"
+import type { ReadonlyFlags } from "regexp-ast-analysis"
+import { mention, mentionChar } from "../utils/mention"
+import type {
+    CharacterClass,
+    CharacterClassElement,
+    Quantifier,
+} from "regexpp/ast"
+import type { PatternRange } from "../utils/ast-utils/pattern-source"
+
+const splitter = new GraphemeSplitter()
+
+/** Returns whether the given string starts with a valid surrogate pair. */
+function startsWithSurrogate(s: string): boolean {
+    if (s.length < 2) {
+        return false
+    }
+    const h = s.charCodeAt(0)
+    const l = s.charCodeAt(1)
+    return h >= 0xd800 && h <= 0xdbff && l >= 0xdc00 && l <= 0xdfff
+}
+
+type Problem = "Multi" | "Surrogate"
+
+/**
+ * Returns the problem (if any) with the given grapheme.
+ */
+function getProblem(grapheme: string, flags: ReadonlyFlags): Problem | null {
+    if (
+        grapheme.length > 2 ||
+        (grapheme.length === 2 && !startsWithSurrogate(grapheme))
+    ) {
+        return "Multi"
+    } else if (!flags.unicode && startsWithSurrogate(grapheme)) {
+        return "Surrogate"
+    }
+    return null
+}
+
+/** Returns the last grapheme of the quantified element. */
+function getGraphemeBeforeQuant(quant: Quantifier): string {
+    const alt = quant.parent
+
+    // find the start index of the first character left of
+    // this quantifier
+    let start = quant.start
+    for (let i = alt.elements.indexOf(quant) - 1; i >= 0; i--) {
+        const e = alt.elements[i]
+        if (e.type === "Character" && !isEscapeSequence(e.raw)) {
+            start = e.start
+        } else {
+            break
+        }
+    }
+
+    const before = alt.raw.slice(
+        start - alt.start,
+        quant.element.end - alt.start,
+    )
+
+    const graphemes = splitter.splitGraphemes(before)
+    const grapheme = graphemes[graphemes.length - 1]
+
+    return grapheme
+}
+
+interface GraphemeProblem {
+    readonly grapheme: string
+    readonly problem: Problem
+    readonly start: number
+    readonly end: number
+    /** A sorted list of all unique elements that overlap with this grapheme */
+    readonly elements: CharacterClassElement[]
+}
+
+/** Returns all grapheme problem in the given character class. */
+function getGraphemeProblems(
+    cc: CharacterClass,
+    flags: ReadonlyFlags,
+): GraphemeProblem[] {
+    let offset = cc.negate ? 2 : 1
+
+    const graphemes = splitter.splitGraphemes(cc.raw.slice(offset, -1))
+    const problems: GraphemeProblem[] = []
+
+    for (const grapheme of graphemes) {
+        const problem = getProblem(grapheme, flags)
+        if (problem !== null) {
+            const start = offset + cc.start
+            const end = start + grapheme.length
+
+            problems.push({
+                grapheme,
+                problem,
+                start,
+                end,
+                elements: cc.elements.filter(
+                    (e) => e.start < end && e.end > start,
+                ),
+            })
+        }
+        offset += grapheme.length
+    }
+
+    return problems
+}
+
+/** Returns a fix for the given problems (if possible). */
+function getGraphemeProblemsFix(
+    problems: readonly GraphemeProblem[],
+    cc: CharacterClass,
+): string | null {
+    if (cc.negate) {
+        // we can't fix a negated character class
+        return null
+    }
+
+    if (
+        !problems.every(
+            (p) =>
+                p.start === p.elements[0].start &&
+                p.end === p.elements[p.elements.length - 1].end,
+        )
+    ) {
+        // the graphemes don't line up with character class elements
+        return null
+    }
+
+    // The prefix of graphemes
+    const prefix = problems
+        .map((p) => p.grapheme)
+        .sort((a, b) => b.length - a.length)
+        .join("|")
+
+    // The rest of the character class
+    let ccRaw = cc.raw
+    for (let i = problems.length - 1; i >= 0; i--) {
+        const { start, end } = problems[i]
+        ccRaw = ccRaw.slice(0, start) + ccRaw.slice(end)
+    }
+    if (ccRaw.startsWith("[^")) {
+        ccRaw = `[\\${ccRaw.slice(1)}`
+    }
+
+    let fix = prefix
+    let singleAlternative = problems.length === 1
+    if (ccRaw !== "[]") {
+        fix += `|${ccRaw}`
+        singleAlternative = false
+    }
+
+    if (singleAlternative && cc.parent.type === "Alternative") {
+        return fix
+    }
+
+    if (cc.parent.type === "Alternative" && cc.parent.elements.length === 1) {
+        // The character class is the only
+        return fix
+    }
+
+    return `(?:${fix})`
+}
+
+export default createRule("no-misleading-unicode-character", {
+    meta: {
+        docs: {
+            description:
+                "disallow multi-code-point characters in character classes and quantifiers",
+            category: "Possible Errors",
+            // TODO Switch to recommended in the major version.
+            // recommended: true,
+            recommended: false,
+        },
+        schema: [],
+        fixable: "code",
+        messages: {
+            characterClass:
+                "The character(s) {{ graphemes }} are all represented using multiple {{ unit }}.{{ uFlag }}",
+            quantifierMulti:
+                "The character {{ grapheme }} is represented using multiple Unicode code points. The quantifier only applies to the last code point {{ last }} and not to the whole character.",
+            quantifierSurrogate:
+                "The character {{ grapheme }} is represented using a surrogate pair. The quantifier only applies to the tailing surrogate {{ last }} and not to the whole character.",
+        },
+        type: "problem",
+    },
+    create(context) {
+        /**
+         * Create visitor
+         */
+        function createVisitor(
+            regexpContext: RegExpContext,
+        ): RegExpVisitor.Handlers {
+            const {
+                node,
+                patternSource,
+                flags,
+                getRegexpLocation,
+                fixReplaceNode,
+            } = regexpContext
+
+            return {
+                onCharacterClassEnter(ccNode) {
+                    const problems = getGraphemeProblems(ccNode, flags)
+                    if (problems.length === 0) {
+                        return
+                    }
+
+                    const range: PatternRange = {
+                        start: problems[0].start,
+                        end: problems[problems.length - 1].end,
+                    }
+
+                    const fix = getGraphemeProblemsFix(problems, ccNode)
+
+                    const uFlag = problems.every(
+                        (p) => p.problem === "Surrogate",
+                    )
+
+                    context.report({
+                        node,
+                        loc: getRegexpLocation(range),
+                        messageId: "characterClass",
+                        data: {
+                            graphemes: problems
+                                .map((p) => mention(p.grapheme))
+                                .join(", "),
+                            unit: flags.unicode ? "code points" : "char codes",
+                            uFlag: uFlag ? " Use the `u` flag." : "",
+                        },
+                        fix: fixReplaceNode(ccNode, () => fix),
+                    })
+                },
+                onQuantifierEnter(qNode) {
+                    if (qNode.element.type !== "Character") {
+                        return
+                    }
+
+                    const grapheme = getGraphemeBeforeQuant(qNode)
+
+                    const problem = getProblem(grapheme, flags)
+                    if (problem === null) {
+                        return
+                    }
+
+                    context.report({
+                        node,
+                        loc: getRegexpLocation(qNode),
+                        messageId: `quantifier${problem}`,
+                        data: {
+                            grapheme: mention(grapheme),
+                            last: mentionChar(qNode.element),
+                        },
+                        fix(fixer) {
+                            const range = patternSource.getReplaceRange({
+                                start: qNode.element.end - grapheme.length,
+                                end: qNode.element.end,
+                            })
+                            if (!range) {
+                                return null
+                            }
+
+                            return range.replace(fixer, `(?:${grapheme})`)
+                        },
+                    })
+                },
+            }
+        }
+
+        return defineRegexpVisitor(context, {
+            createVisitor,
+        })
+    },
+})

--- a/lib/rules/no-misleading-unicode-character.ts
+++ b/lib/rules/no-misleading-unicode-character.ts
@@ -139,7 +139,7 @@ function getGraphemeProblemsFix(
     let ccRaw = cc.raw
     for (let i = problems.length - 1; i >= 0; i--) {
         const { start, end } = problems[i]
-        ccRaw = ccRaw.slice(0, start) + ccRaw.slice(end)
+        ccRaw = ccRaw.slice(0, start - cc.start) + ccRaw.slice(end - cc.start)
     }
     if (ccRaw.startsWith("[^")) {
         ccRaw = `[\\${ccRaw.slice(1)}`

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -18,6 +18,7 @@ import noInvalidRegexp from "../rules/no-invalid-regexp"
 import noInvisibleCharacter from "../rules/no-invisible-character"
 import noLazyEnds from "../rules/no-lazy-ends"
 import noLegacyFeatures from "../rules/no-legacy-features"
+import noMisleadingUnicodeCharacter from "../rules/no-misleading-unicode-character"
 import noNonStandardFlag from "../rules/no-non-standard-flag"
 import noObscureRange from "../rules/no-obscure-range"
 import noOctal from "../rules/no-octal"
@@ -87,6 +88,7 @@ export const rules = [
     noInvisibleCharacter,
     noLazyEnds,
     noLegacyFeatures,
+    noMisleadingUnicodeCharacter,
     noNonStandardFlag,
     noObscureRange,
     noOctal,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7913,6 +7913,11 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "dev": true
         },
+        "grapheme-splitter": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+        },
         "gray-matter": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "dependencies": {
         "comment-parser": "^1.1.2",
         "eslint-utils": "^3.0.0",
+        "grapheme-splitter": "^1.0.4",
         "jsdoctypeparser": "^9.0.0",
         "refa": "^0.9.0",
         "regexp-ast-analysis": "^0.3.0",

--- a/tests/lib/rules/no-misleading-unicode-character.ts
+++ b/tests/lib/rules/no-misleading-unicode-character.ts
@@ -1,0 +1,215 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/no-misleading-unicode-character"
+
+const tester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+})
+
+tester.run("no-misleading-unicode-character", rule as any, {
+    valid: [
+        `/[👍]/u`,
+        `/👍+/u`,
+        `/[\uD83D\uDC4D]/u`,
+        `/[\u{1F44D}]/u`,
+        `/❇️/`,
+        `/Á/`,
+        `/[❇]/`,
+        `/🇯🇵/`,
+        `/[JP]/`,
+        `/👨‍👩‍👦/`,
+
+        // Ignore solo lead/tail surrogate.
+        `/[\uD83D]/`,
+        `/[\uDC4D]/`,
+        `/[\uD83D]/u`,
+        `/[\uDC4D]/u`,
+
+        // Ignore solo combining char.
+        `/[\u0301]/`,
+        `/[\uFE0F]/`,
+        `/[\u0301]/u`,
+        `/[\uFE0F]/u`,
+
+        // Ignore solo emoji modifier.
+        `/[\u{1F3FB}]/u`,
+
+        // Ignore solo regional indicator symbol.
+        `/[🇯]/u`,
+        `/[🇵]/u`,
+
+        // Ignore solo ZWJ.
+        `/[\u200D]/`,
+        `/[\u200D]/u`,
+
+        // Ignore escaped symbols because it's obvious they aren't together
+        `/[\\uD83D\\uDC4D]/`,
+    ],
+    invalid: [
+        {
+            code: `/[👍]/`,
+            output: `/👍/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[👍]foo/`,
+            output: `/👍foo/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[👍]|foo/`,
+            output: `/👍|foo/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[👍a]foo/`,
+            output: `/(?:👍|[a])foo/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[👍a]|foo/`,
+            output: `/👍|[a]|foo/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[fooo👍bar]baz/`,
+            output: `/(?:👍|[fooobar])baz/`,
+            errors: [
+                "The character(s) '👍' are all represented using multiple char codes. Use the `u` flag.",
+            ],
+        },
+        {
+            code: `/👍+/`,
+            output: `/(?:👍)+/`,
+            errors: [
+                "The character '👍' is represented using a surrogate pair. The quantifier only applies to the tailing surrogate '\udc4d' (U+dc4d) and not to the whole character.",
+            ],
+        },
+        {
+            code: `/[Á]/`,
+            output: `/Á/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[Á]/u`,
+            output: `/Á/u`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[\u0041\u0301]/`,
+            output: `/\u0041\u0301/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[\u0041\u0301]/u`,
+            output: `/\u0041\u0301/u`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[\u{41}\u{301}]/u`,
+            output: `/\u{41}\u{301}/u`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[❇️]/`,
+            output: `/❇️/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[❇️]/u`,
+            output: `/❇️/u`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/❇️+/u`,
+            output: `/(?:❇️)+/u`,
+            errors: [
+                "The character '❇️' is represented using multiple Unicode code points. The quantifier only applies to the last code point '\ufe0f' (U+fe0f) and not to the whole character.",
+            ],
+        },
+        {
+            code: `/[🇯🇵]/`,
+            output: `/🇯🇵/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[🇯🇵]/u`,
+            output: `/🇯🇵/u`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[👨‍👩‍👦]/`,
+            output: `/👨‍👩‍👦/`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[👨‍👩‍👦]/u`,
+            output: `/👨‍👩‍👦/u`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/👨‍👩‍👦+/`,
+            output: `/(?:👨‍👩‍👦)+/`,
+            errors: [{ messageId: "quantifierMulti" }],
+        },
+        {
+            code: `/👨‍👩‍👦+/u`,
+            output: `/(?:👨‍👩‍👦)+/u`,
+            errors: [{ messageId: "quantifierMulti" }],
+        },
+
+        // RegExp constructors.
+        {
+            code: String.raw`new RegExp("[👍]", "")`,
+            output: String.raw`new RegExp("👍", "")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: String.raw`new RegExp("[\uD83D\uDC4D]", "")`,
+            output: String.raw`new RegExp("👍", "")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: String.raw`new RegExp("[Á]", "")`,
+            output: String.raw`new RegExp("Á", "")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: String.raw`new RegExp("[Á]", "u")`,
+            output: String.raw`new RegExp("Á", "u")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: String.raw`new RegExp("[❇️]", "")`,
+            output: String.raw`new RegExp("❇️", "")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: String.raw`new RegExp("[❇️]", "u")`,
+            output: String.raw`new RegExp("❇️", "u")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: String.raw`new RegExp("[🇯🇵]", "")`,
+            output: String.raw`new RegExp("🇯🇵", "")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: String.raw`new RegExp("[🇯🇵]", "u")`,
+            output: String.raw`new RegExp("🇯🇵", "u")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: String.raw`new RegExp("[👨‍👩‍👦]", "")`,
+            output: String.raw`new RegExp("👨‍👩‍👦", "")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: String.raw`new RegExp("[👨‍👩‍👦]", "u")`,
+            output: String.raw`new RegExp("👨‍👩‍👦", "u")`,
+            errors: [{ messageId: "characterClass" }],
+        },
+    ],
+})

--- a/tests/lib/rules/no-misleading-unicode-character.ts
+++ b/tests/lib/rules/no-misleading-unicode-character.ts
@@ -159,8 +159,17 @@ tester.run("no-misleading-unicode-character", rule as any, {
             output: `/(?:👨‍👩‍👦)+/u`,
             errors: [{ messageId: "quantifierMulti" }],
         },
+        {
+            code: `/[竈門禰󠄀豆子]|[煉󠄁獄杏寿郎]/`,
+            output: `/禰󠄀|[竈門豆子]|煉󠄁|[獄杏寿郎]/`,
+            errors: [
+                "The character(s) '禰󠄀' are all represented using multiple char codes.",
+                "The character(s) '煉󠄁' are all represented using multiple char codes.",
+            ],
+        },
 
         // RegExp constructors.
+
         {
             code: String.raw`new RegExp("[👍]", "")`,
             output: String.raw`new RegExp("👍", "")`,

--- a/tests/lib/rules/no-misleading-unicode-character.ts
+++ b/tests/lib/rules/no-misleading-unicode-character.ts
@@ -51,31 +51,47 @@ tester.run("no-misleading-unicode-character", rule as any, {
         {
             code: `/[👍]/`,
             output: `/👍/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[👍]foo/`,
             output: `/👍foo/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
+        },
+        {
+            code: `/[👍]foo/`,
+            output: null,
+            errors: [
+                {
+                    messageId: "characterClass",
+                    suggestions: [{ output: `/👍foo/` }],
+                },
+            ],
         },
         {
             code: `/[👍]|foo/`,
             output: `/👍|foo/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[👍a]foo/`,
             output: `/(?:👍|[a])foo/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[👍a]|foo/`,
             output: `/👍|[a]|foo/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[fooo👍bar]baz/`,
             output: `/(?:👍|[fooobar])baz/`,
+            options: [{ fixable: true }],
             errors: [
                 "The character(s) '👍' are all represented using multiple char codes. Use the `u` flag.",
             ],
@@ -83,6 +99,7 @@ tester.run("no-misleading-unicode-character", rule as any, {
         {
             code: `/👍+/`,
             output: `/(?:👍)+/`,
+            options: [{ fixable: true }],
             errors: [
                 "The character '👍' is represented using a surrogate pair. The quantifier only applies to the tailing surrogate '\udc4d' (U+dc4d) and not to the whole character.",
             ],
@@ -90,41 +107,49 @@ tester.run("no-misleading-unicode-character", rule as any, {
         {
             code: `/[Á]/`,
             output: `/Á/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[Á]/u`,
             output: `/Á/u`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[\u0041\u0301]/`,
             output: `/\u0041\u0301/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[\u0041\u0301]/u`,
             output: `/\u0041\u0301/u`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[\u{41}\u{301}]/u`,
             output: `/\u{41}\u{301}/u`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[❇️]/`,
             output: `/❇️/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[❇️]/u`,
             output: `/❇️/u`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/❇️+/u`,
             output: `/(?:❇️)+/u`,
+            options: [{ fixable: true }],
             errors: [
                 "The character '❇️' is represented using multiple Unicode code points. The quantifier only applies to the last code point '\ufe0f' (U+fe0f) and not to the whole character.",
             ],
@@ -132,36 +157,43 @@ tester.run("no-misleading-unicode-character", rule as any, {
         {
             code: `/[🇯🇵]/`,
             output: `/🇯🇵/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[🇯🇵]/u`,
             output: `/🇯🇵/u`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[👨‍👩‍👦]/`,
             output: `/👨‍👩‍👦/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/[👨‍👩‍👦]/u`,
             output: `/👨‍👩‍👦/u`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: `/👨‍👩‍👦+/`,
             output: `/(?:👨‍👩‍👦)+/`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "quantifierMulti" }],
         },
         {
             code: `/👨‍👩‍👦+/u`,
             output: `/(?:👨‍👩‍👦)+/u`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "quantifierMulti" }],
         },
         {
             code: `/[竈門禰󠄀豆子]|[煉󠄁獄杏寿郎]/`,
             output: `/禰󠄀|[竈門豆子]|煉󠄁|[獄杏寿郎]/`,
+            options: [{ fixable: true }],
             errors: [
                 "The character(s) '禰󠄀' are all represented using multiple char codes.",
                 "The character(s) '煉󠄁' are all represented using multiple char codes.",
@@ -173,51 +205,61 @@ tester.run("no-misleading-unicode-character", rule as any, {
         {
             code: String.raw`new RegExp("[👍]", "")`,
             output: String.raw`new RegExp("👍", "")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: String.raw`new RegExp("[\uD83D\uDC4D]", "")`,
             output: String.raw`new RegExp("👍", "")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: String.raw`new RegExp("[Á]", "")`,
             output: String.raw`new RegExp("Á", "")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: String.raw`new RegExp("[Á]", "u")`,
             output: String.raw`new RegExp("Á", "u")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: String.raw`new RegExp("[❇️]", "")`,
             output: String.raw`new RegExp("❇️", "")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: String.raw`new RegExp("[❇️]", "u")`,
             output: String.raw`new RegExp("❇️", "u")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: String.raw`new RegExp("[🇯🇵]", "")`,
             output: String.raw`new RegExp("🇯🇵", "")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: String.raw`new RegExp("[🇯🇵]", "u")`,
             output: String.raw`new RegExp("🇯🇵", "u")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: String.raw`new RegExp("[👨‍👩‍👦]", "")`,
             output: String.raw`new RegExp("👨‍👩‍👦", "")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
         {
             code: String.raw`new RegExp("[👨‍👩‍👦]", "u")`,
             output: String.raw`new RegExp("👨‍👩‍👦", "u")`,
+            options: [{ fixable: true }],
             errors: [{ messageId: "characterClass" }],
         },
     ],


### PR DESCRIPTION
Relates to #325.

This adds the `no-misleading-unicode-character` rule as discussed [here](https://github.com/ota-meshi/eslint-plugin-regexp/issues/325#issuecomment-922271310). There are a few differences to ESLint's `no-misleading-character-class` rule:

- We support misleading quantifiers.
- Reports are auto-fixed.
- Reports are much more granular.
- We ignore characters using escape sequences. We only care about visible characters, not hexadecimal escapes. E.g. ESLint's rule will report `/[\ud83d\udc4d]/`, we won't.

One open question: Should we auto-fix?
Right now, the rule will auto-fix wherever possible using groups. We essentially assume that people want to treat graphemes as single units. That is a very reasonable assumption but an assumption nonetheless. 