### PR TITLE
Add `regexp/use-ignore-case` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/prefer-regexp-test](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-regexp-test.html) | enforce that `RegExp#test` is used instead of `String#match` and `RegExp#exec` | :wrench: |
 | [regexp/require-unicode-regexp](https://ota-meshi.github.io/eslint-plugin-regexp/rules/require-unicode-regexp.html) | enforce the use of the `u` flag | :wrench: |
 | [regexp/sort-alternatives](https://ota-meshi.github.io/eslint-plugin-regexp/rules/sort-alternatives.html) | sort alternatives if order doesn't matter | :wrench: |
+| [regexp/use-ignore-case](https://ota-meshi.github.io/eslint-plugin-regexp/rules/use-ignore-case.html) | use the `i` flag if it simplifies the pattern | :wrench: |
 
 ### Stylistic Issues
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -68,6 +68,7 @@ The rules with the following star :star: are included in the `plugin:regexp/reco
 | [regexp/prefer-regexp-test](./prefer-regexp-test.md) | enforce that `RegExp#test` is used instead of `String#match` and `RegExp#exec` | :wrench: |
 | [regexp/require-unicode-regexp](./require-unicode-regexp.md) | enforce the use of the `u` flag | :wrench: |
 | [regexp/sort-alternatives](./sort-alternatives.md) | sort alternatives if order doesn't matter | :wrench: |
+| [regexp/use-ignore-case](./use-ignore-case.md) | use the `i` flag if it simplifies the pattern | :wrench: |
 
 ### Stylistic Issues
 

--- a/docs/rules/use-ignore-case.md
+++ b/docs/rules/use-ignore-case.md
@@ -1,0 +1,41 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "regexp/use-ignore-case"
+description: "use the `i` flag if it simplifies the pattern"
+---
+# regexp/use-ignore-case
+
+> use the `i` flag if it simplifies the pattern
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule reports regular expressions that can be simplified by adding the `i` flag.
+
+<eslint-code-block fix>
+
+```js
+/* eslint regexp/use-ignore-case: "error" */
+
+/* ✓ GOOD */
+var foo = /\w\d+a/;
+var foo = /\b0x[a-fA-F0-9]+\b/;
+
+/* ✗ BAD */
+var foo = /[a-zA-Z]/;
+var foo = /\b0[xX][a-fA-F0-9]+\b/;
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/lib/rules/use-ignore-case.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-regexp/blob/master/tests/lib/rules/use-ignore-case.ts)

--- a/lib/rules/use-ignore-case.ts
+++ b/lib/rules/use-ignore-case.ts
@@ -1,0 +1,258 @@
+import type { CharSet } from "refa"
+import { Chars, toCharSet } from "regexp-ast-analysis"
+import type { CharacterClass, CharacterClassElement } from "regexpp/ast"
+import type { RegExpVisitor } from "regexpp/visitor"
+import type { RegExpContext } from "../utils"
+import { createRule, defineRegexpVisitor } from "../utils"
+import {
+    getIgnoreCaseFlags,
+    isCaseVariant,
+} from "../utils/regexp-ast/case-variation"
+import { mention } from "../utils/mention"
+import type {
+    PatternSource,
+    PatternRange,
+} from "../utils/ast-utils/pattern-source"
+import type { Rule } from "eslint"
+import { UsageOfPattern } from "../utils/get-usage-of-pattern"
+
+const ELEMENT_ORDER: Record<CharacterClassElement["type"], number> = {
+    Character: 1,
+    CharacterClassRange: 2,
+    CharacterSet: 3,
+}
+
+/**
+ * Finds all character class elements that do not contribute to the whole.
+ */
+function findUseless(
+    elements: readonly CharacterClassElement[],
+    getCharSet: (e: CharacterClassElement) => CharSet,
+    other: CharSet,
+): Set<CharacterClassElement> {
+    const cache = new Map<CharacterClassElement, CharSet>()
+
+    /** A cached version of `getCharSet` */
+    function get(e: CharacterClassElement): CharSet {
+        let cached = cache.get(e)
+        if (cached === undefined) {
+            cached = getCharSet(e)
+            cache.set(e, cached)
+        }
+        return cached
+    }
+
+    // When searching for useless elements, we want to first
+    // search for useless characters, then useless ranges, and
+    // finally useless sets.
+
+    const sortedElements = [...elements]
+        .reverse()
+        .sort((a, b) => ELEMENT_ORDER[a.type] - ELEMENT_ORDER[b.type])
+
+    const useless = new Set<CharacterClassElement>()
+
+    for (const e of sortedElements) {
+        const cs = get(e)
+        if (cs.isSubsetOf(other)) {
+            useless.add(e)
+            continue
+        }
+
+        // the total of all other elements
+        const otherElements = elements.filter((o) => o !== e && !useless.has(o))
+        const total = other.union(...otherElements.map(get))
+        if (cs.isSubsetOf(total)) {
+            useless.add(e)
+            continue
+        }
+    }
+
+    return useless
+}
+
+/** Returns all elements not in the given set */
+function without<T>(iter: Iterable<T>, set: ReadonlySet<T>): T[] {
+    const result: T[] = []
+    for (const item of iter) {
+        if (!set.has(item)) {
+            result.push(item)
+        }
+    }
+    return result
+}
+
+/**
+ * Removes all the given ranges from the given pattern.
+ *
+ * This assumes that all ranges are disjoint
+ */
+function removeAll(
+    fixer: Rule.RuleFixer,
+    patternSource: PatternSource,
+    ranges: readonly PatternRange[],
+) {
+    const sorted = [...ranges].sort((a, b) => b.start - a.start)
+    let pattern = patternSource.value
+
+    for (const { start, end } of sorted) {
+        pattern = pattern.slice(0, start) + pattern.slice(end)
+    }
+
+    const range = patternSource.getReplaceRange({
+        start: 0,
+        end: patternSource.value.length,
+    })
+    if (range) {
+        return range.replace(fixer, pattern)
+    }
+    return null
+}
+
+export default createRule("use-ignore-case", {
+    meta: {
+        docs: {
+            description: "use the `i` flag if it simplifies the pattern",
+            category: "Best Practices",
+            // TODO Switch to recommended in the major version.
+            // recommended: true,
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [],
+        messages: {
+            unexpected:
+                "The character class(es) {{ classes }} can be simplified using the `i` flag.",
+        },
+        type: "suggestion",
+    },
+    create(context) {
+        /**
+         * Create visitor
+         */
+        function createVisitor(
+            regexpContext: RegExpContext,
+        ): RegExpVisitor.Handlers {
+            const {
+                node,
+                flags,
+                ownsFlags,
+                flagsString,
+                patternAst,
+                patternSource,
+                getUsageOfPattern,
+                getFlagsLocation,
+                fixReplaceFlags,
+            } = regexpContext
+
+            if (!ownsFlags || flagsString === null) {
+                // It's not (statically) fixable
+                return {}
+            }
+            if (flags.ignoreCase) {
+                // We can't suggest the i flag if it's already used
+                return {}
+            }
+            if (getUsageOfPattern() === UsageOfPattern.partial) {
+                // Adding flags to partial patterns isn't a good idea
+                return {}
+            }
+            if (isCaseVariant(patternAst, flags)) {
+                // We can't add the i flag
+                return {}
+            }
+
+            const uselessElements: CharacterClassElement[] = []
+            const ccs: CharacterClass[] = []
+
+            return {
+                onCharacterClassEnter(ccNode) {
+                    const invariantElement = ccNode.elements.filter(
+                        (e) => !isCaseVariant(e, flags),
+                    )
+                    if (invariantElement.length === ccNode.elements.length) {
+                        // all elements are case invariant
+                        return
+                    }
+
+                    const invariant = Chars.empty(flags).union(
+                        ...invariantElement.map((e) => toCharSet(e, flags)),
+                    )
+
+                    let variantElements = without(
+                        ccNode.elements,
+                        new Set(invariantElement),
+                    )
+
+                    // find all elements that are useless even without
+                    // the i flag
+                    const alwaysUseless = findUseless(
+                        variantElements,
+                        (e) => toCharSet(e, flags),
+                        invariant,
+                    )
+
+                    // remove useless elements
+                    variantElements = without(variantElements, alwaysUseless)
+
+                    // find useless elements
+                    const iFlags = getIgnoreCaseFlags(flags)
+                    const useless = findUseless(
+                        variantElements,
+                        (e) => toCharSet(e, iFlags),
+                        invariant,
+                    )
+
+                    uselessElements.push(...useless)
+                    ccs.push(ccNode)
+                },
+
+                onPatternLeave() {
+                    if (uselessElements.length === 0) {
+                        return
+                    }
+
+                    context.report({
+                        node,
+                        loc: getFlagsLocation(),
+                        messageId: "unexpected",
+                        data: {
+                            classes: ccs.map((cc) => mention(cc)).join(", "),
+                        },
+                        fix(fixer) {
+                            const patternFix = removeAll(
+                                fixer,
+                                patternSource,
+                                uselessElements,
+                            )
+                            if (!patternFix) {
+                                return null
+                            }
+
+                            const flagsFix = fixReplaceFlags(
+                                `${flagsString}i`,
+                                false,
+                            )(fixer)
+                            if (!flagsFix) {
+                                return null
+                            }
+
+                            const fix = [patternFix]
+                            if (Array.isArray(flagsFix)) {
+                                fix.push(...flagsFix)
+                            } else {
+                                fix.push(flagsFix)
+                            }
+
+                            return fix
+                        },
+                    })
+                },
+            }
+        }
+
+        return defineRegexpVisitor(context, {
+            createVisitor,
+        })
+    },
+})

--- a/lib/utils/regexp-ast/case-variation.ts
+++ b/lib/utils/regexp-ast/case-variation.ts
@@ -1,0 +1,153 @@
+import type { ReadonlyFlags } from "regexp-ast-analysis"
+import {
+    toCache,
+    hasSomeDescendant,
+    toCharSet,
+    isEmptyBackreference,
+} from "regexp-ast-analysis"
+import type {
+    Alternative,
+    Character,
+    CharacterClassElement,
+    CharacterClassRange,
+    CharacterSet,
+    Element,
+    Pattern,
+} from "regexpp/ast"
+
+const ignoreCaseFlagsCache = new WeakMap<ReadonlyFlags, ReadonlyFlags>()
+const caseSensitiveFlagsCache = new WeakMap<ReadonlyFlags, ReadonlyFlags>()
+
+/**
+ * Returns flags equivalent to the given flags but with the `i` flag set.
+ */
+export function getIgnoreCaseFlags(flags: ReadonlyFlags): ReadonlyFlags {
+    if (flags.ignoreCase) {
+        return flags
+    }
+
+    let cached = ignoreCaseFlagsCache.get(flags)
+    if (cached === undefined) {
+        cached = toCache({ ...flags, ignoreCase: true })
+        ignoreCaseFlagsCache.set(flags, cached)
+    }
+    return cached
+}
+
+/**
+ * Returns flags equivalent to the given flags but without the `i` flag set.
+ */
+export function getCaseSensitiveFlags(flags: ReadonlyFlags): ReadonlyFlags {
+    if (flags.ignoreCase === false) {
+        return flags
+    }
+
+    let cached = caseSensitiveFlagsCache.get(flags)
+    if (cached === undefined) {
+        cached = toCache({ ...flags, ignoreCase: false })
+        caseSensitiveFlagsCache.set(flags, cached)
+    }
+    return cached
+}
+
+/**
+ * Returns whether the given element **will not** behave the same with or
+ * without the `i` flag.
+ *
+ * @param wholeCharacterClass Whether character classes will be checked as a
+ * whole or as a list of character class elements.
+ *
+ * If `false`, then the character class is case-variant if any of its elements
+ * is case-variant.
+ *
+ * Examples:
+ * - `wholeCharacterClass: true`: `isCaseVariant(/[a-zA-Z]/) -> false`
+ * - `wholeCharacterClass: false`: `isCaseVariant(/[a-zA-Z]/) -> true`
+ */
+export function isCaseVariant(
+    element: Element | CharacterClassElement | Alternative | Pattern,
+    flags: ReadonlyFlags,
+    wholeCharacterClass = true,
+): boolean {
+    const { unicode = false } = flags
+
+    const iSet = getIgnoreCaseFlags(flags)
+    const iUnset = getCaseSensitiveFlags(flags)
+
+    /** Whether the given character class element is case variant */
+    function ccElementIsCaseVariant(
+        e: Character | CharacterClassRange | CharacterSet,
+    ): boolean {
+        switch (e.type) {
+            case "Character":
+                // case-variant characters will accept > 1 characters
+                return toCharSet(e, iSet).size !== 1
+
+            case "CharacterClassRange":
+                return !toCharSet(e, iSet).equals(toCharSet(e, iUnset))
+
+            case "CharacterSet":
+                switch (e.kind) {
+                    case "word":
+                        // \w which is case-variant in Unicode mode
+                        return unicode
+                    case "property":
+                        // just check for equality
+                        return !toCharSet(e, iSet).equals(toCharSet(e, iUnset))
+                    default:
+                        // all other character sets are case-invariant
+                        return false
+                }
+
+            default:
+                throw new Error(`Unknown type: ${e}`)
+        }
+    }
+
+    return hasSomeDescendant(
+        element,
+        (d) => {
+            switch (d.type) {
+                case "Assertion":
+                    // \b and \B are defined in terms of \w which is
+                    // case-variant in Unicode mode
+                    return unicode && d.kind === "word"
+
+                case "Backreference":
+                    // we need to check whether the associated capturing group
+                    // is case variant
+                    if (hasSomeDescendant(element, d.resolved)) {
+                        // the capturing group is part of the root element, so
+                        // we don't need to make an extra check
+                        return false
+                    }
+
+                    return (
+                        !isEmptyBackreference(d) &&
+                        isCaseVariant(d.resolved, flags)
+                    )
+
+                case "Character":
+                case "CharacterClassRange":
+                case "CharacterSet":
+                    return ccElementIsCaseVariant(d)
+
+                case "CharacterClass":
+                    if (!wholeCharacterClass) {
+                        return d.elements.some(ccElementIsCaseVariant)
+                    }
+                    // just check for equality
+                    return !toCharSet(d, iSet).equals(toCharSet(d, iUnset))
+
+                default:
+                    return false
+            }
+        },
+        (d) => {
+            // don't go into character classes and ranges
+            return (
+                d.type !== "CharacterClass" && d.type !== "CharacterClassRange"
+            )
+        },
+    )
+}

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -72,6 +72,7 @@ import sortCharacterClassElements from "../rules/sort-character-class-elements"
 import sortFlags from "../rules/sort-flags"
 import strict from "../rules/strict"
 import unicodeEscape from "../rules/unicode-escape"
+import useIgnoreCase from "../rules/use-ignore-case"
 
 export const rules = [
     confusingQuantifier,
@@ -147,4 +148,5 @@ export const rules = [
     sortFlags,
     strict,
     unicodeEscape,
+    useIgnoreCase,
 ] as RuleModule[]

--- a/tests/lib/rules/use-ignore-case.ts
+++ b/tests/lib/rules/use-ignore-case.ts
@@ -1,0 +1,45 @@
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/use-ignore-case"
+
+const tester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+})
+
+tester.run("use-ignore-case", rule as any, {
+    valid: [
+        String.raw`/regexp/`,
+        String.raw`/[aA]/i`,
+        String.raw`/[aA]a/`,
+        String.raw`/[aAb]/`,
+        String.raw`/[aaaa]/`,
+
+        // partial pattern
+        String.raw`/[a-zA-Z]/.source`,
+    ],
+    invalid: [
+        {
+            code: String.raw`/[a-zA-Z]/`,
+            output: String.raw`/[a-z]/i`,
+            errors: [
+                "The character class(es) '[a-zA-Z]' can be simplified using the `i` flag.",
+            ],
+        },
+        {
+            code: String.raw`/\b0[xX][a-fA-F0-9]+\b/`,
+            output: String.raw`/\b0[x][a-f0-9]+\b/i`,
+            errors: [
+                "The character class(es) '[xX]', '[a-fA-F0-9]' can be simplified using the `i` flag.",
+            ],
+        },
+        {
+            code: String.raw`RegExp("[a-zA-Z]")`,
+            output: String.raw`RegExp("[a-z]", "i")`,
+            errors: [
+                "The character class(es) '[a-zA-Z]' can be simplified using the `i` flag.",
+            ],
+        },
+    ],
+})


### PR DESCRIPTION
This resolves #201, a somewhat long-standing issue.

Other changes:

- I moved the case-invariance logic from `no-useless-flags` into its own file, so `use-ignore-case` can use it.
- I fixed a bug with `fixReplaceFlags`. The new `includePattern` parameter added in #338 was ignored for regex literals. I noticed this big because `use-ignore-case`'s fix didn't work.