### PR TITLE
`prefer-w`: Add support for `v` flag

### DIFF
--- a/.changeset/tasty-penguins-cheat.md
+++ b/.changeset/tasty-penguins-cheat.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+`prefer-w`: Add support for `v` flag

--- a/lib/rules/prefer-w.ts
+++ b/lib/rules/prefer-w.ts
@@ -75,29 +75,27 @@ export default createRule("prefer-w", {
                 onCharacterClassEnter(ccNode: CharacterClass) {
                     const charSet = toUnicodeSet(ccNode, flags)
 
-                    if (charSet.accept.isEmpty) {
-                        let predefined: string | undefined = undefined
-                        const word = Chars.word(flags)
-                        if (charSet.chars.equals(word)) {
-                            predefined = "\\w"
-                        } else if (charSet.chars.equals(word.negate())) {
-                            predefined = "\\W"
-                        }
+                    let predefined: string | undefined = undefined
+                    const word = Chars.word(flags)
+                    if (charSet.equals(word)) {
+                        predefined = "\\w"
+                    } else if (charSet.equals(word.negate())) {
+                        predefined = "\\W"
+                    }
 
-                        if (predefined) {
-                            context.report({
-                                node,
-                                loc: getRegexpLocation(ccNode),
-                                messageId: "unexpected",
-                                data: {
-                                    type: "character class",
-                                    expr: mention(ccNode),
-                                    instead: predefined,
-                                },
-                                fix: fixReplaceNode(ccNode, predefined),
-                            })
-                            return
-                        }
+                    if (predefined) {
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(ccNode),
+                            messageId: "unexpected",
+                            data: {
+                                type: "character class",
+                                expr: mention(ccNode),
+                                instead: predefined,
+                            },
+                            fix: fixReplaceNode(ccNode, predefined),
+                        })
+                        return
                     }
 
                     const lowerAToZ: CharacterClassElement[] = []

--- a/tests/lib/rules/prefer-w.ts
+++ b/tests/lib/rules/prefer-w.ts
@@ -3,13 +3,13 @@ import rule from "../../../lib/rules/prefer-w"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
 
 tester.run("prefer-w", rule as any, {
-    valid: ["/\\w/"],
+    valid: ["/\\w/", "/[\\Da-zA-Z_#]/", "/\\w/v", "/[\\Da-zA-Z_#]/v"],
     invalid: [
         {
             code: "/[0-9a-zA-Z_]/",
@@ -33,6 +33,20 @@ tester.run("prefer-w", rule as any, {
                     column: 2,
                     endColumn: 15,
                 },
+            ],
+        },
+        {
+            code: "/[\\da-zA-Z_#]/",
+            output: "/[\\w#]/",
+            errors: [
+                "Unexpected character class ranges '[\\da-zA-Z_]'. Use '\\w' instead.",
+            ],
+        },
+        {
+            code: "/[0-9a-z_[\\s&&\\p{ASCII}]]/iv",
+            output: "/[\\w[\\s&&\\p{ASCII}]]/iv",
+            errors: [
+                "Unexpected character class ranges '[0-9a-z_]'. Use '\\w' instead.",
             ],
         },
         {


### PR DESCRIPTION
Besides adding support for the `v` flag, I also fixed a bug. `\D` was incorrectly detected as `\d` in `isDigitRangeOrSet`.