### PR TITLE
Improve `regexp/no-invalid-regexp` rule to check for unknown pattern flags.

### DIFF
--- a/.changeset/warm-ladybugs-wonder.md
+++ b/.changeset/warm-ladybugs-wonder.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Improve `regexp/no-invalid-regexp` rule to check for unknown pattern flags.

--- a/lib/rules/no-invalid-regexp.ts
+++ b/lib/rules/no-invalid-regexp.ts
@@ -22,8 +22,8 @@ export default createRule("no-invalid-regexp", {
         schema: [],
         messages: {
             error: "{{message}}",
-            duplicateFlag: "Duplicate {{flag}} flag",
-            uvFlag: "Regex 'u' and 'v' flags cannot be used together",
+            duplicateFlag: "Duplicate {{flag}} flag.",
+            uvFlag: "Regex 'u' and 'v' flags cannot be used together.",
         },
         type: "problem",
     },

--- a/lib/rules/no-invalid-regexp.ts
+++ b/lib/rules/no-invalid-regexp.ts
@@ -76,9 +76,6 @@ export default createRule("no-invalid-regexp", {
                 flagSet.add(flag)
             }
 
-            // `regexpp` checks the combination of `u` and `v` flags when parsing `Pattern` according to `ecma262`,
-            // but this rule may check only the flag when the pattern is unidentifiable, so check it here.
-            // https://tc39.es/ecma262/multipage/text-processing.html#sec-parsepattern
             if (flags.unicode && flags.unicodeSets) {
                 context.report({
                     node,

--- a/tests/lib/rules/no-invalid-regexp.ts
+++ b/tests/lib/rules/no-invalid-regexp.ts
@@ -49,7 +49,7 @@ tester.run("no-invalid-regexp", rule as any, {
             code: "new RegExp(pattern, 'uu');",
             errors: [
                 {
-                    message: "Duplicate u flag",
+                    message: "Duplicate u flag.",
                     column: 22,
                 },
             ],
@@ -58,7 +58,7 @@ tester.run("no-invalid-regexp", rule as any, {
             code: "new RegExp(pattern, 'uv');",
             errors: [
                 {
-                    message: "Regex 'u' and 'v' flags cannot be used together",
+                    message: "Regex 'u' and 'v' flags cannot be used together.",
                     column: 22,
                 },
             ],

--- a/tests/lib/rules/no-invalid-regexp.ts
+++ b/tests/lib/rules/no-invalid-regexp.ts
@@ -44,5 +44,16 @@ tester.run("no-invalid-regexp", rule as any, {
                 },
             ],
         },
+
+        // ES2024
+        {
+            code: "new RegExp(pattern, 'uv');",
+            errors: [
+                {
+                    message: "Regex 'u' and 'v' flags cannot be used together",
+                    column: 22,
+                },
+            ],
+        },
     ],
 })

--- a/tests/lib/rules/no-invalid-regexp.ts
+++ b/tests/lib/rules/no-invalid-regexp.ts
@@ -45,7 +45,15 @@ tester.run("no-invalid-regexp", rule as any, {
             ],
         },
 
-        // ES2024
+        {
+            code: "new RegExp(pattern, 'uu');",
+            errors: [
+                {
+                    message: "Duplicate u flag",
+                    column: 22,
+                },
+            ],
+        },
         {
             code: "new RegExp(pattern, 'uv');",
             errors: [


### PR DESCRIPTION
This PR improves the `regexp/no-invalid-regexp` rule to check flags even for unknown patterns.