### PR TITLE
Update refa & co

### DIFF
--- a/.changeset/cyan-waves-notice.md
+++ b/.changeset/cyan-waves-notice.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Update refa, regexp-ast-analysis, and scslre

--- a/lib/rules/confusing-quantifier.ts
+++ b/lib/rules/confusing-quantifier.ts
@@ -29,11 +29,15 @@ export default createRule("confusing-quantifier", {
          */
         function createVisitor({
             node,
+            flags,
             getRegexpLocation,
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onQuantifierEnter(qNode) {
-                    if (qNode.min > 0 && isPotentiallyEmpty(qNode.element)) {
+                    if (
+                        qNode.min > 0 &&
+                        isPotentiallyEmpty(qNode.element, flags)
+                    ) {
                         const proposal = quantToString({ ...qNode, min: 0 })
                         context.report({
                             node,

--- a/lib/rules/negation.ts
+++ b/lib/rules/negation.ts
@@ -53,13 +53,15 @@ export default createRule("negation", {
                         // All other character sets are either case-invariant
                         // (/./, /\s/, /\d/) or inconsistent (/\w/).
 
+                        // FIXME: TS Error
+                        // @ts-expect-error -- FIXME
                         const ccSet = toCharSet(ccNode, flags)
 
                         const negatedElementSet = toCharSet(
+                            // FIXME: TS Error
+                            // @ts-expect-error -- FIXME
                             {
                                 ...element,
-                                // FIXME: TS Error
-                                // @ts-expect-error -- FIXME
                                 negate: !element.negate,
                             },
                             flags,

--- a/lib/rules/no-contradiction-with-assertion.ts
+++ b/lib/rules/no-contradiction-with-assertion.ts
@@ -43,7 +43,7 @@ function isTrivialAssertion(
     }
 
     if (assertion.kind === "lookahead" || assertion.kind === "lookbehind") {
-        if (isPotentiallyEmpty(assertion.alternatives)) {
+        if (isPotentiallyEmpty(assertion.alternatives, flags)) {
             // The assertion is guaranteed to trivially accept/reject.
             return true
         }
@@ -80,6 +80,7 @@ function isTrivialAssertion(
 function* getNextElements(
     start: Element,
     dir: MatchingDirection,
+    flags: ReadonlyFlags,
 ): Iterable<Element> {
     let element = start
 
@@ -110,7 +111,7 @@ function* getNextElements(
         for (let i = index + inc; i >= 0 && i < elements.length; i += inc) {
             const e = elements[i]
             yield e
-            if (!isZeroLength(e)) {
+            if (!isZeroLength(e, flags)) {
                 return
             }
         }
@@ -142,6 +143,7 @@ function tryFindContradictionIn(
     element: Element,
     dir: MatchingDirection,
     condition: (e: Element | Alternative) => boolean,
+    flags: ReadonlyFlags,
 ): boolean {
     if (condition(element)) {
         return true
@@ -151,7 +153,7 @@ function tryFindContradictionIn(
         // Go into the alternatives of groups
         let some = false
         element.alternatives.forEach((a) => {
-            if (tryFindContradictionInAlternative(a, dir, condition)) {
+            if (tryFindContradictionInAlternative(a, dir, condition, flags)) {
                 some = true
             }
         })
@@ -160,7 +162,7 @@ function tryFindContradictionIn(
 
     if (element.type === "Quantifier" && element.max === 1) {
         // Go into the element of quantifiers if their maximum is 1
-        return tryFindContradictionIn(element.element, dir, condition)
+        return tryFindContradictionIn(element.element, dir, condition, flags)
     }
 
     if (
@@ -173,7 +175,7 @@ function tryFindContradictionIn(
         // Since we don't consume characters, we want to keep going even if we
         // find a contradiction inside the lookaround.
         element.alternatives.forEach((a) =>
-            tryFindContradictionInAlternative(a, dir, condition),
+            tryFindContradictionInAlternative(a, dir, condition, flags),
         )
     }
 
@@ -188,6 +190,7 @@ function tryFindContradictionInAlternative(
     alternative: Alternative,
     dir: MatchingDirection,
     condition: (e: Element | Alternative) => boolean,
+    flags: ReadonlyFlags,
 ): boolean {
     if (condition(alternative)) {
         return true
@@ -199,10 +202,10 @@ function tryFindContradictionInAlternative(
     const inc = dir === "ltr" ? 1 : -1
     for (let i = first; i >= 0 && i < elements.length; i += inc) {
         const e = elements[i]
-        if (tryFindContradictionIn(e, dir, condition)) {
+        if (tryFindContradictionIn(e, dir, condition, flags)) {
             return true
         }
-        if (!isZeroLength(e)) {
+        if (!isZeroLength(e, flags)) {
             break
         }
     }
@@ -271,8 +274,10 @@ export default createRule("no-contradiction-with-assertion", {
                     getFirstConsumedChar(assertion, dir, flags),
                 )
 
-                for (const element of getNextElements(assertion, dir)) {
-                    if (tryFindContradictionIn(element, dir, contradicts)) {
+                for (const element of getNextElements(assertion, dir, flags)) {
+                    if (
+                        tryFindContradictionIn(element, dir, contradicts, flags)
+                    ) {
                         break
                     }
                 }

--- a/lib/rules/no-dupe-characters-character-class.ts
+++ b/lib/rules/no-dupe-characters-character-class.ts
@@ -15,6 +15,7 @@ import {
     defineRegexpVisitor,
     toCharSetSource,
     fixRemoveCharacterClassElement,
+    assertValidFlags,
 } from "../utils"
 import type { CharRange, CharSet } from "refa"
 import { JS } from "refa"
@@ -276,6 +277,8 @@ export default createRule("no-dupe-characters-character-class", {
                     // report characters that are already matched by some range or set
                     for (const char of characters) {
                         for (const other of rangesAndSets) {
+                            // FIXME: TS Error
+                            // @ts-expect-error -- FIXME
                             if (toCharSet(other, flags).has(char.value)) {
                                 reportSubset(regexpContext, char, other)
                                 subsets.add(char)
@@ -292,7 +295,11 @@ export default createRule("no-dupe-characters-character-class", {
                             }
 
                             if (
+                                // FIXME: TS Error
+                                // @ts-expect-error -- FIXME
                                 toCharSet(element, flags).isSubsetOf(
+                                    // FIXME: TS Error
+                                    // @ts-expect-error -- FIXME
                                     toCharSet(other, flags),
                                 )
                             ) {
@@ -317,9 +324,13 @@ export default createRule("no-dupe-characters-character-class", {
                         const totalOthers = characterTotal.union(
                             ...rangesAndSets
                                 .filter((e) => !subsets.has(e) && e !== element)
+                                // FIXME: TS Error
+                                // @ts-expect-error -- FIXME
                                 .map((e) => toCharSet(e, flags)),
                         )
 
+                        // FIXME: TS Error
+                        // @ts-expect-error -- FIXME
                         const elementCharSet = toCharSet(element, flags)
                         if (elementCharSet.isSubsetOf(totalOthers)) {
                             const superSetElements = ccNode.elements
@@ -359,6 +370,8 @@ export default createRule("no-dupe-characters-character-class", {
                             const intersection = toCharSet(
                                 range,
                                 flags,
+                                // FIXME: TS Error
+                                // @ts-expect-error -- FIXME
                             ).intersect(toCharSet(other, flags))
                             if (intersection.isEmpty) {
                                 continue
@@ -379,6 +392,7 @@ export default createRule("no-dupe-characters-character-class", {
                             // (see GH #189).
                             // to prevent this, we will create a new CharSet
                             // using `createCharSet`
+                            assertValidFlags(flags)
                             const interest = JS.createCharSet(
                                 interestingRanges,
                                 flags,

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -14,6 +14,7 @@ import {
     defineRegexpVisitor,
     fixRemoveCharacterClassElement,
     fixRemoveAlternative,
+    assertValidFlags,
 } from "../utils"
 import { getParser, isCoveredNode, isEqualNodes } from "../utils/regexp-ast"
 import type { Expression, FiniteAutomaton, NoParent, ReadonlyNFA } from "refa"
@@ -434,6 +435,7 @@ function getPartialSubsetRelation(
  */
 function faToSource(fa: FiniteAutomaton, flags: ReadonlyFlags): string {
     try {
+        assertValidFlags(flags)
         return JS.toLiteral(fa.toRegex(), { flags }).source
     } catch (_error) {
         return "<ERROR>"

--- a/lib/rules/no-empty-capturing-group.ts
+++ b/lib/rules/no-empty-capturing-group.ts
@@ -22,11 +22,12 @@ export default createRule("no-empty-capturing-group", {
          */
         function createVisitor({
             node,
+            flags,
             getRegexpLocation,
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCapturingGroupEnter(cgNode) {
-                    if (isZeroLength(cgNode)) {
+                    if (isZeroLength(cgNode, flags)) {
                         context.report({
                             node,
                             loc: getRegexpLocation(cgNode),

--- a/lib/rules/no-empty-lookarounds-assertion.ts
+++ b/lib/rules/no-empty-lookarounds-assertion.ts
@@ -24,6 +24,7 @@ export default createRule("no-empty-lookarounds-assertion", {
          */
         function createVisitor({
             node,
+            flags,
             getRegexpLocation,
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
@@ -35,7 +36,7 @@ export default createRule("no-empty-lookarounds-assertion", {
                         return
                     }
 
-                    if (isPotentiallyEmpty(aNode.alternatives)) {
+                    if (isPotentiallyEmpty(aNode.alternatives, flags)) {
                         context.report({
                             node,
                             loc: getRegexpLocation(aNode),

--- a/lib/rules/no-optional-assertion.ts
+++ b/lib/rules/no-optional-assertion.ts
@@ -8,6 +8,7 @@ import type {
 } from "@eslint-community/regexpp/ast"
 import type { RegExpContext } from "../utils"
 import { createRule, defineRegexpVisitor } from "../utils"
+import type { ReadonlyFlags } from "regexp-ast-analysis"
 import { isZeroLength } from "regexp-ast-analysis"
 
 type ZeroQuantifier = Quantifier & { min: 0 }
@@ -26,7 +27,11 @@ function isZeroQuantifier(node: Quantifier): node is ZeroQuantifier {
  * consume characters. For more information and examples on optional assertions, see the documentation page of this
  * rule.
  */
-function isOptional(assertion: Assertion, quantifier: ZeroQuantifier): boolean {
+function isOptional(
+    assertion: Assertion,
+    quantifier: ZeroQuantifier,
+    flags: ReadonlyFlags,
+): boolean {
     let element: Assertion | Quantifier | Group | CapturingGroup = assertion
     while (element.parent !== quantifier) {
         const parent: Quantifier | Alternative = element.parent
@@ -37,7 +42,7 @@ function isOptional(assertion: Assertion, quantifier: ZeroQuantifier): boolean {
                     continue // we will ignore this element.
                 }
 
-                if (!isZeroLength(e)) {
+                if (!isZeroLength(e, flags)) {
                     // Some element around our target element can possibly consume characters.
                     // This means, we found a path from or to the assertion which can consume characters.
                     return false
@@ -52,7 +57,7 @@ function isOptional(assertion: Assertion, quantifier: ZeroQuantifier): boolean {
             element = parent.parent
         } else {
             // parent.type === "Quantifier"
-            if (parent.max > 1 && !isZeroLength(parent)) {
+            if (parent.max > 1 && !isZeroLength(parent, flags)) {
                 // If an ascendant quantifier of the element has maximum of 2 or more, we have to check whether
                 // the quantifier itself has zero length.
                 // E.g. in /(?:a|(\b|-){2})?/ the \b is not optional
@@ -87,6 +92,7 @@ export default createRule("no-optional-assertion", {
          */
         function createVisitor({
             node,
+            flags,
             getRegexpLocation,
         }: RegExpContext): RegExpVisitor.Handlers {
             // The closest quantifier with a minimum of 0 is stored at index = 0.
@@ -105,7 +111,7 @@ export default createRule("no-optional-assertion", {
                 onAssertionEnter(assertion) {
                     const q = zeroQuantifierStack[0]
 
-                    if (q && isOptional(assertion, q)) {
+                    if (q && isOptional(assertion, q, flags)) {
                         context.report({
                             node,
                             loc: getRegexpLocation(assertion),

--- a/lib/rules/no-potentially-useless-backreference.ts
+++ b/lib/rules/no-potentially-useless-backreference.ts
@@ -28,11 +28,12 @@ export default createRule("no-potentially-useless-backreference", {
          */
         function createVisitor({
             node,
+            flags,
             getRegexpLocation,
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onBackreferenceEnter(backreference) {
-                    if (isEmptyBackreference(backreference)) {
+                    if (isEmptyBackreference(backreference, flags)) {
                         // handled by regexp/no-useless-backreference
                         return
                     }

--- a/lib/rules/no-useless-assertions.ts
+++ b/lib/rules/no-useless-assertions.ts
@@ -85,7 +85,7 @@ function createReorderingGetFirstCharAfter(
             const start = elements.indexOf(afterThis)
             for (let i = start + inc; i >= 0 && i < elements.length; i += inc) {
                 const other = elements[i]
-                if (!isZeroLength(other)) {
+                if (!isZeroLength(other, flags)) {
                     break
                 }
                 if (hasForbidden(other)) {
@@ -318,7 +318,7 @@ export default createRule("no-useless-assertions", {
                 assertion: LookaroundAssertion,
                 getFirstCharAfterFn: GetFirstCharAfter,
             ): void {
-                if (isPotentiallyEmpty(assertion.alternatives)) {
+                if (isPotentiallyEmpty(assertion.alternatives, flags)) {
                     // we don't handle trivial accept/reject based on emptiness
                     return
                 }
@@ -372,7 +372,7 @@ export default createRule("no-useless-assertions", {
                         (d) => d !== assertion && d.type === "Assertion",
                     )
                 ) {
-                    const range = getLengthRange(assertion.alternatives)
+                    const range = getLengthRange(assertion.alternatives, flags)
                     // we only check the first character, so it's only correct if the assertion requires only one
                     // character
                     if (range.max === 1) {

--- a/lib/rules/no-useless-quantifier.ts
+++ b/lib/rules/no-useless-quantifier.ts
@@ -35,7 +35,8 @@ export default createRule("no-useless-quantifier", {
         function createVisitor(
             regexpContext: RegExpContext,
         ): RegExpVisitor.Handlers {
-            const { node, getRegexpLocation, fixReplaceNode } = regexpContext
+            const { node, flags, getRegexpLocation, fixReplaceNode } =
+                regexpContext
 
             /**
              * Returns a fix that replaces the given quantifier with its
@@ -83,7 +84,7 @@ export default createRule("no-useless-quantifier", {
 
                     // the quantified element already accepts the empty string
                     // e.g. (||)*
-                    if (isEmpty(qNode.element)) {
+                    if (isEmpty(qNode.element, flags)) {
                         context.report({
                             node,
                             loc: getRegexpLocation(qNode),
@@ -99,7 +100,7 @@ export default createRule("no-useless-quantifier", {
                         qNode.min === 0 &&
                         qNode.max === 1 &&
                         qNode.greedy &&
-                        isPotentiallyEmpty(qNode.element)
+                        isPotentiallyEmpty(qNode.element, flags)
                     ) {
                         context.report({
                             node,
@@ -112,7 +113,7 @@ export default createRule("no-useless-quantifier", {
 
                     // the quantified is zero length
                     // e.g. (\b){5}
-                    if (qNode.min >= 1 && isZeroLength(qNode.element)) {
+                    if (qNode.min >= 1 && isZeroLength(qNode.element, flags)) {
                         context.report({
                             node,
                             loc: getRegexpLocation(qNode),

--- a/lib/rules/optimal-quantifier-concatenation.ts
+++ b/lib/rules/optimal-quantifier-concatenation.ts
@@ -73,6 +73,8 @@ function getSingleConsumedChar(
         case "CharacterSet":
         case "CharacterClass":
             return {
+                // FIXME: TS Error
+                // @ts-expect-error -- FIXME
                 char: toCharSet(element, flags),
                 complete: true,
             }
@@ -513,12 +515,8 @@ function getLoc(
 function getCapturingGroupStack(element: Element): string {
     let result = ""
     for (
-        // FIXME: TS Error
-        // @ts-expect-error -- FIXME
         let p: Ancestor<Element> = element.parent;
         p.type !== "Pattern";
-        // FIXME: TS Error
-        // @ts-expect-error -- FIXME
         p = p.parent
     ) {
         if (p.type === "CapturingGroup") {

--- a/lib/rules/optimal-quantifier-concatenation.ts
+++ b/lib/rules/optimal-quantifier-concatenation.ts
@@ -17,8 +17,13 @@ import type { AST } from "eslint"
 import type { RegExpContext, Quant } from "../utils"
 import { createRule, defineRegexpVisitor, quantToString } from "../utils"
 import type { Ancestor, ReadonlyFlags } from "regexp-ast-analysis"
-import { Chars, hasSomeDescendant, toCharSet } from "regexp-ast-analysis"
-import { getParser, getPossiblyConsumedChar } from "../utils/regexp-ast"
+import {
+    Chars,
+    hasSomeDescendant,
+    toCharSet,
+    getConsumedChars,
+} from "regexp-ast-analysis"
+import { getParser } from "../utils/regexp-ast"
 import type { CharSet } from "refa"
 import { joinEnglishList, mention } from "../utils/mention"
 import { canSimplifyQuantifier } from "../utils/regexp-ast/simplify-quantifier"
@@ -183,10 +188,10 @@ function getQuantifiersReplacement(
     const rSingle = getSingleConsumedChar(right.element, flags)
     const lPossibleChar = lSingle.complete
         ? lSingle.char
-        : getPossiblyConsumedChar(left.element, flags).char
+        : getConsumedChars(left.element, flags).chars
     const rPossibleChar = rSingle.complete
         ? rSingle.char
-        : getPossiblyConsumedChar(right.element, flags).char
+        : getConsumedChars(right.element, flags).chars
     const greedy = left.greedy
 
     let lQuant: Readonly<Quant>, rQuant: Readonly<Quant>
@@ -344,8 +349,8 @@ function getNestedReplacement(
         return null
     }
 
-    const nestedPossible = getPossiblyConsumedChar(nested.element, flags)
-    if (single.char.isSupersetOf(nestedPossible.char)) {
+    const nestedPossible = getConsumedChars(nested.element, flags)
+    if (single.char.isSupersetOf(nestedPossible.chars)) {
         const { min } = nested
         if (min === 0) {
             return {

--- a/lib/rules/prefer-character-class.ts
+++ b/lib/rules/prefer-character-class.ts
@@ -155,6 +155,8 @@ function categorizeRawAlts(
                     isCharacter: true,
                     alternative,
                     element,
+                    // FIXME: TS Error
+                    // @ts-expect-error -- FIXME
                     char: toCharSet(element, flags),
                 }
             }
@@ -219,6 +221,8 @@ function parseRawAlts(
                 return {
                     isCharacter: true,
                     elements,
+                    // FIXME: TS Error
+                    // @ts-expect-error -- FIXME
                     char: toCharSet(a.element, flags),
                     raw: a.alternative.raw,
                 }
@@ -352,8 +356,12 @@ function totalIsAll(
     for (const a of alternatives) {
         if (a.isCharacter) {
             if (total === undefined) {
+                // FIXME: TS Error
+                // @ts-expect-error -- FIXME
                 total = toCharSet(a.element, flags)
             } else {
+                // FIXME: TS Error
+                // @ts-expect-error -- FIXME
                 total = total.union(toCharSet(a.element, flags))
             }
         }

--- a/lib/rules/prefer-d.ts
+++ b/lib/rules/prefer-d.ts
@@ -71,6 +71,8 @@ export default createRule("prefer-d", {
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCharacterClassEnter(ccNode) {
+                    // FIXME: TS Error
+                    // @ts-expect-error -- FIXME
                     const charSet = toCharSet(ccNode, flags)
 
                     let predefined: string | undefined = undefined

--- a/lib/rules/prefer-predefined-assertion.ts
+++ b/lib/rules/prefer-predefined-assertion.ts
@@ -203,6 +203,8 @@ export default createRule("prefer-predefined-assertion", {
                         }
                     }
 
+                    // FIXME: TS Error
+                    // @ts-expect-error -- FIXME
                     const charSet = toCharSet(chars, flags)
                     if (charSet.isAll) {
                         replaceEdgeAssertion(aNode, false)

--- a/lib/rules/prefer-w.ts
+++ b/lib/rules/prefer-w.ts
@@ -92,6 +92,8 @@ export default createRule("prefer-w", {
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
                 onCharacterClassEnter(ccNode: CharacterClass) {
+                    // FIXME: TS Error
+                    // @ts-expect-error -- FIXME
                     const charSet = toCharSet(ccNode, flags)
 
                     let predefined: string | undefined = undefined

--- a/lib/rules/require-unicode-regexp.ts
+++ b/lib/rules/require-unicode-regexp.ts
@@ -146,6 +146,8 @@ function isCompatibleCharLike(
     flags: ReadonlyFlags,
     uFlags: ReadonlyFlags,
 ): boolean {
+    // FIXME: TS Error
+    // @ts-expect-error -- FIXME
     const cs = toCharSet(char, flags)
     if (!cs.isDisjointWith(SURROGATES)) {
         // If the character (class/set) contains high or low
@@ -154,6 +156,8 @@ function isCompatibleCharLike(
         return false
     }
 
+    // FIXME: TS Error
+    // @ts-expect-error -- FIXME
     const uCs = toCharSet(char, uFlags)
 
     // Compare the ranges.
@@ -199,12 +203,16 @@ function isCompatibleQuantifier(
         return undefined
     }
 
+    // FIXME: TS Error
+    // @ts-expect-error -- FIXME
     const cs = toCharSet(q.element, flags)
     if (!cs.isSupersetOf(SURROGATES)) {
         // failed condition 1
         return false
     }
 
+    // FIXME: TS Error
+    // @ts-expect-error -- FIXME
     const uCs = toCharSet(q.element, uFlags)
     if (!uCs.isSupersetOf(SURROGATES) || !uCs.isSupersetOf(ASTRAL)) {
         // failed condition 2

--- a/lib/rules/sort-alternatives.ts
+++ b/lib/rules/sort-alternatives.ts
@@ -19,6 +19,7 @@ import {
     CP_APOSTROPHE,
     createRule,
     defineRegexpVisitor,
+    assertValidFlags,
 } from "../utils"
 import type {
     GetLongestPrefixOptions,
@@ -43,6 +44,7 @@ const cache = new Map<string, Readonly<AllowedChars>>()
 
 /** */
 function getAllowedChars(flags: ReadonlyFlags) {
+    assertValidFlags(flags)
     const cacheKey = (flags.ignoreCase ? "i" : "") + (flags.unicode ? "u" : "")
     let result = cache.get(cacheKey)
     if (result === undefined) {
@@ -168,6 +170,8 @@ function getLexicographicallySmallestFromAlternative(
         // fast path to avoid converting simple alternatives into NFAs
         const smallest: Word = []
         for (const e of elements) {
+            // FIXME: TS Error
+            // @ts-expect-error -- FIXME
             const cs = toCharSet(e, flags)
             if (cs.isEmpty) return undefined
             smallest.push(cs.ranges[0].min)

--- a/lib/rules/sort-alternatives.ts
+++ b/lib/rules/sort-alternatives.ts
@@ -31,10 +31,11 @@ import {
     canReorder,
     getLongestPrefix,
     toCharSet,
+    getConsumedChars,
 } from "regexp-ast-analysis"
 import type { CharSet, Word, ReadonlyWord } from "refa"
 import { NFA, JS, transform } from "refa"
-import { getParser, getPossiblyConsumedChar } from "../utils/regexp-ast"
+import { getParser } from "../utils/regexp-ast"
 
 interface AllowedChars {
     allowed: CharSet
@@ -549,11 +550,11 @@ export default createRule("sort-alternatives", {
             const possibleCharsCache = new Map<Alternative, CharSet>()
             const parser = getParser(regexpContext)
 
-            /** A cached version of getPossiblyConsumedChar */
+            /** A cached version of getConsumedChars */
             function getPossibleChars(a: Alternative): CharSet {
                 let chars = possibleCharsCache.get(a)
                 if (chars === undefined) {
-                    chars = getPossiblyConsumedChar(a, flags).char
+                    chars = getConsumedChars(a, flags).chars
                     possibleCharsCache.set(a, chars)
                 }
                 return chars

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -209,6 +209,18 @@ export function parseFlags(flags: string): ReadonlyFlags {
 }
 
 /**
+ * Asserts that the given flags are valid (no `u` and `v` flag together).
+ * @param flags
+ */
+export function assertValidFlags(
+    flags: ReadonlyFlags,
+): asserts flags is JS.Flags {
+    if (!JS.isFlags(flags)) {
+        throw new Error(`Invalid flags: ${JSON.stringify(flags)}`)
+    }
+}
+
+/**
  * Define the rule.
  * @param ruleName ruleName
  * @param rule rule module
@@ -1071,6 +1083,7 @@ export function toCharSetSource(
     charSetOrChar: CharSet | number,
     flags: ReadonlyFlags,
 ): string {
+    assertValidFlags(flags)
     let charSet
     if (typeof charSetOrChar === "number") {
         charSet = JS.createCharSet([charSetOrChar], flags)

--- a/lib/utils/partial-parser.ts
+++ b/lib/utils/partial-parser.ts
@@ -206,7 +206,7 @@ export class PartialParser {
             }
             return {
                 type: "CharacterClass",
-                characters: JS.createCharSet([range], this.parser.ast.flags),
+                characters: JS.createCharSet([range], this.parser.flags),
             }
         }
         // FIXME: TS Error

--- a/lib/utils/regexp-ast/case-variation.ts
+++ b/lib/utils/regexp-ast/case-variation.ts
@@ -4,6 +4,7 @@ import {
     hasSomeDescendant,
     toCharSet,
     isEmptyBackreference,
+    toUnicodeSet,
 } from "regexp-ast-analysis"
 import type {
     Alternative,
@@ -93,7 +94,9 @@ export function isCaseVariant(
                         return unicode
                     case "property":
                         // just check for equality
-                        return !toCharSet(e, iSet).equals(toCharSet(e, iUnset))
+                        return !toUnicodeSet(e, iSet).equals(
+                            toUnicodeSet(e, iUnset),
+                        )
                     default:
                         // all other character sets are case-invariant
                         return false
@@ -123,7 +126,7 @@ export function isCaseVariant(
                     }
 
                     return (
-                        !isEmptyBackreference(d) &&
+                        !isEmptyBackreference(d, flags) &&
                         isCaseVariant(d.resolved, flags)
                     )
 
@@ -139,7 +142,9 @@ export function isCaseVariant(
                         return d.elements.some(ccElementIsCaseVariant)
                     }
                     // just check for equality
-                    return !toCharSet(d, iSet).equals(toCharSet(d, iUnset))
+                    return !toUnicodeSet(d, iSet).equals(
+                        toUnicodeSet(d, iUnset),
+                    )
 
                 default:
                     return false

--- a/lib/utils/regexp-ast/is-covered.ts
+++ b/lib/utils/regexp-ast/is-covered.ts
@@ -435,6 +435,8 @@ function normalizeNodeWithoutCache(
         node.type === "Character" ||
         node.type === "CharacterClassRange"
     ) {
+        // FIXME: TS Error
+        // @ts-expect-error -- FIXME
         return NormalizedCharacter.fromElement(node, options)
     }
     if (node.type === "Alternative") {

--- a/lib/utils/regexp-ast/is-equals.ts
+++ b/lib/utils/regexp-ast/is-equals.ts
@@ -1,5 +1,9 @@
-import type { ToCharSetElement, ReadonlyFlags } from "regexp-ast-analysis"
-import { toCharSet } from "regexp-ast-analysis"
+import type {
+    ToCharSetElement,
+    ReadonlyFlags,
+    ToUnicodeSetElement,
+} from "regexp-ast-analysis"
+import { toUnicodeSet } from "regexp-ast-analysis"
 import type {
     Alternative,
     Assertion,
@@ -24,12 +28,12 @@ import type { ShortCircuit } from "./common"
  * Returns whether the two given character element as equal in the characters
  * that they accept.
  *
- * This is equivalent to `toCharSet(a).equals(toCharSet(b))` but implemented
+ * This is equivalent to `toUnicodeSet(a).equals(toUnicodeSet(b))` but implemented
  * more efficiently.
  */
 function isEqualChar(
-    a: ToCharSetElement,
-    b: ToCharSetElement,
+    a: ToUnicodeSetElement,
+    b: ToUnicodeSetElement,
     flags: ReadonlyFlags,
 ): boolean {
     if (a.type === "Character") {
@@ -56,7 +60,7 @@ function isEqualChar(
         return true
     }
 
-    return toCharSet(a, flags).equals(toCharSet(b, flags))
+    return toUnicodeSet(a, flags).equals(toUnicodeSet(b, flags))
 }
 
 const EQUALS_CHECKER = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
                 "comment-parser": "^1.4.0",
                 "grapheme-splitter": "^1.0.4",
                 "jsdoctypeparser": "^9.0.0",
-                "refa": "^0.11.0",
-                "regexp-ast-analysis": "^0.6.0",
-                "scslre": "^0.2.0"
+                "refa": "^0.12.0",
+                "regexp-ast-analysis": "^0.7.0",
+                "scslre": "^0.3.0"
             },
             "devDependencies": {
                 "@changesets/cli": "^2.26.2",
@@ -1861,9 +1861,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-            "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+            "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
@@ -5350,6 +5350,42 @@
             },
             "peerDependencies": {
                 "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-regexp/node_modules/refa": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/refa/-/refa-0.11.0.tgz",
+            "integrity": "sha512-486O8/pQXwj9jV0mVvUnTsxq0uknpBnNJ0eCUhkZqJRQ8KutrT1PhzmumdCeM1hSBF2eMlFPmwECRER4IbKXlQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.5.0"
+            },
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-regexp/node_modules/regexp-ast-analysis": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.6.0.tgz",
+            "integrity": "sha512-OLxjyjPkVH+rQlBLb1I/P/VTmamSjGkvN5PTV5BXP432k3uVz727J7H29GA5IFiY0m7e1xBN7049Wn59FY3DEQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.5.0",
+                "refa": "^0.11.0"
+            },
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-regexp/node_modules/scslre": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.2.0.tgz",
+            "integrity": "sha512-4hc49fUMmX3jM0XdFUAPBrs1xwEcdHa0KyjEsjFs+Zfc66mpFpq5YmRgDtl+Ffo6AtJIilfei+yKw8fUn3N88w==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.5.0",
+                "refa": "^0.11.0",
+                "regexp-ast-analysis": "^0.6.0"
             }
         },
         "node_modules/eslint-plugin-vue": {
@@ -9334,11 +9370,11 @@
             }
         },
         "node_modules/refa": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/refa/-/refa-0.11.0.tgz",
-            "integrity": "sha512-486O8/pQXwj9jV0mVvUnTsxq0uknpBnNJ0eCUhkZqJRQ8KutrT1PhzmumdCeM1hSBF2eMlFPmwECRER4IbKXlQ==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.0.tgz",
+            "integrity": "sha512-3yCTEBzW93NF2uNsmXCuwmrnu0VcNldYSeFi8t43maVi/J8/M3QOf61XhfcyZiI+SPCQbAucVRhv1Iv7WU0B9Q==",
             "dependencies": {
-                "@eslint-community/regexpp": "^4.5.0"
+                "@eslint-community/regexpp": "^4.8.0"
             },
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -9351,12 +9387,12 @@
             "dev": true
         },
         "node_modules/regexp-ast-analysis": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.6.0.tgz",
-            "integrity": "sha512-OLxjyjPkVH+rQlBLb1I/P/VTmamSjGkvN5PTV5BXP432k3uVz727J7H29GA5IFiY0m7e1xBN7049Wn59FY3DEQ==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.0.tgz",
+            "integrity": "sha512-Y7L2aE4KOKkatMh6YzzwSeTcUWDUHyo6G7nZReIXtB50KzDZT+HCPnBmgeHKSaCwbiEviRBeI8JS7m4KF2pzjw==",
             "dependencies": {
-                "@eslint-community/regexpp": "^4.5.0",
-                "refa": "^0.11.0"
+                "@eslint-community/regexpp": "^4.8.0",
+                "refa": "^0.12.0"
             },
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -9573,13 +9609,16 @@
             "peer": true
         },
         "node_modules/scslre": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.2.0.tgz",
-            "integrity": "sha512-4hc49fUMmX3jM0XdFUAPBrs1xwEcdHa0KyjEsjFs+Zfc66mpFpq5YmRgDtl+Ffo6AtJIilfei+yKw8fUn3N88w==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+            "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
             "dependencies": {
-                "@eslint-community/regexpp": "^4.5.0",
-                "refa": "^0.11.0",
-                "regexp-ast-analysis": "^0.6.0"
+                "@eslint-community/regexpp": "^4.8.0",
+                "refa": "^0.12.0",
+                "regexp-ast-analysis": "^0.7.0"
+            },
+            "engines": {
+                "node": "^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/semver": {
@@ -12737,9 +12776,9 @@
             }
         },
         "@eslint-community/regexpp": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-            "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw=="
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+            "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg=="
         },
         "@eslint/eslintrc": {
             "version": "2.1.2",
@@ -15216,6 +15255,38 @@
                 "refa": "^0.11.0",
                 "regexp-ast-analysis": "^0.6.0",
                 "scslre": "^0.2.0"
+            },
+            "dependencies": {
+                "refa": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/refa/-/refa-0.11.0.tgz",
+                    "integrity": "sha512-486O8/pQXwj9jV0mVvUnTsxq0uknpBnNJ0eCUhkZqJRQ8KutrT1PhzmumdCeM1hSBF2eMlFPmwECRER4IbKXlQ==",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/regexpp": "^4.5.0"
+                    }
+                },
+                "regexp-ast-analysis": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.6.0.tgz",
+                    "integrity": "sha512-OLxjyjPkVH+rQlBLb1I/P/VTmamSjGkvN5PTV5BXP432k3uVz727J7H29GA5IFiY0m7e1xBN7049Wn59FY3DEQ==",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/regexpp": "^4.5.0",
+                        "refa": "^0.11.0"
+                    }
+                },
+                "scslre": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.2.0.tgz",
+                    "integrity": "sha512-4hc49fUMmX3jM0XdFUAPBrs1xwEcdHa0KyjEsjFs+Zfc66mpFpq5YmRgDtl+Ffo6AtJIilfei+yKw8fUn3N88w==",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/regexpp": "^4.5.0",
+                        "refa": "^0.11.0",
+                        "regexp-ast-analysis": "^0.6.0"
+                    }
+                }
             }
         },
         "eslint-plugin-vue": {
@@ -18128,11 +18199,11 @@
             }
         },
         "refa": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/refa/-/refa-0.11.0.tgz",
-            "integrity": "sha512-486O8/pQXwj9jV0mVvUnTsxq0uknpBnNJ0eCUhkZqJRQ8KutrT1PhzmumdCeM1hSBF2eMlFPmwECRER4IbKXlQ==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.0.tgz",
+            "integrity": "sha512-3yCTEBzW93NF2uNsmXCuwmrnu0VcNldYSeFi8t43maVi/J8/M3QOf61XhfcyZiI+SPCQbAucVRhv1Iv7WU0B9Q==",
             "requires": {
-                "@eslint-community/regexpp": "^4.5.0"
+                "@eslint-community/regexpp": "^4.8.0"
             }
         },
         "regenerator-runtime": {
@@ -18142,12 +18213,12 @@
             "dev": true
         },
         "regexp-ast-analysis": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.6.0.tgz",
-            "integrity": "sha512-OLxjyjPkVH+rQlBLb1I/P/VTmamSjGkvN5PTV5BXP432k3uVz727J7H29GA5IFiY0m7e1xBN7049Wn59FY3DEQ==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.0.tgz",
+            "integrity": "sha512-Y7L2aE4KOKkatMh6YzzwSeTcUWDUHyo6G7nZReIXtB50KzDZT+HCPnBmgeHKSaCwbiEviRBeI8JS7m4KF2pzjw==",
             "requires": {
-                "@eslint-community/regexpp": "^4.5.0",
-                "refa": "^0.11.0"
+                "@eslint-community/regexpp": "^4.8.0",
+                "refa": "^0.12.0"
             }
         },
         "regexp.prototype.flags": {
@@ -18286,13 +18357,13 @@
             "peer": true
         },
         "scslre": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.2.0.tgz",
-            "integrity": "sha512-4hc49fUMmX3jM0XdFUAPBrs1xwEcdHa0KyjEsjFs+Zfc66mpFpq5YmRgDtl+Ffo6AtJIilfei+yKw8fUn3N88w==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+            "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
             "requires": {
-                "@eslint-community/regexpp": "^4.5.0",
-                "refa": "^0.11.0",
-                "regexp-ast-analysis": "^0.6.0"
+                "@eslint-community/regexpp": "^4.8.0",
+                "refa": "^0.12.0",
+                "regexp-ast-analysis": "^0.7.0"
             }
         },
         "semver": {

--- a/package.json
+++ b/package.json
@@ -107,9 +107,9 @@
         "comment-parser": "^1.4.0",
         "grapheme-splitter": "^1.0.4",
         "jsdoctypeparser": "^9.0.0",
-        "refa": "^0.11.0",
-        "regexp-ast-analysis": "^0.6.0",
-        "scslre": "^0.2.0"
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0",
+        "scslre": "^0.3.0"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
This updates `refa`, `regex-ast-analysis`, and `scslre`.

There are a lot of changes in both refa and RAA because of the `v` flag, so fixing all errors will be fun... I also had to change the semantics of a few common functions in RAA. Noteably, `is{Potentially,}{Empty,ZeroLength}` and a few others now require a flags argument. (Since we can't assume that a single character class/set is a single character anymore, we have to evaluate the whole thing in some cases, and that requires flags.)

This PR is still a work in progress. Since some type errors are caused by the algorithm fundamentally assuming a single character, I will liberally use `// @ts-expect-error -- FIXME` for now.