### PR TITLE
Remove duplicate code and cache `JS.Parser` instances

### DIFF
--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -15,7 +15,7 @@ import {
     fixRemoveCharacterClassElement,
     fixRemoveAlternative,
 } from "../utils"
-import { isCoveredNode, isEqualNodes } from "../utils/regexp-ast"
+import { getParser, isCoveredNode, isEqualNodes } from "../utils/regexp-ast"
 import type { Expression, FiniteAutomaton, NoParent, ReadonlyNFA } from "refa"
 import {
     combineTransformers,
@@ -35,7 +35,6 @@ import {
     getEffectiveMaximumRepetition,
     canReorder,
 } from "regexp-ast-analysis"
-import { RegExpParser } from "regexpp"
 import { UsageOfPattern } from "../utils/get-usage-of-pattern"
 import { mention, mentionChar } from "../utils/mention"
 import type { NestedAlternative } from "../utils/partial-parser"
@@ -964,25 +963,10 @@ export default createRule("no-dupe-disjunctions", {
         function createVisitor(
             regexpContext: RegExpContext,
         ): RegExpVisitor.Handlers {
-            const {
-                patternAst,
-                flagsString,
-                flags,
-                node,
-                getRegexpLocation,
-                getUsageOfPattern,
-            } = regexpContext
+            const { flags, node, getRegexpLocation, getUsageOfPattern } =
+                regexpContext
 
-            const parser = JS.Parser.fromAst({
-                pattern: patternAst,
-                flags: new RegExpParser().parseFlags(
-                    [
-                        ...new Set(
-                            (flagsString || "").replace(/[^gimsuy]/gu, ""),
-                        ),
-                    ].join(""),
-                ),
-            })
+            const parser = getParser(regexpContext)
 
             /** Returns the filter information for the given node */
             function getFilterInfo(parentNode: ParentNode): FilterInfo {

--- a/lib/rules/no-super-linear-backtracking.ts
+++ b/lib/rules/no-super-linear-backtracking.ts
@@ -2,10 +2,10 @@ import type { RegExpVisitor } from "regexpp/visitor"
 import type { RegExpContext } from "../utils"
 import { createRule, defineRegexpVisitor } from "../utils"
 import { UsageOfPattern } from "../utils/get-usage-of-pattern"
-import type { ParsedLiteral } from "scslre"
 import { analyse } from "scslre"
 import type { Position, SourceLocation } from "estree"
 import { mention } from "../utils/mention"
+import { getJSRegexppAst } from "../utils/regexp-ast"
 
 /**
  * Returns the combined source location of the two given locations.
@@ -24,31 +24,6 @@ function unionLocations(a: SourceLocation, b: SourceLocation): SourceLocation {
     return {
         start: { ...(less(a.start, b.start) ? a.start : b.start) },
         end: { ...(less(a.end, b.end) ? b.end : a.end) },
-    }
-}
-
-/**
- * Create a parsed literal object as required by the scslre library.
- */
-function getParsedLiteral(context: RegExpContext): ParsedLiteral {
-    const { flags, flagsString, patternAst } = context
-
-    return {
-        pattern: patternAst,
-        flags: {
-            type: "Flags",
-            raw: flagsString ?? "",
-            parent: null,
-            start: NaN,
-            end: NaN,
-            dotAll: flags.dotAll ?? false,
-            global: flags.global ?? false,
-            hasIndices: flags.hasIndices ?? false,
-            ignoreCase: flags.ignoreCase ?? false,
-            multiline: flags.multiline ?? false,
-            sticky: flags.sticky ?? false,
-            unicode: flags.unicode ?? false,
-        },
     }
 }
 
@@ -102,7 +77,7 @@ export default createRule("no-super-linear-backtracking", {
                 getUsageOfPattern,
             } = regexpContext
 
-            const result = analyse(getParsedLiteral(regexpContext), {
+            const result = analyse(getJSRegexppAst(regexpContext), {
                 reportTypes: { Move: false },
                 assumeRejectingSuffix:
                     reportUncertain &&

--- a/lib/rules/sort-alternatives.ts
+++ b/lib/rules/sort-alternatives.ts
@@ -33,8 +33,7 @@ import {
 } from "regexp-ast-analysis"
 import type { CharSet, Word, ReadonlyWord } from "refa"
 import { NFA, JS, transform } from "refa"
-import { getPossiblyConsumedChar } from "../utils/regexp-ast"
-import { RegExpParser } from "regexpp"
+import { getParser, getPossiblyConsumedChar } from "../utils/regexp-ast"
 
 interface AllowedChars {
     allowed: CharSet
@@ -540,28 +539,13 @@ export default createRule("sort-alternatives", {
         function createVisitor(
             regexpContext: RegExpContext,
         ): RegExpVisitor.Handlers {
-            const {
-                node,
-                getRegexpLocation,
-                fixReplaceNode,
-                flags,
-                flagsString,
-                patternAst,
-            } = regexpContext
+            const { node, getRegexpLocation, fixReplaceNode, flags } =
+                regexpContext
 
             const allowedChars = getAllowedChars(flags)
 
             const possibleCharsCache = new Map<Alternative, CharSet>()
-            const parser = JS.Parser.fromAst({
-                pattern: patternAst,
-                flags: new RegExpParser().parseFlags(
-                    [
-                        ...new Set(
-                            (flagsString || "").replace(/[^gimsuy]/gu, ""),
-                        ),
-                    ].join(""),
-                ),
-            })
+            const parser = getParser(regexpContext)
 
             /** A cached version of getPossiblyConsumedChar */
             function getPossibleChars(a: Alternative): CharSet {


### PR DESCRIPTION
In #421, I needed a `JS.Parser` and just copied the code to create one from `no-dupe-disjunction` rule. This PR cleans all of that up.

Changes:
- Added a cached `getParser` method
- Moved the `getParsedLiteral` methods into util and named it `getJSRegexppAst`.

---

This PR is currently still a draft because I'm waiting for #421 to get merged. This branch is not a branch from #421, so it doesn't include those changes yet.