### PR TITLE
Improve `sort-flags` to fix unknown patterns

### DIFF
--- a/lib/rules/sort-flags.ts
+++ b/lib/rules/sort-flags.ts
@@ -42,7 +42,7 @@ export default createRule("sort-flags", {
                         loc: getFlagsLocation(),
                         messageId: "sortFlags",
                         data: { flags: flagsString, sortedFlags },
-                        fix: fixReplaceFlags(sortedFlags),
+                        fix: fixReplaceFlags(sortedFlags, false),
                     })
                 }
             }

--- a/tests/lib/rules/sort-flags.ts
+++ b/tests/lib/rules/sort-flags.ts
@@ -82,5 +82,16 @@ tester.run("sort-flags", rule as any, {
                 },
             ],
         },
+        {
+            // sort flags even on non-owned pattern
+            code: String.raw`var a = "foo"; RegExp(foo, 'us'); RegExp(foo, 'u');`,
+            output: String.raw`var a = "foo"; RegExp(foo, 'su'); RegExp(foo, 'u');`,
+            errors: [
+                {
+                    message: "The flags 'us' should be in the order 'su'.",
+                    column: 29,
+                },
+            ],
+        },
     ],
 })

--- a/tests/lib/rules/sort-flags.ts
+++ b/tests/lib/rules/sort-flags.ts
@@ -71,5 +71,16 @@ tester.run("sort-flags", rule as any, {
                 },
             ],
         },
+        {
+            // sort flags even on unknown
+            code: String.raw`RegExp('a' + b, 'us');`,
+            output: String.raw`RegExp('a' + b, 'su');`,
+            errors: [
+                {
+                    message: "The flags 'us' should be in the order 'su'.",
+                    column: 18,
+                },
+            ],
+        },
     ],
 })


### PR DESCRIPTION
Fixes #337.

The main change is that `fixReplaceFlags` now takes an `includePattern` parameter. This controls whether a flags fix includes the whole pattern as well. Including the whole pattern is necessary in pretty much all cases except for sorting (and maybe some others), so it will default to `true`.