### PR TITLE
Use new refa AST transformers

### DIFF
--- a/.changeset/hungry-spoons-mix.md
+++ b/.changeset/hungry-spoons-mix.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": patch
+---
+
+Use new refa AST transformers and fixed max character for `v`-flag regexes in `no-dupe-disjunctions` and `no-super-linear-move`.

--- a/lib/rules/no-super-linear-move.ts
+++ b/lib/rules/no-super-linear-move.ts
@@ -19,8 +19,8 @@ import {
     visitAst,
     JS,
     transform,
-    combineTransformers,
     Transformers,
+    CombinedTransformer,
 } from "refa"
 import { getJSRegexppAst } from "../utils/regexp-ast"
 
@@ -99,24 +99,16 @@ function* findReachableQuantifiers(
     }
 }
 
-const TRANFORMER_OPTIONS: Transformers.CreationOptions = {
+const TRANSFORMER_OPTIONS: Transformers.CreationOptions = {
     ignoreAmbiguity: true,
     ignoreOrder: true,
 }
-const PASS_1 = combineTransformers([
-    Transformers.inline(TRANFORMER_OPTIONS),
-    Transformers.removeDeadBranches(TRANFORMER_OPTIONS),
-    Transformers.unionCharacters(TRANFORMER_OPTIONS),
-    Transformers.moveUpEmpty(TRANFORMER_OPTIONS),
-    Transformers.nestedQuantifiers(TRANFORMER_OPTIONS),
-    Transformers.removeUnnecessaryAssertions(TRANFORMER_OPTIONS),
-    Transformers.applyAssertions(TRANFORMER_OPTIONS),
-])
-const PASS_2 = combineTransformers([
-    Transformers.inline(TRANFORMER_OPTIONS),
-    Transformers.removeDeadBranches(TRANFORMER_OPTIONS),
+const PASS_1 = Transformers.simplify(TRANSFORMER_OPTIONS)
+const PASS_2 = new CombinedTransformer([
+    Transformers.inline(TRANSFORMER_OPTIONS),
+    Transformers.removeDeadBranches(TRANSFORMER_OPTIONS),
     Transformers.replaceAssertions({
-        ...TRANFORMER_OPTIONS,
+        ...TRANSFORMER_OPTIONS,
         replacement: "empty-set",
     }),
 ])


### PR DESCRIPTION
Since the combination of `Transformers.applyAssertions` + `Transformers.removeUnnecessaryAssertions` + everything else was quite common, I added a new transformer for this in refa v0.12.0. This PR just makes 2 rules use the new transformer.

I also fixed `parser.ast.flags.unicode ? 0x10ffff : 0xffff` while I was at it. This was not only wrong because of the `v` flag, but also unnecessary. `parser.maxCharacter` is the value we want.