### PR TITLE
Remove unused code in `sort-alternatives`

### DIFF
--- a/lib/rules/sort-alternatives.ts
+++ b/lib/rules/sort-alternatives.ts
@@ -18,7 +18,6 @@ import type {
 } from "regexp-ast-analysis"
 import {
     Chars,
-    getFirstConsumedChar,
     hasSomeDescendant,
     canReorder,
     getLongestPrefix,
@@ -162,16 +161,6 @@ function sortAlternatives(
     alternatives: Alternative[],
     flags: ReadonlyFlags,
 ): void {
-    const firstChars = new Map<Alternative, number>()
-    for (const a of alternatives) {
-        const chars = getFirstConsumedChar(a, "ltr", flags)
-        const char =
-            chars.empty || chars.char.isEmpty
-                ? Infinity
-                : chars.char.ranges[0].min
-        firstChars.set(a, char)
-    }
-
     alternatives.sort((a, b) => {
         const prefixDiff = compareCharSetStrings(
             getLongestPrefix(a, "ltr", flags, LONGEST_PREFIX_OPTIONS),


### PR DESCRIPTION
I forgot to remove some old code in #320. This code used to be part of the comparison, but was replaced by the prefix-based comparison function we use today.