### PR TITLE
Add metadata object

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ import type { RuleModule } from "./types"
 import { rules as ruleList } from "./utils/rules"
 import * as recommended from "./configs/recommended"
 import * as all from "./configs/all"
+export * as meta from "./meta"
 
 export const configs = {
     recommended,

--- a/lib/meta.ts
+++ b/lib/meta.ts
@@ -1,0 +1,3 @@
+// note - cannot migrate this to an import statement because it will make TSC copy the package.json to the dist folder
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- Get meta data
+export const { name, version } = require("../package.json")

--- a/tests/lib/meta.ts
+++ b/tests/lib/meta.ts
@@ -1,0 +1,13 @@
+import assert from "assert"
+import * as plugin from "../../lib"
+import { version } from "../../package.json"
+const expectedMeta = {
+    name: "eslint-plugin-regexp",
+    version,
+}
+
+describe("Test for meta object", () => {
+    it("A plugin should have a meta object.", () => {
+        assert.deepStrictEqual(plugin.meta, expectedMeta)
+    })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
             "*": ["typings/*"]
         },
         "esModuleInterop": true,
+        "resolveJsonModule": true,
 
         "skipLibCheck": true
     },


### PR DESCRIPTION
This PR makes the plugin export metadata objects.

ESLint now recommends that plugins have metadata.
https://eslint.org/docs/latest/extend/plugins#metadata-in-plugins