### PR TITLE
Improve `prefer-lookaround` rule to report when there are leading/trailing assertions

### DIFF
--- a/lib/rules/prefer-lookaround.ts
+++ b/lib/rules/prefer-lookaround.ts
@@ -258,7 +258,7 @@ function isTrailingAssertion(element: Element): element is TrailingAssertion {
 }
 
 /** Checks whether the given element is simple (single alternative, and positive) lookaround assertion or not. */
-function isSingleLookaroundAssertion(
+function isSimpleLookaroundAssertion(
     element: Element,
 ): element is LookaroundAssertion & {
     negate: false
@@ -330,7 +330,7 @@ function parsePatternElements(node: Pattern): {
                 !leadingAssertion
                     ? ""
                     : // If the leading assertion is simple lookbehind assertion, unwrap the parens.
-                    isSingleLookaroundAssertion(leadingAssertion)
+                    isSimpleLookaroundAssertion(leadingAssertion)
                     ? leadingAssertion.alternatives[0].raw
                     : leadingAssertion.raw
             }${capturingGroup.alternatives.map((a) => a.raw).join("|")})`,
@@ -364,7 +364,7 @@ function parsePatternElements(node: Pattern): {
                 !trailingAssertion
                     ? ""
                     : // If the trailing assertion is simple lookahead assertion, unwrap the parens.
-                    isSingleLookaroundAssertion(trailingAssertion)
+                    isSimpleLookaroundAssertion(trailingAssertion)
                     ? trailingAssertion.alternatives[0].raw
                     : trailingAssertion.raw
             })`,

--- a/lib/rules/prefer-lookaround.ts
+++ b/lib/rules/prefer-lookaround.ts
@@ -180,12 +180,6 @@ function getSideEffectsWhenReplacingCapturingGroup(
     }
 }
 
-/** Checks if the given element is a zero length element that can be placed as a leading/trailing element. */
-function isLeadingTrailingElement(element: Element): boolean {
-    if (element.type === "CapturingGroup") return false
-    return isZeroLength(element)
-}
-
 /** Checks whether the given element is a capturing group of length 1 or greater. */
 function isCapturingGroupAndNotZeroLength(
     element: Element,
@@ -242,7 +236,7 @@ function parsePatternElements(node: Pattern): ParsedElements | null {
     let start: ParsedStartPattern | null = null
 
     for (const element of elements) {
-        if (isLeadingTrailingElement(element)) {
+        if (isZeroLength(element)) {
             leadingElements.push(element)
             continue
         }
@@ -267,7 +261,7 @@ function parsePatternElements(node: Pattern): ParsedElements | null {
     let end: ParsedEndPattern | null = null
     const trailingElements: Element[] = []
     for (const element of [...elements].reverse()) {
-        if (isLeadingTrailingElement(element)) {
+        if (isZeroLength(element)) {
             trailingElements.unshift(element)
             continue
         }

--- a/tests/lib/rules/prefer-lookaround.ts
+++ b/tests/lib/rules/prefer-lookaround.ts
@@ -772,5 +772,33 @@ tester.run("prefer-lookaround", rule as any, {
                 "These capturing groups can be replaced with lookaround assertions ('(?<=^\\bJ)' and '(?=Script\\b$)').",
             ],
         },
+        {
+            code: String.raw`var str = 'foobar'.replace(/foo(bar)(\b|$)/, 'bar$1')`,
+            output: String.raw`var str = 'foobar'.replace(/foo(?=bar(\b|$))/, 'bar')`,
+            errors: [
+                "This capturing group can be replaced with a lookahead assertion ('(?=bar(\\b|$))').",
+            ],
+        },
+        {
+            code: String.raw`var str = 'foobar'.replace(/foo(bar)(\b|$)/, '$2$1')`,
+            output: null,
+            errors: [
+                "This capturing group can be replaced with a lookahead assertion ('(?=bar(\\b|$))').",
+            ],
+        },
+        {
+            code: `var str = 'JavaScript'.replace(/Java(Scrip)((?=t))/g, 'Type$1')`,
+            output: `var str = 'JavaScript'.replace(/Java(?=Scrip((?=t)))/g, 'Type')`,
+            errors: [
+                "This capturing group can be replaced with a lookahead assertion ('(?=Scrip((?=t)))').",
+            ],
+        },
+        {
+            code: `var str = 'JavaScriptCode'.replace(/((?<=Java))(Script)Code/g, '$2Linter')`,
+            output: `var str = 'JavaScriptCode'.replace(/(?<=((?<=Java))Script)Code/g, 'Linter')`,
+            errors: [
+                "This capturing group can be replaced with a lookbehind assertion ('(?<=((?<=Java))Script)').",
+            ],
+        },
     ],
 })

--- a/tests/lib/rules/prefer-lookaround.ts
+++ b/tests/lib/rules/prefer-lookaround.ts
@@ -199,6 +199,9 @@ tester.run("prefer-lookaround", rule as any, {
         "aaaaaa".replace(/(?<=a)aa(?:)/g, "bb")
         // 'abbbba'
         `,
+        // cannot replace assertions
+        `var str = 'JavaScript'.replace(/Java(Script)^/g, 'Type$1')`,
+        `var str = 'Java'.replace(/$(J)ava/g, '$1Query')`,
     ],
     invalid: [
         {
@@ -435,6 +438,264 @@ tester.run("prefer-lookaround", rule as any, {
             output: null,
             errors: [
                 "This capturing group can be replaced with a lookahead assertion ('(?=(a))').",
+            ],
+        },
+        {
+            code: `var str = 'JavaScript'.replace(/Java(Script)$/g, 'Type$1')`,
+            output: `var str = 'JavaScript'.replace(/Java(?=Script$)/g, 'Type')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookahead assertion ('(?=Script$)').",
+                    column: 37,
+                    endColumn: 46,
+                },
+            ],
+        },
+        {
+            code: String.raw`var str = 'JavaScript'.replace(/Java(Script)\b/g, 'Type$1')`,
+            output: String.raw`var str = 'JavaScript'.replace(/Java(?=Script\b)/g, 'Type')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookahead assertion ('(?=Script\\b)').",
+                    column: 37,
+                    endColumn: 47,
+                },
+            ],
+        },
+        {
+            code: String.raw`var str = 'JavaScript'.replace(/Java(Script)(?:\b|$)/g, 'Type$1')`,
+            output: String.raw`var str = 'JavaScript'.replace(/Java(?=Script(?:\b|$))/g, 'Type')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookahead assertion ('(?=Script(?:\\b|$))').",
+                    column: 37,
+                    endColumn: 53,
+                },
+            ],
+        },
+        {
+            code: `var str = 'JavaScript'.replace(/Java(Scrip)(?=t)/g, 'Type$1')`,
+            output: `var str = 'JavaScript'.replace(/Java(?=Script)/g, 'Type')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookahead assertion ('(?=Script)').",
+                    column: 37,
+                    endColumn: 49,
+                },
+            ],
+        },
+        {
+            code: `var str = 'JavaScriptLinter'.replace(/Java(Script)(?=Linter|Checker)/g, 'Type$1')`,
+            output: `var str = 'JavaScriptLinter'.replace(/Java(?=Script(?=Linter|Checker))/g, 'Type')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookahead assertion ('(?=Script(?=Linter|Checker))').",
+                    column: 43,
+                    endColumn: 69,
+                },
+            ],
+        },
+        {
+            code: `var str = 'Java'.replace(/^(J)ava/g, '$1Query')`,
+            output: `var str = 'Java'.replace(/(?<=^J)ava/g, 'Query')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookbehind assertion ('(?<=^J)').",
+                    column: 27,
+                    endColumn: 31,
+                },
+            ],
+        },
+        {
+            code: String.raw`var str = 'Java'.replace(/\b(J)ava/g, '$1Query')`,
+            output: String.raw`var str = 'Java'.replace(/(?<=\bJ)ava/g, 'Query')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookbehind assertion ('(?<=\\bJ)').",
+                    column: 27,
+                    endColumn: 32,
+                },
+            ],
+        },
+        {
+            code: String.raw`var str = 'Java'.replace(/(?:^|\b)(J)ava/g, '$1Query')`,
+            output: String.raw`var str = 'Java'.replace(/(?<=(?:^|\b)J)ava/g, 'Query')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookbehind assertion ('(?<=(?:^|\\b)J)').",
+                    column: 27,
+                    endColumn: 38,
+                },
+            ],
+        },
+        {
+            code: `var str = 'JavaScriptCode'.replace(/(?<=Java)(Script)Code/g, '$1Linter')`,
+            output: `var str = 'JavaScriptCode'.replace(/(?<=JavaScript)Code/g, 'Linter')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookbehind assertion ('(?<=JavaScript)').",
+                    column: 37,
+                    endColumn: 54,
+                },
+            ],
+        },
+        {
+            code: `var str = 'JavaScriptCode'.replace(/(?<=Java|Type)(Script)Code/g, '$1Linter')`,
+            output: `var str = 'JavaScriptCode'.replace(/(?<=(?<=Java|Type)Script)Code/g, 'Linter')`,
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookbehind assertion ('(?<=(?<=Java|Type)Script)').",
+                    column: 37,
+                    endColumn: 59,
+                },
+            ],
+        },
+        {
+            code: `
+            const str = 'JavaScript'.replace(/^(Java)(Script)$/, '$1 and Type$2');
+            `,
+            output: `
+            const str = 'JavaScript'.replace(/(?<=^Java)(?=Script$)/, ' and Type');
+            `,
+            errors: [
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=^Java)' and '(?=Script$)').",
+                    column: 47,
+                    endColumn: 54,
+                },
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=^Java)' and '(?=Script$)').",
+                    column: 54,
+                    endColumn: 63,
+                },
+            ],
+        },
+        {
+            code: String.raw`
+            const str = 'JavaScript'.replace(/\b(Java)(Script)\b/, '$1 and Type$2');
+            `,
+            output: String.raw`
+            const str = 'JavaScript'.replace(/(?<=\bJava)(?=Script\b)/, ' and Type');
+            `,
+            errors: [
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=\\bJava)' and '(?=Script\\b)').",
+                    column: 47,
+                    endColumn: 55,
+                },
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=\\bJava)' and '(?=Script\\b)').",
+                    column: 55,
+                    endColumn: 65,
+                },
+            ],
+        },
+        {
+            code: String.raw`
+            const str = 'JavaScript'.replace(/(?:^|\b)(Java)(Script)(?:\b|$)/, '$1 and Type$2');
+            `,
+            output: String.raw`
+            const str = 'JavaScript'.replace(/(?<=(?:^|\b)Java)(?=Script(?:\b|$))/, ' and Type');
+            `,
+            errors: [
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=(?:^|\\b)Java)' and '(?=Script(?:\\b|$))').",
+                    column: 47,
+                    endColumn: 61,
+                },
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=(?:^|\\b)Java)' and '(?=Script(?:\\b|$))').",
+                    column: 61,
+                    endColumn: 77,
+                },
+            ],
+        },
+        {
+            code: `
+            const str = 'JavaScript'.replace(/^(J)(ava)(Script)$/, '$1Query, and Java$3');
+            `,
+            output: `
+            const str = 'JavaScript'.replace(/(?<=^J)(ava)(?=Script$)/, 'Query, and Java');
+            `,
+            errors: [
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=^J)' and '(?=Script$)').",
+                    column: 47,
+                    endColumn: 51,
+                },
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=^J)' and '(?=Script$)').",
+                    column: 56,
+                    endColumn: 65,
+                },
+            ],
+        },
+        {
+            code: String.raw`
+            const str = 'JavaScript'.replace(/\b(J)(ava)(Script)\b/, '$1Query, and Java$3');
+            `,
+            output: String.raw`
+            const str = 'JavaScript'.replace(/(?<=\bJ)(ava)(?=Script\b)/, 'Query, and Java');
+            `,
+            errors: [
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=\\bJ)' and '(?=Script\\b)').",
+                    column: 47,
+                    endColumn: 52,
+                },
+                {
+                    message:
+                        "These capturing groups can be replaced with lookaround assertions ('(?<=\\bJ)' and '(?=Script\\b)').",
+                    column: 57,
+                    endColumn: 67,
+                },
+            ],
+        },
+        {
+            code: `var str = 'JavaScript'.replace(/Java(S)(c)(r)(i)(p)(t)/g, 'Type$1$2$3$4$5$6')`,
+            output: `var str = 'JavaScript'.replace(/Java(S)(c)(r)(i)(p)(?=t)/g, 'Type$1$2$3$4$5')`,
+            errors: [
+                "This capturing group can be replaced with a lookahead assertion ('(?=t)').",
+            ],
+        },
+        {
+            code: `var str = 'JavaScript'.replace(/Java(S)(c)(r)(i)(p)(?=t)/g, 'Type$1$2$3$4$5')`,
+            output: `var str = 'JavaScript'.replace(/Java(S)(c)(r)(i)(?=pt)/g, 'Type$1$2$3$4')`,
+            errors: [
+                "This capturing group can be replaced with a lookahead assertion ('(?=pt)').",
+            ],
+        },
+        {
+            code: `var str = 'JavaScript'.replace(/Java(S)(c)(r)(i)(?=pt)/g, 'Type$1$2$3$4')`,
+            output: `var str = 'JavaScript'.replace(/Java(S)(c)(r)(?=ipt)/g, 'Type$1$2$3')`,
+            errors: [
+                "This capturing group can be replaced with a lookahead assertion ('(?=ipt)').",
+            ],
+        },
+        {
+            code: `var str = 'JavaScript'.replace(/(?<=J)(a)(v)(a)Script/g, '$1$2$3Runtime')`,
+            output: null,
+            errors: [
+                "This capturing group can be replaced with a lookbehind assertion ('(?<=Ja)').",
             ],
         },
     ],


### PR DESCRIPTION
close  #478