### PR TITLE
Improve `regexp/require-unicode-regexp` fixes

### DIFF
--- a/lib/rules/require-unicode-regexp.ts
+++ b/lib/rules/require-unicode-regexp.ts
@@ -164,7 +164,7 @@ function isCompatibleCharLike(
  * Whether the given quantifier accepts the same characters with and without
  * the u flag.
  *
- * This will return `null` if undecided.
+ * This will return `undefined` if the function cannot decide.
  */
 function isCompatibleQuantifier(
     q: Quantifier,

--- a/tests/lib/rules/require-unicode-regexp.ts
+++ b/tests/lib/rules/require-unicode-regexp.ts
@@ -100,6 +100,21 @@ tester.run("require-unicode-regexp", rule as any, {
             errors: 1,
         },
         {
+            code: String.raw`/ab+c/`,
+            output: String.raw`/ab+c/u`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/a.*b/`,
+            output: String.raw`/a.*b/u`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/<[^<>]+>/`,
+            output: String.raw`/<[^<>]+>/u`,
+            errors: 1,
+        },
+        {
             // "k" maps to 3 characters in ignore-case Unicode mode
             code: String.raw`/k/i`,
             output: null,
@@ -129,6 +144,12 @@ tester.run("require-unicode-regexp", rule as any, {
         },
         {
             code: String.raw`/\p{Ll}/`,
+            output: null,
+            errors: 1,
+        },
+        {
+            // "<😃>" is accepted by one but not the other
+            code: String.raw`/<[^<>]>/`,
             output: null,
             errors: 1,
         },


### PR DESCRIPTION
This makes `regexp/require-unicode-regexp` a little smarter so it can auto-fix more problems. It can now fix quantifiers like `a.*?b`.

Running the old and new `regexp/require-unicode-regexp` rule on Prism's codebase (which has 0 `u`-flag regexes) yields this:

Old:
```
4236 problems (4236 errors, 0 warnings)
2222 errors and 0 warnings potentially fixable with the `--fix` option.
```

New:
```
4236 problems (4236 errors, 0 warnings)
2562 errors and 0 warnings potentially fixable with the `--fix` option.
```

The number of fixable regexes went from 52% to 60%.

