### PR TITLE
Update `@eslint-community/regexpp` to v4.6

### DIFF
--- a/.changeset/small-doors-lie.md
+++ b/.changeset/small-doors-lie.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Update `@eslint-community/regexpp` to v4.6

--- a/lib/rules/negation.ts
+++ b/lib/rules/negation.ts
@@ -58,6 +58,8 @@ export default createRule("negation", {
                         const negatedElementSet = toCharSet(
                             {
                                 ...element,
+                                // FIXME: TS Error
+                                // @ts-expect-error -- FIXME
                                 negate: !element.negate,
                             },
                             flags,

--- a/lib/rules/no-contradiction-with-assertion.ts
+++ b/lib/rules/no-contradiction-with-assertion.ts
@@ -105,7 +105,7 @@ function* getNextElements(
         // FIXME: TS Error
         // @ts-expect-error -- FIXME
         const elements = parent.elements
-        const index = elements.indexOf(element)
+        const index = elements.indexOf(element) as number
         const inc = dir === "ltr" ? 1 : -1
         for (let i = index + inc; i >= 0 && i < elements.length; i += inc) {
             const e = elements[i]

--- a/lib/rules/no-contradiction-with-assertion.ts
+++ b/lib/rules/no-contradiction-with-assertion.ts
@@ -102,6 +102,8 @@ function* getNextElements(
             }
         }
 
+        // FIXME: TS Error
+        // @ts-expect-error -- FIXME
         const elements = parent.elements
         const index = elements.indexOf(element)
         const inc = dir === "ltr" ? 1 : -1

--- a/lib/rules/no-dupe-characters-character-class.ts
+++ b/lib/rules/no-dupe-characters-character-class.ts
@@ -67,6 +67,8 @@ function groupElements(
     }
 
     for (const e of elements) {
+        // FIXME: TS Error
+        // @ts-expect-error -- FIXME
         const charSet = toCharSet(e, flags)
 
         if (e.type === "Character") {
@@ -324,6 +326,8 @@ export default createRule("no-dupe-characters-character-class", {
                                 .filter((e) => !subsets.has(e) && e !== element)
                                 .filter(
                                     (e) =>
+                                        // FIXME: TS Error
+                                        // @ts-expect-error -- FIXME
                                         !toCharSet(e, flags).isDisjointWith(
                                             elementCharSet,
                                         ),

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -875,6 +875,8 @@ function fixRemoveNestedAlternative(
         }
 
         default:
+            // FIXME: TS Error
+            // @ts-expect-error -- FIXME
             throw assertNever(alternative)
     }
 }

--- a/lib/rules/no-misleading-capturing-group.ts
+++ b/lib/rules/no-misleading-capturing-group.ts
@@ -91,6 +91,8 @@ function* getStartQuantifiers(
             }
             break
         default:
+            // FIXME: TS Error
+            // @ts-expect-error -- FIXME
             yield assertNever(root)
     }
 }
@@ -179,6 +181,8 @@ function uncachedGetSingleRepeatedChar(
             return getSingleRepeatedChar(element.element, flags, cache)
 
         default:
+            // FIXME: TS Error
+            // @ts-expect-error -- FIXME
             return assertNever(element)
     }
 }
@@ -232,6 +236,8 @@ function getTradingQuantifiersAfter(
                         return state
 
                     default:
+                        // FIXME: TS Error
+                        // @ts-expect-error -- FIXME
                         return assertNever(element)
                 }
             },

--- a/lib/rules/optimal-quantifier-concatenation.ts
+++ b/lib/rules/optimal-quantifier-concatenation.ts
@@ -513,8 +513,12 @@ function getLoc(
 function getCapturingGroupStack(element: Element): string {
     let result = ""
     for (
+        // FIXME: TS Error
+        // @ts-expect-error -- FIXME
         let p: Ancestor<Element> = element.parent;
         p.type !== "Pattern";
+        // FIXME: TS Error
+        // @ts-expect-error -- FIXME
         p = p.parent
     ) {
         if (p.type === "CapturingGroup") {

--- a/lib/rules/prefer-character-class.ts
+++ b/lib/rules/prefer-character-class.ts
@@ -124,6 +124,8 @@ function elementsToCharacterClass(elements: CharElementArray): string {
                 break
 
             default:
+                // FIXME: TS Error
+                // @ts-expect-error -- FIXME
                 throw new Error(e)
         }
     })

--- a/lib/rules/sort-character-class-elements.ts
+++ b/lib/rules/sort-character-class-elements.ts
@@ -241,6 +241,8 @@ export default createRule("sort-character-class-elements", {
             if (node.type === "CharacterClassRange") {
                 return node.min.value
             }
+            // FIXME: TS Error
+            // @ts-expect-error -- FIXME
             return node.value
         }
 
@@ -257,6 +259,8 @@ function escapeRaw(node: CharacterClassElement, target: CharacterClassElement) {
     let raw = node.raw
     if (raw.startsWith("-")) {
         const parent = target.parent as CharacterClass
+        // FIXME: TS Error
+        // @ts-expect-error -- FIXME
         const prev = parent.elements[parent.elements.indexOf(target) - 1]
         if (
             prev &&

--- a/lib/rules/use-ignore-case.ts
+++ b/lib/rules/use-ignore-case.ts
@@ -19,6 +19,8 @@ import type {
 import type { Rule } from "eslint"
 import { UsageOfPattern } from "../utils/get-usage-of-pattern"
 
+// FIXME: TS Error
+// @ts-expect-error -- FIXME
 const ELEMENT_ORDER: Record<CharacterClassElement["type"], number> = {
     Character: 1,
     CharacterClassRange: 2,
@@ -179,6 +181,8 @@ export default createRule("use-ignore-case", {
                     }
 
                     const invariant = Chars.empty(flags).union(
+                        // FIXME: TS Error
+                        // @ts-expect-error -- FIXME
                         ...invariantElement.map((e) => toCharSet(e, flags)),
                     )
 
@@ -191,6 +195,8 @@ export default createRule("use-ignore-case", {
                     // the i flag
                     const alwaysUseless = findUseless(
                         variantElements,
+                        // FIXME: TS Error
+                        // @ts-expect-error -- FIXME
                         (e) => toCharSet(e, flags),
                         invariant,
                     )
@@ -202,6 +208,8 @@ export default createRule("use-ignore-case", {
                     const iFlags = getIgnoreCaseFlags(flags)
                     const useless = findUseless(
                         variantElements,
+                        // FIXME: TS Error
+                        // @ts-expect-error -- FIXME
                         (e) => toCharSet(e, iFlags),
                         invariant,
                     )

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1196,8 +1196,12 @@ export function fixRemoveCharacterClassElement(
         }
 
         const elementBefore: CharacterClassElement | undefined =
+            // FIXME: TS Error
+            // @ts-expect-error -- FIXME
             cc.elements[cc.elements.indexOf(element) - 1]
         const elementAfter: CharacterClassElement | undefined =
+            // FIXME: TS Error
+            // @ts-expect-error -- FIXME
             cc.elements[cc.elements.indexOf(element) + 1]
 
         if (

--- a/lib/utils/partial-parser.ts
+++ b/lib/utils/partial-parser.ts
@@ -181,6 +181,8 @@ export class PartialParser {
             }
 
             default:
+                // FIXME: TS Error
+                // @ts-expect-error -- FIXME
                 throw assertNever(element)
         }
     }
@@ -207,6 +209,8 @@ export class PartialParser {
                 characters: JS.createCharSet([range], this.parser.ast.flags),
             }
         }
+        // FIXME: TS Error
+        // @ts-expect-error -- FIXME
         return this.nativeParseElement(context.alternative)
     }
 

--- a/lib/utils/regexp-ast/case-variation.ts
+++ b/lib/utils/regexp-ast/case-variation.ts
@@ -134,6 +134,8 @@ export function isCaseVariant(
 
                 case "CharacterClass":
                     if (!wholeCharacterClass) {
+                        // FIXME: TS Error
+                        // @ts-expect-error -- FIXME
                         return d.elements.some(ccElementIsCaseVariant)
                     }
                     // just check for equality

--- a/lib/utils/regexp-ast/index.ts
+++ b/lib/utils/regexp-ast/index.ts
@@ -155,6 +155,8 @@ export function getJSRegexppAst(
 
     return {
         pattern: patternAst,
+        // FIXME: TS Error
+        // @ts-expect-error -- FIXME
         flags: {
             type: "Flags",
             raw: flagsString ?? "",

--- a/lib/utils/regexp-ast/is-equals.ts
+++ b/lib/utils/regexp-ast/is-equals.ts
@@ -227,6 +227,8 @@ export function isEqualNodes<N extends Node>(
         }
     }
     if (/[(*+?[\\{|]/u.test(a.raw) || /[(*+?[\\{|]/u.test(b.raw)) {
+        // FIXME: TS Error
+        // @ts-expect-error -- FIXME
         return EQUALS_CHECKER[a.type](
             a as never,
             b as never,

--- a/lib/utils/regexp-ast/simplify-quantifier.ts
+++ b/lib/utils/regexp-ast/simplify-quantifier.ts
@@ -418,6 +418,8 @@ function getTailQuantifiers(
         }
 
         default:
+            // FIXME: TS Error
+            // @ts-expect-error -- FIXME
             return assertNever(element)
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.4.0",
+                "@eslint-community/regexpp": "^4.6.2",
                 "comment-parser": "^1.1.2",
                 "grapheme-splitter": "^1.0.4",
                 "jsdoctypeparser": "^9.0.0",
@@ -1853,9 +1853,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
-            "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+            "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
@@ -12448,9 +12448,9 @@
             }
         },
         "@eslint-community/regexpp": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
-            "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ=="
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+            "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw=="
         },
         "@eslint/eslintrc": {
             "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     },
     "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint-community/regexpp": "^4.6.2",
         "comment-parser": "^1.1.2",
         "grapheme-splitter": "^1.0.4",
         "jsdoctypeparser": "^9.0.0",


### PR DESCRIPTION
This PR updates `@eslint-community/regexpp` to v4.6.
TS errors caused by this change are temporarily avoided with suppression comments. We will have to fix these errors later.

Related to #545