### PR TITLE
Fixed false negatives around edges and added second phase of reporting

### DIFF
--- a/tests/lib/rules/no-useless-assertions.ts
+++ b/tests/lib/rules/no-useless-assertions.ts
@@ -360,5 +360,61 @@ tester.run("no-useless-assertions", rule as any, {
             code: String.raw`/(?=a|$)b/u`,
             errors: ["The lookahead '(?=a|$)' will always reject."],
         },
+
+        {
+            code: String.raw`/^^a$$/`,
+            errors: [
+                "'^' will always accept because it is never preceded by a character.",
+                "'$' will always accept because it is never followed by a character.",
+            ],
+        },
+        {
+            code: String.raw`/^^a$$/m`,
+            errors: [
+                "'^' will always accept because it is preceded by a line-terminator character or the start of the input string.",
+                "'$' will always accept because it is followed by a line-terminator character or the end of the input string.",
+            ],
+        },
+        {
+            code: String.raw`/\b^a\b$/u`,
+            errors: [
+                "'\\b' will always accept because it is preceded by a non-word character and followed by a word character.",
+                "'\\b' will always accept because it is preceded by a word character and followed by a non-word character.",
+            ],
+        },
+        {
+            code: String.raw`/^\ba$\b/`,
+            errors: [
+                "'\\b' will always accept because it is preceded by a non-word character and followed by a word character.",
+                "'\\b' will always accept because it is preceded by a word character and followed by a non-word character.",
+            ],
+        },
+        {
+            code: String.raw`/\b\ba\b\b/u`,
+            errors: [
+                "'\\b' will always accept because it is preceded by a non-word character and followed by a word character.",
+                "'\\b' will always accept because it is preceded by a word character and followed by a non-word character.",
+            ],
+        },
+        {
+            code: String.raw`/Java(?=Script)$/`,
+            errors: ["The lookahead '(?=Script)' will always reject."],
+        },
+        {
+            code: String.raw`/Java$(?=Script)/`,
+            errors: [
+                "'$' will always reject because it is followed by a character.",
+            ],
+        },
+        {
+            code: String.raw`/a$(?!.)/s`,
+            errors: [
+                "'$' will always accept because it is never followed by a character.",
+            ],
+        },
+        {
+            code: String.raw`/a(?!.)$/s`,
+            errors: ["The negative lookahead '(?!.)' will always accept."],
+        },
     ],
 })

--- a/tests/lib/rules/no-useless-assertions.ts
+++ b/tests/lib/rules/no-useless-assertions.ts
@@ -416,5 +416,13 @@ tester.run("no-useless-assertions", rule as any, {
             code: String.raw`/a(?!.)$/s`,
             errors: ["The negative lookahead '(?!.)' will always accept."],
         },
+
+        {
+            code: String.raw`/^(\b|\B-[a-z]{1,10}-)((?:repeating-)?(?:linear|radial)-gradient)/`,
+            errors: [
+                "'\\b' will always accept because it is preceded by a non-word character and followed by a word character.",
+                "'\\B' will always accept because it is preceded by a non-word character and followed by a non-word character.",
+            ],
+        },
     ],
 })


### PR DESCRIPTION
Fixes #479.

This PR includes 2 changes:
1. I improved the handling of edges. Previously, all verify function would just immediately return without reporting anything if the next character included the start/end (edge) of the input string. I likely did this because the logic around string edges is a bit more complex.
2. In order to fully report all useless assertion in the examples [here](https://github.com/ota-meshi/eslint-plugin-regexp/issues/479#issuecomment-1321446605), I had to add assertion reordering. E.g. to detect that the `\b` in `/\b^a/` is useless, `\b` has to know that there is a `^` after it. The solution here is to (conceptually) reorder the assertions to `/^\ba/` which allows `\b` to "see" `^`.
    However, assertion reordering also causes overreporting. E.g. Since both `$`s in `/$$/` can see each other, both will be reported even though only one is actually useless. To fix this, reporting is done in 2 phases. In the first phase, we do everything just like we did before. In the second phase, we reorder while being careful not to reorder already reported assertions.