### PR TITLE
Improve `regexp/require-unicode-regexp` rule to allow patterns with v flag

### DIFF
--- a/.changeset/loud-flowers-search.md
+++ b/.changeset/loud-flowers-search.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Improve `regexp/require-unicode-regexp` rule to allow patterns with v flag

--- a/lib/rules/require-unicode-regexp.ts
+++ b/lib/rules/require-unicode-regexp.ts
@@ -146,10 +146,7 @@ function isCompatibleCharLike(
     flags: ReadonlyFlags,
     uFlags: ReadonlyFlags,
 ): boolean {
-    // since we know that the property doesn't contain strings,
-    // we can just get the characters of the character class
-    // without worrying about the strings
-    const cs = toUnicodeSet(char, flags).chars
+    const cs = toUnicodeSet(char, flags)
     if (!cs.isDisjointWith(SURROGATES)) {
         // If the character (class/set) contains high or low
         // surrogates, then we won't be able to guarantee that the
@@ -157,10 +154,10 @@ function isCompatibleCharLike(
         return false
     }
 
-    const uCs = toUnicodeSet(char, uFlags).chars
+    const uCs = toUnicodeSet(char, uFlags)
 
     // Compare the ranges.
-    return rangeEqual(cs.ranges, uCs.ranges)
+    return rangeEqual(cs.chars.ranges, uCs.chars.ranges)
 }
 
 /**
@@ -202,22 +199,19 @@ function isCompatibleQuantifier(
         return undefined
     }
 
-    // since we know that the property doesn't contain strings,
-    // we can just get the characters of the character class
-    // without worrying about the strings
-    const cs = toUnicodeSet(q.element, flags).chars
+    const cs = toUnicodeSet(q.element, flags)
     if (!cs.isSupersetOf(SURROGATES)) {
         // failed condition 1
         return false
     }
 
-    const uCs = toUnicodeSet(q.element, uFlags).chars
+    const uCs = toUnicodeSet(q.element, uFlags)
     if (!uCs.isSupersetOf(SURROGATES) || !uCs.isSupersetOf(ASTRAL)) {
         // failed condition 2
         return false
     }
 
-    if (!rangeEqual(cs.ranges, uCs.without(ASTRAL).ranges)) {
+    if (!rangeEqual(cs.chars.ranges, uCs.without(ASTRAL).chars.ranges)) {
         // failed condition 3
         return false
     }

--- a/tests/lib/rules/require-unicode-regexp.ts
+++ b/tests/lib/rules/require-unicode-regexp.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/require-unicode-regexp"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -28,6 +28,8 @@ tester.run("require-unicode-regexp", rule as any, {
         String.raw`const flags = 'u'; new globalThis.RegExp('', flags)`,
         String.raw`const flags = 'g'; new globalThis.RegExp('', flags + 'u')`,
         String.raw`const flags = 'gimu'; new globalThis.RegExp('foo', flags[3])`,
+        String.raw`/foo/v`,
+        String.raw`new RegExp('foo', 'v')`,
     ],
     invalid: [
         {


### PR DESCRIPTION
related to https://github.com/ota-meshi/eslint-plugin-regexp/issues/545