### PR TITLE
Add support for v flag to `regexp/prefer-w` rule

### DIFF
--- a/.changeset/long-carrots-stare.md
+++ b/.changeset/long-carrots-stare.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Add support for v flag to `regexp/prefer-w` rule

--- a/lib/rules/prefer-w.ts
+++ b/lib/rules/prefer-w.ts
@@ -16,8 +16,9 @@ import {
     CP_DIGIT_NINE,
     CP_LOW_LINE,
 } from "../utils"
-import { Chars, toCharSet } from "regexp-ast-analysis"
+import { Chars, hasStrings, toUnicodeSet } from "regexp-ast-analysis"
 import { mention } from "../utils/mention"
+import { JS } from "refa"
 
 /**
  * Checks if small letter char class range
@@ -90,16 +91,19 @@ export default createRule("prefer-w", {
             fixReplaceNode,
             patternSource,
         }: RegExpContext): RegExpVisitor.Handlers {
+            const charSetWord = Chars.word(flags)
+            const unicodeSetWord = JS.UnicodeSet.fromChars(charSetWord)
+            const unicodeSetNegateWord = JS.UnicodeSet.fromChars(
+                charSetWord.negate(),
+            )
             return {
                 onCharacterClassEnter(ccNode: CharacterClass) {
-                    // FIXME: TS Error
-                    // @ts-expect-error -- FIXME
-                    const charSet = toCharSet(ccNode, flags)
-
+                    if (hasStrings(ccNode, flags)) return
+                    const us = toUnicodeSet(ccNode, flags)
                     let predefined: string | undefined = undefined
-                    if (charSet.equals(Chars.word(flags))) {
+                    if (us.equals(unicodeSetWord)) {
                         predefined = "\\w"
-                    } else if (charSet.equals(Chars.word(flags).negate())) {
+                    } else if (us.equals(unicodeSetNegateWord)) {
                         predefined = "\\W"
                     }
 

--- a/tests/lib/rules/prefer-w.ts
+++ b/tests/lib/rules/prefer-w.ts
@@ -3,13 +3,18 @@ import rule from "../../../lib/rules/prefer-w"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
 
 tester.run("prefer-w", rule as any, {
-    valid: ["/\\w/"],
+    valid: [
+        "/\\w/",
+        String.raw`/[0-9a-x\q{y|z}A-W[YZ_]]/v`,
+        String.raw`/[0-9a-x\q{z}A-X[YZ_]]/v`,
+        String.raw`/[0-9a-x\q{y|z}A-X[[YZ_]--_]]/v`,
+    ],
     invalid: [
         {
             code: "/[0-9a-zA-Z_]/",
@@ -113,6 +118,30 @@ tester.run("prefer-w", rule as any, {
             `,
             errors: [
                 "Unexpected character class ranges '[0-9A-Z_]'. Use '\\w' instead.",
+            ],
+        },
+        {
+            code: String.raw`/[0-9a-x\q{y|z}A-X[YZ_]]/v`,
+            output: "/\\w/v",
+            errors: [
+                {
+                    message:
+                        "Unexpected character class '[0-9a-x\\q{y|z}A-X[YZ_]]'. Use '\\w' instead.",
+                    column: 2,
+                    endColumn: 25,
+                },
+            ],
+        },
+        {
+            code: String.raw`/[0-9a-zA-Z[[_\q{abc}]--\q{abc}]]/v`,
+            output: "/\\w/v",
+            errors: [
+                {
+                    message:
+                        "Unexpected character class '[0-9a-zA-Z[[_\\q{abc}]--\\q{abc}]]'. Use '\\w' instead.",
+                    column: 2,
+                    endColumn: 34,
+                },
             ],
         },
     ],


### PR DESCRIPTION
related to https://github.com/ota-meshi/eslint-plugin-regexp/issues/545