### PR TITLE
Disable `complexity` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
         "require-jsdoc": "error",
         "no-warning-comments": "warn",
         "no-lonely-if": "off",
+        complexity: "off",
         "@typescript-eslint/no-non-null-assertion": "off",
 
         "no-shadow": "off",

--- a/lib/rules/no-dupe-characters-character-class.ts
+++ b/lib/rules/no-dupe-characters-character-class.ts
@@ -255,7 +255,6 @@ export default createRule("no-dupe-characters-character-class", {
             const { flags } = regexpContext
 
             return {
-                // eslint-disable-next-line complexity -- X
                 onCharacterClassEnter(ccNode: CharacterClass) {
                     const {
                         duplicates,

--- a/lib/rules/no-misleading-capturing-group.ts
+++ b/lib/rules/no-misleading-capturing-group.ts
@@ -1,5 +1,5 @@
 /* eslint-disable eslint-comments/disable-enable-pair -- x */
-/* eslint-disable complexity -- x */
+
 import type { RegExpVisitor } from "@eslint-community/regexpp/visitor"
 import type {
     Alternative,

--- a/lib/rules/no-useless-character-class.ts
+++ b/lib/rules/no-useless-character-class.ts
@@ -45,7 +45,6 @@ export default createRule("no-useless-character-class", {
             getRegexpLocation,
         }: RegExpContext): RegExpVisitor.Handlers {
             return {
-                // eslint-disable-next-line complexity -- X(
                 onCharacterClassEnter(ccNode) {
                     if (ccNode.elements.length !== 1) {
                         return

--- a/lib/rules/optimal-quantifier-concatenation.ts
+++ b/lib/rules/optimal-quantifier-concatenation.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair -- x
-/* eslint-disable complexity -- x */
 import type { RegExpVisitor } from "@eslint-community/regexpp/visitor"
 import type {
     Alternative,

--- a/lib/rules/sort-character-class-elements.ts
+++ b/lib/rules/sort-character-class-elements.ts
@@ -145,7 +145,6 @@ export default createRule("sort-character-class-elements", {
          * Check that the two given CharacterClassElements are in a valid order.
          */
         function isValidOrder(
-            /* eslint-enable complexity -- X( */
             prev: CharacterClassElement,
             next: CharacterClassElement,
         ) {

--- a/lib/rules/sort-character-class-elements.ts
+++ b/lib/rules/sort-character-class-elements.ts
@@ -141,7 +141,6 @@ export default createRule("sort-character-class-elements", {
             }
         }
 
-        /* eslint-disable complexity -- X( */
         /**
          * Check that the two given CharacterClassElements are in a valid order.
          */

--- a/lib/rules/strict.ts
+++ b/lib/rules/strict.ts
@@ -133,7 +133,6 @@ export default createRule("strict", {
             }
 
             return {
-                // eslint-disable-next-line complexity -- x
                 onCharacterEnter(cNode) {
                     if (cNode.raw === "\\") {
                         // e.g. \c5 or \c

--- a/lib/utils/ast-utils/extract-expression-references.ts
+++ b/lib/utils/ast-utils/extract-expression-references.ts
@@ -94,10 +94,8 @@ export function* extractExpressionReferencesForVariable(
     })
 }
 
-/* eslint-disable complexity -- ignore */
 /** Iterate references from the given expression */
 function* iterateReferencesForExpression(
-    /* eslint-enable complexity -- ignore */
     expression: Expression,
     context: Rule.RuleContext,
     alreadyChecked: AlreadyChecked,

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1099,16 +1099,11 @@ export function toCharSetSource(
     ).source
 }
 
-/* eslint-disable complexity -- X( */
 /**
  * Returns whether the concatenation of the two string might create new escape
  * sequences or elements.
  */
-export function mightCreateNewElement(
-    /* eslint-enable complexity -- X( */
-    before: string,
-    after: string,
-): boolean {
+export function mightCreateNewElement(before: string, after: string): boolean {
     // control
     // \cA
     if (before.endsWith("\\c") && /^[a-z]/iu.test(after)) {

--- a/lib/utils/regexp-ast/is-covered.ts
+++ b/lib/utils/regexp-ast/is-covered.ts
@@ -335,10 +335,8 @@ export function isCoveredNode(
     return isCoveredForNormalizedNode(leftNode, rightNode, options)
 }
 
-/* eslint-disable complexity -- X( */
 /** Checks whether the right node is covered by the left node. */
 function isCoveredForNormalizedNode(
-    /* eslint-enable complexity -- X( */
     left: NormalizedNode,
     right: NormalizedNode,
     options: Options,
@@ -478,10 +476,8 @@ function isCoveredAnyNode(
     return false
 }
 
-/* eslint-disable complexity -- X( */
 /** Check whether the right nodes is covered by the left nodes. */
 function isCoveredAltNodes(
-    /* eslint-enable complexity -- X( */
     leftNodes: NormalizedNode[],
     rightNodes: NormalizedNode[],
     options: Options,

--- a/lib/utils/regexp-ast/simplify-quantifier.ts
+++ b/lib/utils/regexp-ast/simplify-quantifier.ts
@@ -1,5 +1,5 @@
 /* eslint-disable eslint-comments/disable-enable-pair -- x */
-/* eslint-disable complexity -- x */
+
 import type { JS } from "refa"
 import { DFA, NFA } from "refa"
 import type { MatchingDirection, ReadonlyFlags } from "regexp-ast-analysis"

--- a/lib/utils/regexp-ast/simplify-quantifier.ts
+++ b/lib/utils/regexp-ast/simplify-quantifier.ts
@@ -1,5 +1,3 @@
-/* eslint-disable eslint-comments/disable-enable-pair -- x */
-
 import type { JS } from "refa"
 import { DFA, NFA } from "refa"
 import type { MatchingDirection, ReadonlyFlags } from "regexp-ast-analysis"

--- a/lib/utils/string-literal-parser/tokenizer.ts
+++ b/lib/utils/string-literal-parser/tokenizer.ts
@@ -95,7 +95,6 @@ export class Tokenizer {
         }
     }
 
-    // eslint-disable-next-line complexity -- ignore
     private readEscape(inTemplate: boolean): {
         value: string
         kind: EscapeToken["kind"]

--- a/lib/utils/type-tracker/index.ts
+++ b/lib/utils/type-tracker/index.ts
@@ -140,14 +140,10 @@ export function createTypeTracker(context: Rule.RuleContext): TypeTracker {
         }
     }
 
-    /* eslint-disable complexity -- X( */
     /**
      * Get the type name from given node.
      */
-    function getTypeWithoutCache(
-        /* eslint-enable complexity -- X( */
-        node: ES.Expression,
-    ): TypeInfo | null {
+    function getTypeWithoutCache(node: ES.Expression): TypeInfo | null {
         if (node.type === "Literal") {
             if (typeof node.value === "string") {
                 return STRING
@@ -517,14 +513,10 @@ export function createTypeTracker(context: Rule.RuleContext): TypeTracker {
         return tsType && getTypeFromTsType(tsType)
     }
 
-    /* eslint-disable complexity -- X( */
     /**
      * Check if the name of the given type is expected or not.
      */
-    function getTypeFromTsType(
-        /* eslint-enable complexity -- X( */
-        tsType: TS.Type,
-    ): TypeInfo | null {
+    function getTypeFromTsType(tsType: TS.Type): TypeInfo | null {
         if (isStringLine(tsType)) {
             return STRING
         }
@@ -604,12 +596,8 @@ function typeTextToTypeInfo(typeText?: string): TypeInfo | null {
     return jsDocTypeNodeToTypeInfo(parseTypeText(typeText))
 }
 
-/* eslint-disable complexity -- X-( */
 /** Get type from JSDocTypeNode */
-function jsDocTypeNodeToTypeInfo(
-    /* eslint-enable complexity -- X-( */
-    node: JSDocTypeNode | null,
-): TypeInfo | null {
+function jsDocTypeNodeToTypeInfo(node: JSDocTypeNode | null): TypeInfo | null {
     if (node == null) {
         return null
     }
@@ -698,12 +686,8 @@ function jsDocTypeNodeToTypeInfo(
     return null
 }
 
-/* eslint-disable complexity -- X( */
 /** Get type from type name */
-function typeNameToTypeInfo(
-    /* eslint-enable complexity -- X( */
-    name: string,
-): TypeInfo | null {
+function typeNameToTypeInfo(name: string): TypeInfo | null {
     if (name === "String" || name === "string") {
         return STRING
     }


### PR DESCRIPTION
I don't like this rule. My main issue is that it heavily punishes exhaustive `switch` statements. I use the following pattern all over my TS projects:

```ts
switch (someVar.type) {
  case "a":
  case "b":
    return x;
  case "c":
  case "d":
    return y;
  default:
    return assertNever(someVar);
}
```

([Real example](https://github.com/RunDevelopment/regexp-ast-analysis/blob/008797bb5b9fd9ac92f56f6de0c23d56a706f308/src/basic.ts#L144).) If `type` is the discriminator of some union type, then this pattern ensures that we exhaustively cover all possible variants. So if we later add/remove variants, TS will give us a compiler error. This is great for correctness because it forces us to explicitly state what we want to do for every variant. 

```ts
if (someVar.type == "a" || someVar.type == "b") {
  return x;
} else { 
  return y;
}
```

Compared to the classic `if/else`, the exhaustive `switch` pattern allows TS to catch future errors for us.

But the `complexity` rule punishes this pattern. Every `case` gets for 1 point, so the above `switch` code has a complexity of 4 while the `if/else` has a complexity of 2. Each `case` counting as 1 point is going to be a huge problem for us, because regexpp has 18 node types now, but the maximum allowed complexity is 15. 

---

Side note: I don't like how long the exhaustive `switch` pattern is either, but it's the best we have in JS. What I really want is something like [Rust's `match`](https://doc.rust-lang.org/rust-by-example/flow_control/match.html). Then we could write this:
```
return match (someVar.type) {
  "a" | "b" => x,
  "c" | "d" => y,
  // compiler checks that no variants are missing
};
```