### PR TITLE
Add `insideCharacterClass` option to `prefer-d`

### DIFF
--- a/docs/rules/prefer-d.md
+++ b/docs/rules/prefer-d.md
@@ -34,7 +34,79 @@ var foo = /[^0-9]/;
 
 ## :wrench: Options
 
-Nothing.
+```json5
+{
+  "regexp/prefer-d": [
+    "error",
+    {
+        "insideCharacterClass": "d"
+    }
+  ]
+}
+```
+
+### `insideCharacterClass`
+
+This option control how character class element equivalent to `\d` will be treated.
+
+*Note:* This option does not affect character classes equivalent to `\d`. E.g. `[\d]`, `[0-9]`, and `[0123456789]` are unaffected.
+
+- `insideCharacterClass: "d"` (_default_)
+
+  Character class element equivalent to `\d` will be reported and replaced with `\d`.
+
+  <eslint-code-block fix>
+
+  ```js
+  /* eslint regexp/prefer-d: ["error", { insideCharacterClass: "d" }] */
+
+  /* ✓ GOOD */
+  var foo = /[\da-z]/;
+
+  /* ✗ BAD */
+  var foo = /[0-9a-z]/;
+  var foo = /[0-9]/;
+  ```
+
+  </eslint-code-block>
+
+- `insideCharacterClass: "range"`
+
+  Character class element equivalent to `\d` will be reported and replaced with the range `0-9`.
+
+  <eslint-code-block fix>
+
+  ```js
+  /* eslint regexp/prefer-d: ["error", { insideCharacterClass: "range" }] */
+
+  /* ✓ GOOD */
+  var foo = /[0-9a-z]/;
+
+  /* ✗ BAD */
+  var foo = /[\da-z]/;
+  var foo = /[0-9]/;
+  ```
+
+  </eslint-code-block>
+
+- `insideCharacterClass: "ignore"`
+
+  Character class element will not be reported.
+
+  <eslint-code-block fix>
+
+  ```js
+  /* eslint regexp/prefer-d: ["error", { insideCharacterClass: "ignore" }] */
+
+  /* ✓ GOOD */
+  var foo = /[\da-z]/;
+  var foo = /[0-9a-z]/;
+
+  /* ✗ BAD */
+  var foo = /[0-9]/;
+  ```
+
+  </eslint-code-block>
 
 ## :rocket: Version
 

--- a/tests/lib/rules/prefer-d.ts
+++ b/tests/lib/rules/prefer-d.ts
@@ -9,7 +9,26 @@ const tester = new RuleTester({
 })
 
 tester.run("prefer-d", rule as any, {
-    valid: ["/\\d/", "/[1-9]/"],
+    valid: [
+        String.raw`/\d/`,
+        String.raw`/[1-9]/`,
+        {
+            code: String.raw`/[0-9a-z]/`,
+            options: [{ insideCharacterClass: "ignore" }],
+        },
+        {
+            code: String.raw`/[\da-z]/`,
+            options: [{ insideCharacterClass: "ignore" }],
+        },
+        {
+            code: String.raw`/[0-9a-z]/`,
+            options: [{ insideCharacterClass: "range" }],
+        },
+        {
+            code: String.raw`/[\da-z]/`,
+            options: [{ insideCharacterClass: "d" }],
+        },
+    ],
     invalid: [
         {
             code: "/[0-9]/",
@@ -65,6 +84,20 @@ tester.run("prefer-d", rule as any, {
             `,
             output: null,
             errors: ["Unexpected character class '[0-9]'. Use '\\d' instead."],
+        },
+        {
+            code: String.raw`/[0-9a-z]/`,
+            output: String.raw`/[\da-z]/`,
+            options: [{ insideCharacterClass: "d" }],
+            errors: [
+                "Unexpected character class range '0-9'. Use '\\d' instead.",
+            ],
+        },
+        {
+            code: String.raw`/[\da-z]/`,
+            output: String.raw`/[0-9a-z]/`,
+            options: [{ insideCharacterClass: "range" }],
+            errors: ["Unexpected character set '\\d'. Use '0-9' instead."],
         },
     ],
 })


### PR DESCRIPTION
This fixes #341.

The new option adds 3 modes for character class elements:

- `ignore`: This is the don't-care option.
- `d` *(default)*: Replace all with `\d`. This is the current behaviour.
- `range`: Replace all with `0-9`.