### PR TITLE
Add support for v flag to `regexp/unicode-escape` and `regexp/prefer-unicode-codepoint-escapes` rules

### DIFF
--- a/.changeset/early-guests-hug.md
+++ b/.changeset/early-guests-hug.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Add support for v flag to `regexp/prefer-unicode-codepoint-escapes` rule

--- a/.changeset/large-dingos-allow.md
+++ b/.changeset/large-dingos-allow.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Add support for v flag to `regexp/unicode-escape` rule

--- a/lib/rules/prefer-unicode-codepoint-escapes.ts
+++ b/lib/rules/prefer-unicode-codepoint-escapes.ts
@@ -26,7 +26,7 @@ export default createRule("prefer-unicode-codepoint-escapes", {
         ): RegExpVisitor.Handlers {
             const { node, flags, getRegexpLocation, fixReplaceNode } =
                 regexpContext
-            if (!flags.unicode) {
+            if (!flags.unicode && !flags.unicodeSets) {
                 return {}
             }
             return {

--- a/lib/rules/unicode-escape.ts
+++ b/lib/rules/unicode-escape.ts
@@ -97,7 +97,7 @@ export default createRule("unicode-escape", {
             regexpContext: RegExpContext,
         ): RegExpVisitor.Handlers {
             const { flags } = regexpContext
-            if (!flags.unicode) {
+            if (!flags.unicode && !flags.unicodeSets) {
                 return {}
             }
             return {

--- a/tests/lib/rules/prefer-unicode-codepoint-escapes.ts
+++ b/tests/lib/rules/prefer-unicode-codepoint-escapes.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/prefer-unicode-codepoint-escapes"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -15,6 +15,8 @@ tester.run("prefer-unicode-codepoint-escapes", rule as any, {
         String.raw`/[\ud83d\ude00]/`,
         String.raw`/\u{1f600}/u`,
         String.raw`/😀/u`,
+        String.raw`/\u{1f600}/v`,
+        String.raw`/😀/v`,
     ],
     invalid: [
         {
@@ -73,6 +75,20 @@ tester.run("prefer-unicode-codepoint-escapes", rule as any, {
             output: null,
             errors: [
                 "Use Unicode codepoint escapes instead of Unicode escapes using surrogate pairs.",
+            ],
+        },
+        {
+            code: String.raw`/\ud83d\ude00/v`,
+            output: String.raw`/\u{1f600}/v`,
+            errors: [
+                {
+                    message:
+                        "Use Unicode codepoint escapes instead of Unicode escapes using surrogate pairs.",
+                    line: 1,
+                    column: 2,
+                    endLine: 1,
+                    endColumn: 14,
+                },
             ],
         },
     ],

--- a/tests/lib/rules/unicode-escape.ts
+++ b/tests/lib/rules/unicode-escape.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/unicode-escape"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -17,6 +17,14 @@ tester.run("unicode-escape", rule as any, {
         },
         {
             code: String.raw`/a \x0a \cM \0 \u0100 \u00ff \ud83d\ude00 \u{1f600}/u`,
+            options: ["unicodeEscape"],
+        },
+        {
+            code: String.raw`/a \x0a \cM \0 \u{ff} \u{100} \ud83d\ude00 \u{1f600}/v`,
+            options: ["unicodeCodePointEscape"],
+        },
+        {
+            code: String.raw`/a \x0a \cM \0 \u0100 \u00ff \ud83d\ude00 \u{1f600}/v`,
             options: ["unicodeEscape"],
         },
 
@@ -63,6 +71,40 @@ tester.run("unicode-escape", rule as any, {
         {
             code: String.raw`/a \x0a \cM \0 \u{ff} \u{100} \ud83d\ude00 \u{1f600}/u`,
             output: String.raw`/a \x0a \cM \0 \u00ff \u0100 \ud83d\ude00 \u{1f600}/u`,
+            options: ["unicodeEscape"],
+            errors: [
+                {
+                    message:
+                        "Expected unicode escape ('\\u00ff'), but unicode code point escape ('\\u{ff}') is used.",
+                    column: 16,
+                },
+                {
+                    message:
+                        "Expected unicode escape ('\\u0100'), but unicode code point escape ('\\u{100}') is used.",
+                    column: 23,
+                },
+            ],
+        },
+        {
+            code: String.raw`/a \x0a \cM \0 \u0100 \u00ff \ud83d\ude00 \u{1f600}/v`,
+            output: String.raw`/a \x0a \cM \0 \u{100} \u{ff} \ud83d\ude00 \u{1f600}/v`,
+            options: ["unicodeCodePointEscape"],
+            errors: [
+                {
+                    message:
+                        "Expected unicode code point escape ('\\u{100}'), but unicode escape ('\\u0100') is used.",
+                    column: 16,
+                },
+                {
+                    message:
+                        "Expected unicode code point escape ('\\u{ff}'), but unicode escape ('\\u00ff') is used.",
+                    column: 23,
+                },
+            ],
+        },
+        {
+            code: String.raw`/a \x0a \cM \0 \u{ff} \u{100} \ud83d\ude00 \u{1f600}/v`,
+            output: String.raw`/a \x0a \cM \0 \u00ff \u0100 \ud83d\ude00 \u{1f600}/v`,
             options: ["unicodeEscape"],
             errors: [
                 {


### PR DESCRIPTION


related to https://github.com/ota-meshi/eslint-plugin-regexp/issues/545