### PR TITLE
Refactor to pass flag object to `parsePattern()`

### DIFF
--- a/lib/rules/require-unicode-regexp.ts
+++ b/lib/rules/require-unicode-regexp.ts
@@ -46,7 +46,7 @@ function isSyntacticallyCompatible(pattern: Pattern): false | Pattern {
             pattern.raw,
             undefined,
             undefined,
-            true,
+            { unicode: true },
         )
     } catch (_error) {
         return false

--- a/lib/rules/strict.ts
+++ b/lib/rules/strict.ts
@@ -12,6 +12,7 @@ import {
     defineRegexpVisitor,
     isEscapeSequence,
 } from "../utils"
+import type { ReadonlyFlags } from "regexp-ast-analysis"
 
 const validator = new RegExpValidator({ strict: true, ecmaVersion: 2020 })
 
@@ -21,10 +22,10 @@ const validator = new RegExpValidator({ strict: true, ecmaVersion: 2020 })
  */
 function validateRegExpPattern(
     pattern: string,
-    uFlag?: boolean,
+    flags: ReadonlyFlags,
 ): string | null {
     try {
-        validator.validatePattern(pattern, undefined, undefined, uFlag)
+        validator.validatePattern(pattern, undefined, undefined, flags)
         return null
     } catch (err) {
         return err instanceof Error ? err.message : null
@@ -272,10 +273,7 @@ export default createRule("strict", {
                         // our own logic couldn't find any problems,
                         // so let's use a real parser to do the job.
 
-                        const message = validateRegExpPattern(
-                            pattern,
-                            flags.unicode,
-                        )
+                        const message = validateRegExpPattern(pattern, flags)
 
                         if (message) {
                             context.report({

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -329,7 +329,7 @@ function buildRegexpVisitor(
                 patternSource.value,
                 0,
                 patternSource.value.length,
-                flags.unicode,
+                flags,
             )
         } catch (error: unknown) {
             if (error instanceof SyntaxError) {

--- a/lib/utils/regexp-ast/index.ts
+++ b/lib/utils/regexp-ast/index.ts
@@ -42,7 +42,10 @@ export function getRegExpNodeFromExpression(
                     node.regex.pattern,
                     0,
                     node.regex.pattern.length,
-                    node.regex.flags.includes("u"),
+                    {
+                        unicode: node.regex.flags.includes("u"),
+                        unicodeSets: node.regex.flags.includes("v"),
+                    },
                 )
             } catch {
                 return null


### PR DESCRIPTION
This PR refactors to use the changed API with regexpp supporting the v flag.

<https://github.com/eslint-community/regexpp/pull/82#:~:text=has%20no%20negation.-,Change%20API,-The%20fourth%20argument>