### PR TITLE
Added `lookbehind` option for `prefer-lookaround`

### DIFF
--- a/docs/rules/prefer-lookaround.md
+++ b/docs/rules/prefer-lookaround.md
@@ -34,13 +34,23 @@ var str = 'JavaScript'.replace(/Java(Script)/g, 'Type$1')
 ```json
 {
   "regexp/prefer-lookaround": ["error", {
+      "lookbehind": true,
       "strictTypes": true
   }]
 }
 ```
 
-- `strictTypes` ... If `true`, strictly check the type of object to determine if the regex instance was used in `replace()` and `replaceAll()`. Default is `true`.\
-  This option is always on when using TypeScript.
+### `lookbehind`
+
+This option controls whether this rule will suggest using lookbehinds. Default is `true`.
+
+Safari is the last major browser that still does not support regex lookbehind assertions (as of December 2022). So if your code base targets Safari, you cannot use lookbehinds.
+
+### `strictTypes`
+
+If `true`, strictly check the type of object to determine if the regex instance was used in `replace()` and `replaceAll()`. Default is `true`.
+
+This option is always on when using TypeScript.
 
 ## :rocket: Version
 

--- a/tests/lib/rules/prefer-lookaround.ts
+++ b/tests/lib/rules/prefer-lookaround.ts
@@ -202,6 +202,14 @@ tester.run("prefer-lookaround", rule as any, {
         // cannot replace assertions
         `var str = 'JavaScriptCode'.replace(/Java(Script)(?:Code)/g, 'Type$1')`,
         `var str = 'JavaScriptCode'.replace(/(?:Java)(Script)Code/g, '$1Element')`,
+
+        // no lookbehinds
+        {
+            code: `
+            const str = 'A JavaScript formatter written in JavaScript.'.replace(/(Java)Script/g, '$1');
+            `,
+            options: [{ lookbehind: false }],
+        },
     ],
     invalid: [
         {
@@ -798,6 +806,25 @@ tester.run("prefer-lookaround", rule as any, {
             output: `var str = 'JavaScriptCode'.replace(/(?<=((?<=Java))Script)Code/g, 'Linter')`,
             errors: [
                 "This capturing group can be replaced with a lookbehind assertion ('(?<=((?<=Java))Script)').",
+            ],
+        },
+
+        // no lookbehinds
+        {
+            code: `
+            const str = 'I love unicorn! I hate unicorn?'.replace(/(?<before>love )unicorn(?<after>!)/, '$<before>🦄$<after>');
+            `,
+            output: `
+            const str = 'I love unicorn! I hate unicorn?'.replace(/(?<before>love )unicorn(?=!)/, '$<before>🦄');
+            `,
+            options: [{ lookbehind: false }],
+            errors: [
+                {
+                    message:
+                        "This capturing group can be replaced with a lookahead assertion ('(?=!)').",
+                    column: 91,
+                    endColumn: 102,
+                },
             ],
         },
     ],


### PR DESCRIPTION
Resolves #498.

This PR adds a `lookbehind: boolean` option to allow users to turn off lookbehind suggestions.