### PR TITLE
Add `ignoreUnusedNameWhenReplaceWithFunction` option to `regexp/no-unused-capturing-group` rule

### DIFF
--- a/docs/rules/no-unused-capturing-group.md
+++ b/docs/rules/no-unused-capturing-group.md
@@ -56,7 +56,8 @@ var index = '2000-12-31'.search(/(\d{4})-(\d{2})-(\d{2})/) // 0
 ```json
 {
   "regexp/no-unused-capturing-group": ["error", {
-    "fixable": true
+    "fixable": false,
+    "ignoreUnusedNameWhenReplaceWithFunction": true
   }]
 }
 ```
@@ -67,10 +68,87 @@ var index = '2000-12-31'.search(/(\d{4})-(\d{2})-(\d{2})/) // 0
 
   This rule is not fixable by default. Unused capturing groups can indicate a mistake in the code that uses the regex, so changing the regex might not be the right fix. When enabling this option, be sure to carefully check its changes.
 
+- `ignoreUnusedNameWhenReplaceWithFunction: true | false`
+
+  This option controls whether to report unused names in named capturing groups when used in `replace` method with replacer function. Defaults to `true`.
+
+  If you use the `replace` method with replacer function, you must use the last argument (`groups`) to use the named capturing group.
+
+  e.g.
+
+  ```js
+  str.replace(
+    /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/g,
+    (match, year, month, day, offset, string, groups) => {
+      return `${groups.year}/${groups.month}/${groups.day}`
+    }
+  )
+  ```
+
+  In most cases, it's simpler to use the previous argument than to refer to `groups`.
+
+  ```js
+  str.replace(
+    /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/g,
+    (match, year, month, day) => {
+      return `${year}/${month}/${day}`
+    }
+  )
+  ```
+
+  If this option to `true`, it does not report that name is not used (`groups` are not used).
+
+  <eslint-code-block fix>
+
+  ```js
+  /* eslint regexp/no-unused-capturing-group: ["error", {"ignoreUnusedNameWhenReplaceWithFunction": true}] */
+  const str = "2000-12-31"
+  str.replace(
+    /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/g,
+    (match, year, month, day) => {
+      return `${year}/${month}/${day}`
+    }
+  )
+  ```
+
+  </eslint-code-block>
+
+  If this option to `false`, report it. You need to use the `groups`, or remove the name as follows:
+
+  <eslint-code-block fix>
+
+  ```js
+  /* eslint regexp/no-unused-capturing-group: ["error", {"ignoreUnusedNameWhenReplaceWithFunction": false}] */
+  const str = "2000-12-31"
+
+  // Used names
+  str.replace(
+    /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/g,
+    (match, year, month, day, offset, string, groups) => {
+      return `${groups.year}/${groups.month}/${groups.day}`
+    }
+  )
+
+  // Remove names
+  str.replace(
+    /(\d{4})-(\d{2})-(\d{2})/g,
+    (match, year, month, day) => {
+      return `${year}/${month}/${day}`
+    }
+  )
+  ```
+
+  </eslint-code-block>
+
+  However, note that if you remove the names, it will be reported in the [regexp/prefer-named-capture-group] rule and [prefer-named-capture-group] rule.
 
 ## :couple: Related rules
 
-- [regexp/no-useless-dollar-replacements](./no-useless-dollar-replacements.md)
+- [regexp/no-useless-dollar-replacements]
+
+[regexp/no-useless-dollar-replacements]: ./no-useless-dollar-replacements.md
+[regexp/prefer-named-capture-group]: ./prefer-named-capture-group.md
+[prefer-named-capture-group]: https://eslint.org/docs/rules/prefer-named-capture-group
 
 ## :rocket: Version
 

--- a/tests/lib/rules/no-unused-capturing-group.ts
+++ b/tests/lib/rules/no-unused-capturing-group.ts
@@ -39,7 +39,6 @@ tester.run("no-unused-capturing-group", rule as any, {
         var index = '2000-12-31'.search(/(?:\d{4})-(?:\d{2})-(?:\d{2})/) // 0
         `,
         "var replaced = '2000-12-31'.replace(/(\\d{4})-(\\d{2})-(\\d{2})/, (_, y, m, d) => `${y}/${m}/${d}`)",
-        "var replaced = '2000-12-31'.replace(/(?<y>\\d{4})-(?<m>\\d{2})-(?<d>\\d{2})/, (_, y, m, d, o, s, g) => `${g.y}/${g.m}/${g.d}`)",
         String.raw`
         // var replaced = '2000-12-31'.replace(/(\d{4})-(\d{2})-(\d{2})/, '$1/$2')
         var replaced = '2000-12-31'.replace(/\d{4}-\d{2}-\d{2}/, '$1/$2')
@@ -114,6 +113,14 @@ tester.run("no-unused-capturing-group", rule as any, {
                 sourceType: "script",
             },
         },
+        "var replaced = '2000-12-31'.replace(/(?<y>\\d{4})-(?<m>\\d{2})-(?<d>\\d{2})/, (_, y, m, d) => `${y}/${m}/${d}`)",
+        "var replaced = '2000-12-31'.replace(/(?<y>\\d{4})-(?<m>\\d{2})-(?<d>\\d{2})/, function (_, y, m, d) {return `${y}/${m}/${d}`})",
+        "var replaced = '2000-12-31'.replaceAll(/(?<y>\\d{4})-(?<m>\\d{2})-(?<d>\\d{2})/g, (_, y, m, d) => `${y}/${m}/${d}`)",
+        {
+            code:
+                "var replaced = '2000-12-31'.replace(/(?<y>\\d{4})-(?<m>\\d{2})-(?<d>\\d{2})/, (_, y, m, d, o, s, g) => `${g.y}/${g.m}/${g.d}`)",
+            options: [{ ignoreUnusedNameWhenReplaceWithFunction: false }],
+        },
     ],
     invalid: [
         {
@@ -180,6 +187,27 @@ tester.run("no-unused-capturing-group", rule as any, {
         {
             code:
                 "var replaced = '2000-12-31'.replace(/(?<y>\\d{4})-(?<m>\\d{2})-(?<d>\\d{2})/, (_, y, m, d) => `${y}/${m}/${d}`)",
+            options: [{ ignoreUnusedNameWhenReplaceWithFunction: false }],
+            errors: [
+                "Capturing group 'y' has a name, but its name is never used.",
+                "Capturing group 'm' has a name, but its name is never used.",
+                "Capturing group 'd' has a name, but its name is never used.",
+            ],
+        },
+        {
+            code:
+                "var replaced = '2000-12-31'.replace(/(?<y>\\d{4})-(?<m>\\d{2})-(?<d>\\d{2})/, function (_, y, m, d) {return `${y}/${m}/${d}`})",
+            options: [{ ignoreUnusedNameWhenReplaceWithFunction: false }],
+            errors: [
+                "Capturing group 'y' has a name, but its name is never used.",
+                "Capturing group 'm' has a name, but its name is never used.",
+                "Capturing group 'd' has a name, but its name is never used.",
+            ],
+        },
+        {
+            code:
+                "var replaced = '2000-12-31'.replaceAll(/(?<y>\\d{4})-(?<m>\\d{2})-(?<d>\\d{2})/g, (_, y, m, d) => `${y}/${m}/${d}`)",
+            options: [{ ignoreUnusedNameWhenReplaceWithFunction: false }],
             errors: [
                 "Capturing group 'y' has a name, but its name is never used.",
                 "Capturing group 'm' has a name, but its name is never used.",


### PR DESCRIPTION
See https://github.com/ota-meshi/eslint-plugin-regexp/pull/339#discussion_r717214475.

The option is enabled by default, so `replace` with replacer function will no reported.