### PR TITLE
Docs: remove "This rule has not been released yet"

### DIFF
--- a/docs/rules/no-misleading-capturing-group.md
+++ b/docs/rules/no-misleading-capturing-group.md
@@ -13,8 +13,6 @@ since: "v1.12.0"
 
 > disallow capturing groups that do not behave as one would expect
 
-- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
-
 ## :book: Rule Details
 
 This rule reports capturing groups that capture less text than their pattern might suggest.


### PR DESCRIPTION
Remove warning _This rule has not been released yet_ in [`no-misleading-capturing-group`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-misleading-capturing-group.html) documentation.