### PR TITLE
Fix `parseFlags`

### DIFF
--- a/.changeset/wicked-rules-rhyme.md
+++ b/.changeset/wicked-rules-rhyme.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": patch
+---
+
+Fix `parseFlags`

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -179,13 +179,15 @@ type RegexpRule = ParsableRegexpRule & UnparsableRegexpRule
 const regexpRules = new WeakMap<ESTree.Program, RegexpRule[]>()
 
 export const FLAG_GLOBAL = "g"
-export const FLAG_DOTALL = "s"
+export const FLAG_DOT_ALL = "s"
+export const FLAG_HAS_INDICES = "d"
 export const FLAG_IGNORECASE = "i"
 export const FLAG_MULTILINE = "m"
 export const FLAG_STICKY = "y"
 export const FLAG_UNICODE = "u"
+export const FLAG_UNICODE_SETS = "v"
 
-const flagsCache = new Map<string, ReadonlyFlags>()
+const flagsCache = new Map<string, Required<ReadonlyFlags>>()
 
 /**
  * Given some flags, this will return a parsed flags object.
@@ -196,12 +198,14 @@ export function parseFlags(flags: string): ReadonlyFlags {
     let cached = flagsCache.get(flags)
     if (cached === undefined) {
         cached = {
-            dotAll: flags.includes(FLAG_DOTALL),
+            dotAll: flags.includes(FLAG_DOT_ALL),
             global: flags.includes(FLAG_GLOBAL),
+            hasIndices: flags.includes(FLAG_HAS_INDICES),
             ignoreCase: flags.includes(FLAG_IGNORECASE),
             multiline: flags.includes(FLAG_MULTILINE),
             sticky: flags.includes(FLAG_STICKY),
             unicode: flags.includes(FLAG_UNICODE),
+            unicodeSets: flags.includes(FLAG_UNICODE_SETS),
         }
         flagsCache.set(flags, cached)
     }


### PR DESCRIPTION
`parseFlags` did not account for the `d` and `v` flags.

This will make the tests pass in #560.