### PR TITLE
Improve `regexp/strict` rule to ignore patterns with v flag

### DIFF
--- a/lib/rules/strict.ts
+++ b/lib/rules/strict.ts
@@ -88,7 +88,7 @@ export default createRule("strict", {
             const { node, flags, pattern, getRegexpLocation, fixReplaceNode } =
                 regexpContext
 
-            if (flags.unicode) {
+            if (flags.unicode || flags.unicodeSets) {
                 // the Unicode flag enables strict parsing mode automatically
                 return {}
             }

--- a/tests/lib/rules/strict.ts
+++ b/tests/lib/rules/strict.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/strict"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -22,6 +22,7 @@ tester.run("strict", rule as any, {
         String.raw`/[\( \) \[ \] \{ \} \| \* \+ \? \^ \$ \\ \/ \. \-]/`,
         "/\\u000f/",
         "/\\x000f/",
+        String.raw`/[A--B]/v`,
     ],
     invalid: [
         // source characters


### PR DESCRIPTION
related to https://github.com/ota-meshi/eslint-plugin-regexp/issues/545