### PR TITLE
Updated refa, regex-ast-analysis, and scslre

### DIFF
--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -303,7 +303,7 @@ function unionAll(nfas: readonly ReadonlyNFA[]): ReadonlyNFA {
     return total
 }
 
-const DFA_OPTIONS: DFA.CreationOptions = { maxNodes: 100_000 }
+const MAX_DFA_NODES = 100_000
 
 /**
  * Returns whether one NFA is a subset of another.
@@ -313,8 +313,12 @@ function isSubsetOf(
     subset: ReadonlyNFA,
 ): boolean | null {
     try {
-        const a = DFA.fromIntersection(superset, subset, DFA_OPTIONS)
-        const b = DFA.fromFA(subset, DFA_OPTIONS)
+        const a = DFA.fromIntersection(
+            superset,
+            subset,
+            new DFA.LimitedNodeFactory(MAX_DFA_NODES),
+        )
+        const b = DFA.fromFA(subset, new DFA.LimitedNodeFactory(MAX_DFA_NODES))
         a.minimize()
         b.minimize()
         return a.structurallyEqual(b)
@@ -339,13 +343,17 @@ function getSubsetRelation(
     right: ReadonlyNFA,
 ): SubsetRelation {
     try {
-        const inter = DFA.fromIntersection(left, right, DFA_OPTIONS)
+        const inter = DFA.fromIntersection(
+            left,
+            right,
+            new DFA.LimitedNodeFactory(MAX_DFA_NODES),
+        )
         inter.minimize()
 
-        const l = DFA.fromFA(left, DFA_OPTIONS)
+        const l = DFA.fromFA(left, new DFA.LimitedNodeFactory(MAX_DFA_NODES))
         l.minimize()
 
-        const r = DFA.fromFA(right, DFA_OPTIONS)
+        const r = DFA.fromFA(right, new DFA.LimitedNodeFactory(MAX_DFA_NODES))
         r.minimize()
 
         const subset = l.structurallyEqual(inter)

--- a/lib/rules/require-unicode-regexp.ts
+++ b/lib/rules/require-unicode-regexp.ts
@@ -211,7 +211,7 @@ function isCompatibleQuantifier(
         return false
     }
 
-    if (!rangeEqual(cs.ranges, uCs.without([ASTRAL]).ranges)) {
+    if (!rangeEqual(cs.ranges, uCs.without(ASTRAL).ranges)) {
         // failed condition 3
         return false
     }

--- a/lib/rules/sort-alternatives.ts
+++ b/lib/rules/sort-alternatives.ts
@@ -198,13 +198,11 @@ function getLexicographicallySmallestFromAlternative(
         const nfa = NFA.fromRegex(
             expression,
             { maxCharacter: result.maxCharacter },
-            { maxNodes: 1000 },
+            {},
+            new NFA.LimitedNodeFactory(1000),
         )
 
-        return getLexicographicallySmallestFromNfa(
-            nfa.nodes.initial,
-            nfa.nodes.finals,
-        )
+        return getLexicographicallySmallestFromNfa(nfa.initial, nfa.finals)
     } catch (_error) {
         return undefined
     }

--- a/lib/utils/fix-simplify-quantifier.ts
+++ b/lib/utils/fix-simplify-quantifier.ts
@@ -1,7 +1,6 @@
 import type { Rule } from "eslint"
-import type { ClosestAncestor } from "regexp-ast-analysis"
 import { getClosestAncestor } from "regexp-ast-analysis"
-import type { Node, Quantifier } from "@eslint-community/regexpp/ast"
+import type { Quantifier } from "@eslint-community/regexpp/ast"
 import type { RegExpContext } from "."
 import { quantToString } from "."
 import type { CanSimplify } from "./regexp-ast/simplify-quantifier"
@@ -14,10 +13,7 @@ export function fixSimplifyQuantifier(
     result: CanSimplify,
     { fixReplaceNode }: RegExpContext,
 ): [replacement: string, fix: (fixer: Rule.RuleFixer) => Rule.Fix | null] {
-    const ancestor = getClosestAncestorOfAll([
-        quantifier,
-        ...result.dependencies,
-    ])
+    const ancestor = getClosestAncestor(quantifier, ...result.dependencies)
 
     let replacement: string
     if (quantifier.min === 0) {
@@ -44,19 +40,4 @@ export function fixSimplifyQuantifier(
             )
         }),
     ]
-}
-
-/**
- * Returns the closest ancestor of all given elements.
- */
-function getClosestAncestorOfAll<T extends Node>(
-    elements: readonly [T, ...T[]],
-): ClosestAncestor<T, T> {
-    let leftMost = elements[0]
-    let rightMost = elements[0]
-    for (const e of elements) {
-        if (e.start < leftMost.start) leftMost = e
-        if (e.end > rightMost.end) rightMost = e
-    }
-    return getClosestAncestor(leftMost, rightMost)
 }

--- a/lib/utils/regexp-ast/simplify-quantifier.ts
+++ b/lib/utils/regexp-ast/simplify-quantifier.ts
@@ -240,7 +240,12 @@ function toNfa(element: Element, parser: JS.Parser): NFA {
         assertions: "throw",
         backreferences: "throw",
     })
-    return NFA.fromRegex(expression, { maxCharacter }, { maxNodes: 1000 })
+    return NFA.fromRegex(
+        expression,
+        { maxCharacter },
+        {},
+        new NFA.LimitedNodeFactory(1000),
+    )
 }
 
 /**
@@ -261,7 +266,7 @@ function canAbsorbElementFormal(
     try {
         // perform a full NFA/DFA language check
         const qNfa = toNfa(quantifier, parser)
-        const qDfa = DFA.fromFA(qNfa, { maxNodes: 1000 })
+        const qDfa = DFA.fromFA(qNfa, new DFA.LimitedNodeFactory(1000))
         const eNfa = toNfa(element, parser)
         // We want to check whether `QE* = Q`. To perform this check, it's
         // sufficient to check `QE? = Q`. Proof sketch:
@@ -269,7 +274,7 @@ function canAbsorbElementFormal(
         // 2. If `QE? != Q`, then `Q ⊂ QE? ⊆ QE*`, so `QE* != Q`.
         eNfa.quantify(0, 1)
         qNfa.append(eNfa)
-        const qeDfa = DFA.fromFA(qNfa, { maxNodes: 1000 })
+        const qeDfa = DFA.fromFA(qNfa, new DFA.LimitedNodeFactory(1000))
 
         qDfa.minimize()
         qeDfa.minimize()

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
                 "comment-parser": "^1.1.2",
                 "grapheme-splitter": "^1.0.4",
                 "jsdoctypeparser": "^9.0.0",
-                "refa": "^0.9.0",
-                "regexp-ast-analysis": "^0.5.1",
-                "scslre": "^0.1.6"
+                "refa": "^0.11.0",
+                "regexp-ast-analysis": "^0.6.0",
+                "scslre": "^0.2.0"
             },
             "devDependencies": {
                 "@ota-meshi/eslint-plugin": "^0.13.0",
@@ -982,9 +982,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
-            "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+            "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
@@ -3952,6 +3952,46 @@
             },
             "peerDependencies": {
                 "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-regexp/node_modules/refa": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/refa/-/refa-0.9.1.tgz",
+            "integrity": "sha512-egU8LgFq2VXlAfUi8Jcbr5X38wEOadMFf8tCbshgcpVCYlE7k84pJOSlnvXF+muDB4igkdVMq7Z/kiNPqDT9TA==",
+            "dev": true,
+            "dependencies": {
+                "regexpp": "^3.2.0"
+            }
+        },
+        "node_modules/eslint-plugin-regexp/node_modules/regexp-ast-analysis": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.5.1.tgz",
+            "integrity": "sha512-Ca/g9gaTNuMewLuu+mBIq4vCrGRSO8AE9bP32NMQjJ/wBTdWq0g96qLkBb0NbGwEbp7S/q+NQF3o7veeuRfg0g==",
+            "dev": true,
+            "dependencies": {
+                "refa": "^0.9.0",
+                "regexpp": "^3.2.0"
+            }
+        },
+        "node_modules/eslint-plugin-regexp/node_modules/scslre": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.1.6.tgz",
+            "integrity": "sha512-JORxVRlQTfjvlOAaiQKebgFElyAm5/W8b50lgaZ0OkEnKnagJW2ufDh3xRfU75UD9z3FGIu1gL1IyR3Poa6Qmw==",
+            "dev": true,
+            "dependencies": {
+                "refa": "^0.9.0",
+                "regexp-ast-analysis": "^0.2.3",
+                "regexpp": "^3.2.0"
+            }
+        },
+        "node_modules/eslint-plugin-regexp/node_modules/scslre/node_modules/regexp-ast-analysis": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.4.tgz",
+            "integrity": "sha512-8L7kOZQaKPxKKAwGuUZxTQtlO3WZ+tiXy4s6G6PKL6trbOXcZoumwC3AOHHFtI/xoSbNxt7jgLvCnP1UADLWqg==",
+            "dev": true,
+            "dependencies": {
+                "refa": "^0.9.0",
+                "regexpp": "^3.2.0"
             }
         },
         "node_modules/eslint-plugin-vue": {
@@ -7562,20 +7602,26 @@
             }
         },
         "node_modules/refa": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/refa/-/refa-0.9.1.tgz",
-            "integrity": "sha512-egU8LgFq2VXlAfUi8Jcbr5X38wEOadMFf8tCbshgcpVCYlE7k84pJOSlnvXF+muDB4igkdVMq7Z/kiNPqDT9TA==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/refa/-/refa-0.11.0.tgz",
+            "integrity": "sha512-486O8/pQXwj9jV0mVvUnTsxq0uknpBnNJ0eCUhkZqJRQ8KutrT1PhzmumdCeM1hSBF2eMlFPmwECRER4IbKXlQ==",
             "dependencies": {
-                "regexpp": "^3.2.0"
+                "@eslint-community/regexpp": "^4.5.0"
+            },
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/regexp-ast-analysis": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.5.1.tgz",
-            "integrity": "sha512-Ca/g9gaTNuMewLuu+mBIq4vCrGRSO8AE9bP32NMQjJ/wBTdWq0g96qLkBb0NbGwEbp7S/q+NQF3o7veeuRfg0g==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.6.0.tgz",
+            "integrity": "sha512-OLxjyjPkVH+rQlBLb1I/P/VTmamSjGkvN5PTV5BXP432k3uVz727J7H29GA5IFiY0m7e1xBN7049Wn59FY3DEQ==",
             "dependencies": {
-                "refa": "^0.9.0",
-                "regexpp": "^3.2.0"
+                "@eslint-community/regexpp": "^4.5.0",
+                "refa": "^0.11.0"
+            },
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/regexp.prototype.flags": {
@@ -7802,22 +7848,13 @@
             "peer": true
         },
         "node_modules/scslre": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.1.6.tgz",
-            "integrity": "sha512-JORxVRlQTfjvlOAaiQKebgFElyAm5/W8b50lgaZ0OkEnKnagJW2ufDh3xRfU75UD9z3FGIu1gL1IyR3Poa6Qmw==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.2.0.tgz",
+            "integrity": "sha512-4hc49fUMmX3jM0XdFUAPBrs1xwEcdHa0KyjEsjFs+Zfc66mpFpq5YmRgDtl+Ffo6AtJIilfei+yKw8fUn3N88w==",
             "dependencies": {
-                "refa": "^0.9.0",
-                "regexp-ast-analysis": "^0.2.3",
-                "regexpp": "^3.2.0"
-            }
-        },
-        "node_modules/scslre/node_modules/regexp-ast-analysis": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.4.tgz",
-            "integrity": "sha512-8L7kOZQaKPxKKAwGuUZxTQtlO3WZ+tiXy4s6G6PKL6trbOXcZoumwC3AOHHFtI/xoSbNxt7jgLvCnP1UADLWqg==",
-            "dependencies": {
-                "refa": "^0.9.0",
-                "regexpp": "^3.2.0"
+                "@eslint-community/regexpp": "^4.5.0",
+                "refa": "^0.11.0",
+                "regexp-ast-analysis": "^0.6.0"
             }
         },
         "node_modules/semver": {
@@ -9910,9 +9947,9 @@
             }
         },
         "@eslint-community/regexpp": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
-            "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ=="
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+            "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ=="
         },
         "@eslint/eslintrc": {
             "version": "1.3.3",
@@ -12040,6 +12077,50 @@
                 "refa": "^0.9.0",
                 "regexp-ast-analysis": "^0.5.1",
                 "scslre": "^0.1.6"
+            },
+            "dependencies": {
+                "refa": {
+                    "version": "0.9.1",
+                    "resolved": "https://registry.npmjs.org/refa/-/refa-0.9.1.tgz",
+                    "integrity": "sha512-egU8LgFq2VXlAfUi8Jcbr5X38wEOadMFf8tCbshgcpVCYlE7k84pJOSlnvXF+muDB4igkdVMq7Z/kiNPqDT9TA==",
+                    "dev": true,
+                    "requires": {
+                        "regexpp": "^3.2.0"
+                    }
+                },
+                "regexp-ast-analysis": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.5.1.tgz",
+                    "integrity": "sha512-Ca/g9gaTNuMewLuu+mBIq4vCrGRSO8AE9bP32NMQjJ/wBTdWq0g96qLkBb0NbGwEbp7S/q+NQF3o7veeuRfg0g==",
+                    "dev": true,
+                    "requires": {
+                        "refa": "^0.9.0",
+                        "regexpp": "^3.2.0"
+                    }
+                },
+                "scslre": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.1.6.tgz",
+                    "integrity": "sha512-JORxVRlQTfjvlOAaiQKebgFElyAm5/W8b50lgaZ0OkEnKnagJW2ufDh3xRfU75UD9z3FGIu1gL1IyR3Poa6Qmw==",
+                    "dev": true,
+                    "requires": {
+                        "refa": "^0.9.0",
+                        "regexp-ast-analysis": "^0.2.3",
+                        "regexpp": "^3.2.0"
+                    },
+                    "dependencies": {
+                        "regexp-ast-analysis": {
+                            "version": "0.2.4",
+                            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.4.tgz",
+                            "integrity": "sha512-8L7kOZQaKPxKKAwGuUZxTQtlO3WZ+tiXy4s6G6PKL6trbOXcZoumwC3AOHHFtI/xoSbNxt7jgLvCnP1UADLWqg==",
+                            "dev": true,
+                            "requires": {
+                                "refa": "^0.9.0",
+                                "regexpp": "^3.2.0"
+                            }
+                        }
+                    }
+                }
             }
         },
         "eslint-plugin-vue": {
@@ -14700,20 +14781,20 @@
             }
         },
         "refa": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/refa/-/refa-0.9.1.tgz",
-            "integrity": "sha512-egU8LgFq2VXlAfUi8Jcbr5X38wEOadMFf8tCbshgcpVCYlE7k84pJOSlnvXF+muDB4igkdVMq7Z/kiNPqDT9TA==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/refa/-/refa-0.11.0.tgz",
+            "integrity": "sha512-486O8/pQXwj9jV0mVvUnTsxq0uknpBnNJ0eCUhkZqJRQ8KutrT1PhzmumdCeM1hSBF2eMlFPmwECRER4IbKXlQ==",
             "requires": {
-                "regexpp": "^3.2.0"
+                "@eslint-community/regexpp": "^4.5.0"
             }
         },
         "regexp-ast-analysis": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.5.1.tgz",
-            "integrity": "sha512-Ca/g9gaTNuMewLuu+mBIq4vCrGRSO8AE9bP32NMQjJ/wBTdWq0g96qLkBb0NbGwEbp7S/q+NQF3o7veeuRfg0g==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.6.0.tgz",
+            "integrity": "sha512-OLxjyjPkVH+rQlBLb1I/P/VTmamSjGkvN5PTV5BXP432k3uVz727J7H29GA5IFiY0m7e1xBN7049Wn59FY3DEQ==",
             "requires": {
-                "refa": "^0.9.0",
-                "regexpp": "^3.2.0"
+                "@eslint-community/regexpp": "^4.5.0",
+                "refa": "^0.11.0"
             }
         },
         "regexp.prototype.flags": {
@@ -14859,24 +14940,13 @@
             "peer": true
         },
         "scslre": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.1.6.tgz",
-            "integrity": "sha512-JORxVRlQTfjvlOAaiQKebgFElyAm5/W8b50lgaZ0OkEnKnagJW2ufDh3xRfU75UD9z3FGIu1gL1IyR3Poa6Qmw==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.2.0.tgz",
+            "integrity": "sha512-4hc49fUMmX3jM0XdFUAPBrs1xwEcdHa0KyjEsjFs+Zfc66mpFpq5YmRgDtl+Ffo6AtJIilfei+yKw8fUn3N88w==",
             "requires": {
-                "refa": "^0.9.0",
-                "regexp-ast-analysis": "^0.2.3",
-                "regexpp": "^3.2.0"
-            },
-            "dependencies": {
-                "regexp-ast-analysis": {
-                    "version": "0.2.4",
-                    "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.4.tgz",
-                    "integrity": "sha512-8L7kOZQaKPxKKAwGuUZxTQtlO3WZ+tiXy4s6G6PKL6trbOXcZoumwC3AOHHFtI/xoSbNxt7jgLvCnP1UADLWqg==",
-                    "requires": {
-                        "refa": "^0.9.0",
-                        "regexpp": "^3.2.0"
-                    }
-                }
+                "@eslint-community/regexpp": "^4.5.0",
+                "refa": "^0.11.0",
+                "regexp-ast-analysis": "^0.6.0"
             }
         },
         "semver": {

--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
         "comment-parser": "^1.1.2",
         "grapheme-splitter": "^1.0.4",
         "jsdoctypeparser": "^9.0.0",
-        "refa": "^0.9.0",
-        "regexp-ast-analysis": "^0.5.1",
-        "scslre": "^0.1.6"
+        "refa": "^0.11.0",
+        "regexp-ast-analysis": "^0.6.0",
+        "scslre": "^0.2.0"
     }
 }


### PR DESCRIPTION
As the title says, this PR updates my libraries. The main change in all 3 libraries is that I switched to `@eslint-community/regexpp`.

Aside from that, I made several changes to refa, but only a few affect us. The main one would be that DFA/NFA new use node factories to limit the number of nodes created. 

I also changed `getClosestAncestor`, it now takes any number of elements.