### PR TITLE
Upgrade to RAA v0.5.1 and improve `sort-alternatives`

### DIFF
--- a/lib/rules/no-useless-assertions.ts
+++ b/lib/rules/no-useless-assertions.ts
@@ -252,7 +252,7 @@ export default createRule("no-useless-assertions", {
                     const range = getLengthRange(assertion.alternatives)
                     // we only check the first character, so it's only correct if the assertion requires only one
                     // character
-                    if (range && range.max === 1) {
+                    if (range.max === 1) {
                         // require exactness
                         if (
                             firstOf.exact &&

--- a/lib/rules/prefer-lookaround.ts
+++ b/lib/rules/prefer-lookaround.ts
@@ -168,7 +168,7 @@ function getSideEffectsWhenReplacingCapturingGroup(
     /** Checks whether the given element is constant length. */
     function isConstantLength(target: Element): boolean {
         const range = getLengthRange(target)
-        return Boolean(range && range.min === range.max)
+        return range.min === range.max
     }
 }
 

--- a/lib/rules/sort-alternatives.ts
+++ b/lib/rules/sort-alternatives.ts
@@ -152,6 +152,7 @@ function compareCharSetStrings(
 
 const LONGEST_PREFIX_OPTIONS: GetLongestPrefixOptions = {
     includeAfter: true,
+    onlyInside: true,
     looseGroups: true,
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13641,9 +13641,9 @@
             }
         },
         "regexp-ast-analysis": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.4.1.tgz",
-            "integrity": "sha512-dNHpddl5YQ+Q9qyOSEhMJ6tvUxAqRACaqAQi6/imHvo5uVz4re/QGcK/w8jRa0M2H9FGlkiseKj8kthzjHy4Bw==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.5.0.tgz",
+            "integrity": "sha512-TF5VRGBEr11VwA/8L2EbMuKiPpNgfPgtoh36hvR10wjOmm8LjLnQgRA2rP9DIToKLaZ9CN27R9i1b4EgQoaavg==",
             "requires": {
                 "refa": "^0.9.0",
                 "regexpp": "^3.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13641,9 +13641,9 @@
             }
         },
         "regexp-ast-analysis": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.5.0.tgz",
-            "integrity": "sha512-TF5VRGBEr11VwA/8L2EbMuKiPpNgfPgtoh36hvR10wjOmm8LjLnQgRA2rP9DIToKLaZ9CN27R9i1b4EgQoaavg==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.5.1.tgz",
+            "integrity": "sha512-Ca/g9gaTNuMewLuu+mBIq4vCrGRSO8AE9bP32NMQjJ/wBTdWq0g96qLkBb0NbGwEbp7S/q+NQF3o7veeuRfg0g==",
             "requires": {
                 "refa": "^0.9.0",
                 "regexpp": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "grapheme-splitter": "^1.0.4",
         "jsdoctypeparser": "^9.0.0",
         "refa": "^0.9.0",
-        "regexp-ast-analysis": "^0.5.0",
+        "regexp-ast-analysis": "^0.5.1",
         "regexpp": "^3.2.0",
         "scslre": "^0.1.6"
     }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "grapheme-splitter": "^1.0.4",
         "jsdoctypeparser": "^9.0.0",
         "refa": "^0.9.0",
-        "regexp-ast-analysis": "^0.4.1",
+        "regexp-ast-analysis": "^0.5.0",
         "regexpp": "^3.2.0",
         "scslre": "^0.1.6"
     }

--- a/tests/lib/rules/sort-alternatives.ts
+++ b/tests/lib/rules/sort-alternatives.ts
@@ -9,7 +9,13 @@ const tester = new RuleTester({
 })
 
 tester.run("sort-alternatives", rule as any, {
-    valid: [String.raw`/\b(?:a|\d+|c|b)\b/`, String.raw`/\b(?:\^|c|b)\b/`],
+    valid: [
+        String.raw`/\b(?:a|\d+|c|b)\b/`,
+        String.raw`/\b(?:\^|c|b)\b/`,
+        String.raw`/^(?:a|ab)a/u`,
+        String.raw`/^(?:a|ab)c/u`,
+        String.raw`/^(?:deg|g?rad|turn)\b/`,
+    ],
     invalid: [
         {
             code: String.raw`/c|b|a/`,


### PR DESCRIPTION
This fixes #416.

> Fixing this issue will be quite easy.

As it turned out, it was not that easy. Just disabling the `includeAfter` option wasn't good enough, so I added a new option `insideOnly`. This new option is actually what we want, but to implement this option, I needed to change the `getLengthRange` function as well.

Anyway, it all works now and using `getLengthRange` is actually easier now.