### PR TITLE
Add option for capturing groups to `regexp/optimal-quantifier-concatenation`

### DIFF
--- a/docs/rules/optimal-quantifier-concatenation.md
+++ b/docs/rules/optimal-quantifier-concatenation.md
@@ -43,7 +43,37 @@ var foo = /\w+(?:(a)|b)*/;
 
 ## :wrench: Options
 
-Nothing.
+
+```json5
+{
+  "regexp/optimal-quantifier-concatenation": [
+    "error",
+    {
+        "capturingGroups": "report"
+    }
+  ]
+}
+```
+
+### `capturingGroups`
+
+The type of concatenation this rule reports might be intentional around capturing groups. This option allows you turn of false unfixable reports around capturing groups.
+
+- `capturingGroups: "report"` (_default_)
+
+  Concatenations around quantifiers will be reported.
+
+- `capturingGroups: "ignore"`
+
+  Concatenations around quantifiers will not be reported.
+
+  If this option is used, it is recommend to have the [regexp/no-super-linear-backtracking] rule enabled to protect against ReDoS.
+
+## :books: Further reading
+
+- [regexp/no-super-linear-backtracking]
+
+[regexp/no-super-linear-backtracking]: ./no-super-linear-backtracking.md
 
 ## :rocket: Version
 

--- a/docs/rules/optimal-quantifier-concatenation.md
+++ b/docs/rules/optimal-quantifier-concatenation.md
@@ -43,7 +43,6 @@ var foo = /\w+(?:(a)|b)*/;
 
 ## :wrench: Options
 
-
 ```json5
 {
   "regexp/optimal-quantifier-concatenation": [

--- a/lib/rules/optimal-quantifier-concatenation.ts
+++ b/lib/rules/optimal-quantifier-concatenation.ts
@@ -500,7 +500,7 @@ function getLoc(
 }
 
 const enum CapturingGroupReporting {
-    ignore = "ignpre",
+    ignore = "ignore",
     report = "report",
 }
 
@@ -542,7 +542,7 @@ export default createRule("optimal-quantifier-concatenation", {
     },
     create(context) {
         const cgReporting: CapturingGroupReporting =
-            context.options[0]?.reportExponentialBacktracking ??
+            context.options[0]?.capturingGroups ??
             CapturingGroupReporting.report
 
         /**

--- a/lib/rules/optimal-quantifier-concatenation.ts
+++ b/lib/rules/optimal-quantifier-concatenation.ts
@@ -499,6 +499,11 @@ function getLoc(
     })
 }
 
+const enum CapturingGroupReporting {
+    ignore = "ignpre",
+    report = "report",
+}
+
 export default createRule("optimal-quantifier-concatenation", {
     meta: {
         docs: {
@@ -508,7 +513,17 @@ export default createRule("optimal-quantifier-concatenation", {
             recommended: true,
         },
         fixable: "code",
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    capturingGroups: {
+                        enum: ["ignore", "report"],
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
         messages: {
             combine:
                 "{{left}} and {{right}} can be combined into one quantifier {{fix}}.{{cap}}",
@@ -526,6 +541,10 @@ export default createRule("optimal-quantifier-concatenation", {
         type: "suggestion",
     },
     create(context) {
+        const cgReporting: CapturingGroupReporting =
+            context.options[0]?.reportExponentialBacktracking ??
+            CapturingGroupReporting.report
+
         /**
          * Creates a visitor
          */
@@ -548,6 +567,12 @@ export default createRule("optimal-quantifier-concatenation", {
 
                         const involvesCapturingGroup =
                             hasCapturingGroup(left) || hasCapturingGroup(right)
+                        if (
+                            involvesCapturingGroup &&
+                            cgReporting === CapturingGroupReporting.ignore
+                        ) {
+                            continue
+                        }
 
                         const cap = involvesCapturingGroup
                             ? " This cannot be fixed automatically because it might change or remove a capturing group."

--- a/tests/lib/rules/optimal-quantifier-concatenation.ts
+++ b/tests/lib/rules/optimal-quantifier-concatenation.ts
@@ -227,5 +227,11 @@ tester.run("optimal-quantifier-concatenation", rule as any, {
                 "'(\\d)' and '\\d+' can be combined into one quantifier '\\d{2,}'. This cannot be fixed automatically because it might change or remove a capturing group.",
             ],
         },
+        {
+            code: String.raw`/(\d)\d+/`,
+            output: null,
+            options: [{ capturingGroups: "ignore" }],
+            errors: [],
+        },
     ],
 })

--- a/tests/lib/rules/optimal-quantifier-concatenation.ts
+++ b/tests/lib/rules/optimal-quantifier-concatenation.ts
@@ -19,6 +19,10 @@ tester.run("optimal-quantifier-concatenation", rule as any, {
         String.raw`/\d+(?:\w+|-\d+)/`,
         String.raw`/aa?/`,
         String.raw`/\w?\w/`,
+        {
+            code: String.raw`/(\d)\d+/`,
+            options: [{ capturingGroups: "ignore" }],
+        },
     ],
     invalid: [
         {
@@ -226,12 +230,6 @@ tester.run("optimal-quantifier-concatenation", rule as any, {
             errors: [
                 "'(\\d)' and '\\d+' can be combined into one quantifier '\\d{2,}'. This cannot be fixed automatically because it might change or remove a capturing group.",
             ],
-        },
-        {
-            code: String.raw`/(\d)\d+/`,
-            output: null,
-            options: [{ capturingGroups: "ignore" }],
-            errors: [],
         },
     ],
 })


### PR DESCRIPTION
Resolves #451.

As suggested by @ilyub, I added an option to turn off reports related to capturing groups. These reports cannot be fixed in general and might be false positives. Since they are not only false positives and might reveal bugs, capturing groups are still reported by default.