### PR TITLE
Add support for v flag to `regexp/no-useless-character-class` rule

### DIFF
--- a/.changeset/gold-baboons-clap.md
+++ b/.changeset/gold-baboons-clap.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Improve `regexp/no-useless-character-class` rule auto-fix to supports nested character classes

--- a/.changeset/gold-baboons-clap.md
+++ b/.changeset/gold-baboons-clap.md
@@ -2,4 +2,4 @@
 "eslint-plugin-regexp": minor
 ---
 
-Improve `regexp/no-useless-character-class` rule auto-fix to supports nested character classes
+Add support for v flag to  `regexp/no-useless-character-class` rule

--- a/lib/rules/no-useless-character-class.ts
+++ b/lib/rules/no-useless-character-class.ts
@@ -102,7 +102,16 @@ export default createRule("no-useless-character-class", {
                         if (element.min.value !== element.max.value) {
                             return
                         }
-                    } else if (element.type !== "CharacterSet") {
+                    } else if (element.type === "ClassStringDisjunction") {
+                        if (!characterClassStack.length) {
+                            // Only nesting character class
+                            return
+                        }
+                    } else if (
+                        element.type !== "CharacterSet" &&
+                        element.type !== "ExpressionCharacterClass" &&
+                        element.type !== "CharacterClass"
+                    ) {
                         return
                     }
 

--- a/lib/rules/no-useless-character-class.ts
+++ b/lib/rules/no-useless-character-class.ts
@@ -158,7 +158,7 @@ export default createRule("no-useless-character-class", {
                                 // Only nesting character class
                                 return
                             }
-                            messageData = { type: "string alternative" }
+                            messageData = { type: "string literal" }
                         } else if (element.type === "CharacterSet") {
                             messageData = { type: "character class escape" }
                         } else if (

--- a/lib/rules/no-useless-character-class.ts
+++ b/lib/rules/no-useless-character-class.ts
@@ -3,8 +3,20 @@ import type { RegExpContext } from "../utils"
 import { canUnwrapped, createRule, defineRegexpVisitor } from "../utils"
 import type {
     CharacterClass,
+    CharacterClassElement,
     ExpressionCharacterClass,
 } from "@eslint-community/regexpp/ast"
+
+const ESCAPES_OUTSIDE_CHARACTER_CLASS = new Set("$()*+./?[{|")
+const ESCAPES_OUTSIDE_CHARACTER_CLASS_WITH_U = new Set([
+    ...ESCAPES_OUTSIDE_CHARACTER_CLASS,
+    "}",
+])
+// A single character set of ClassSetReservedDoublePunctuator.
+// && !! ## $$ %% ** ++ ,, .. :: ;; << == >> ?? @@ ^^ `` ~~ are ClassSetReservedDoublePunctuator
+const REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR = new Set(
+    "!#$%&*+,.:;<=>?@^`~",
+)
 
 export default createRule("no-useless-character-class", {
     meta: {
@@ -31,8 +43,10 @@ export default createRule("no-useless-character-class", {
             },
         ],
         messages: {
-            unexpected:
+            unexpectedCharacterClassWith:
                 "Unexpected character class with one {{type}}. Can remove brackets{{additional}}.",
+            unexpectedUnnecessaryNestingCharacterClass:
+                "Unexpected unnecessary nesting character class. Can remove brackets.",
         },
         type: "suggestion", // "problem",
     },
@@ -65,110 +79,190 @@ export default createRule("no-useless-character-class", {
                 },
                 onCharacterClassLeave(ccNode) {
                     characterClassStack.pop()
-                    if (ccNode.elements.length !== 1) {
-                        return
-                    }
                     if (ccNode.negate) {
                         return
                     }
-                    const element = ccNode.elements[0]
-                    if (ignores.length > 0 && ignores.includes(element.raw)) {
-                        return
-                    }
-                    let messageData: { type: string; additional?: string }
-                    if (element.type === "Character") {
-                        if (element.raw === "\\b") {
-                            // Backspace escape
+                    let messageId: string,
+                        messageData: { type: string; additional?: string }
+                    const unwrapped: string[] = ccNode.elements.map(
+                        (_e, index) => {
+                            const element = ccNode.elements[index]
+                            return (
+                                (index === 0
+                                    ? getEscapedFirstRawIfNeeded(element)
+                                    : null) ??
+                                (index === ccNode.elements.length - 1
+                                    ? getEscapedLatsRawIfNeeded(element)
+                                    : null) ??
+                                element.raw
+                            )
+                        },
+                    )
+                    if (
+                        ccNode.elements.length !== 1 &&
+                        ccNode.parent.type === "CharacterClass"
+                    ) {
+                        messageId = "unexpectedUnnecessaryNestingCharacterClass"
+                        messageData = {
+                            type: "unnecessary nesting character class",
+                        }
+                    } else {
+                        if (ccNode.elements.length !== 1) {
                             return
                         }
-                        if (
-                            /^\\\d+$/u.test(element.raw) &&
-                            !element.raw.startsWith("\\0")
-                        ) {
-                            // Avoid back reference
-                            return
-                        }
+                        const element = ccNode.elements[0]
                         if (
                             ignores.length > 0 &&
-                            ignores.includes(
-                                String.fromCodePoint(element.value),
-                            )
+                            ignores.includes(element.raw)
                         ) {
                             return
                         }
-                        if (!canUnwrapped(ccNode, element.raw)) {
+                        if (element.type === "Character") {
+                            if (element.raw === "\\b") {
+                                // Backspace escape
+                                return
+                            }
+                            if (
+                                /^\\\d+$/u.test(element.raw) &&
+                                !element.raw.startsWith("\\0")
+                            ) {
+                                // Avoid back reference
+                                return
+                            }
+                            if (
+                                ignores.length > 0 &&
+                                ignores.includes(
+                                    String.fromCodePoint(element.value),
+                                )
+                            ) {
+                                return
+                            }
+                            if (!canUnwrapped(ccNode, element.raw)) {
+                                return
+                            }
+                            messageData = { type: "character" }
+                        } else if (element.type === "CharacterClassRange") {
+                            if (element.min.value !== element.max.value) {
+                                return
+                            }
+                            messageData = {
+                                type: "character class range",
+                                additional: " and range",
+                            }
+                            unwrapped[0] =
+                                getEscapedFirstRawIfNeeded(element.min) ??
+                                getEscapedLatsRawIfNeeded(element.min) ??
+                                element.min.raw
+                        } else if (element.type === "ClassStringDisjunction") {
+                            if (!characterClassStack.length) {
+                                // Only nesting character class
+                                return
+                            }
+                            messageData = { type: "string alternative" }
+                        } else if (element.type === "CharacterSet") {
+                            messageData = { type: "character class escape" }
+                        } else if (
+                            element.type === "CharacterClass" ||
+                            element.type === "ExpressionCharacterClass"
+                        ) {
+                            messageData = { type: "character class" }
+                        } else {
                             return
                         }
-                        messageData = { type: "character" }
-                    } else if (element.type === "CharacterClassRange") {
-                        if (element.min.value !== element.max.value) {
-                            return
-                        }
-                        messageData = {
-                            type: "character class range",
-                            additional: " and range",
-                        }
-                    } else if (element.type === "ClassStringDisjunction") {
-                        if (!characterClassStack.length) {
-                            // Only nesting character class
-                            return
-                        }
-                        messageData = { type: "string alternative" }
-                    } else if (element.type === "CharacterSet") {
-                        messageData = { type: "character class escape" }
-                    } else if (
-                        element.type === "CharacterClass" ||
-                        element.type === "ExpressionCharacterClass"
-                    ) {
-                        messageData = { type: "character class" }
-                    } else {
-                        return
+                        messageId = "unexpectedCharacterClassWith"
                     }
 
                     context.report({
                         node,
                         loc: getRegexpLocation(ccNode),
-                        messageId: "unexpected",
+                        messageId,
                         data: {
                             type: messageData.type,
                             additional: messageData.additional || "",
                         },
-                        fix: fixReplaceNode(ccNode, () => {
-                            let text: string =
-                                element.type === "CharacterClassRange"
-                                    ? element.min.raw
-                                    : element.raw
-                            if (
-                                element.type === "Character" ||
-                                element.type === "CharacterClassRange"
-                            ) {
-                                let needsEscape = false
-                                if (characterClassStack.length) {
-                                    // Nesting character class
-
-                                    // A single character of ClassSetReservedDoublePunctuator.
-                                    // && !! ## $$ %% ** ++ ,, .. :: ;; << == >> ?? @@ ^^ `` ~~ are ClassSetReservedDoublePunctuator
-                                    if (/^[!#$%&*+,.:;<=>?@^`~]$/u.test(text)) {
-                                        // Avoid [A[&]&B] => [A&&B], [A&&[&]] => [A&&&]
-                                        needsEscape =
-                                            // The previous character is the same
-                                            pattern[ccNode.end] === text ||
-                                            // The next character is the same
-                                            pattern[ccNode.start - 1] === text
-                                    }
-                                } else {
-                                    // Flat character class
-                                    needsEscape =
-                                        /^[$()*+./?[{|]$/u.test(text) ||
-                                        (flags.unicode && text === "}")
-                                }
-                                if (needsEscape) {
-                                    text = `\\${text}`
-                                }
-                            }
-                            return text
-                        }),
+                        fix: fixReplaceNode(ccNode, unwrapped.join("")),
                     })
+
+                    /**
+                     * Returns the escaped raw text, if the given first element requires escaping.
+                     * Otherwise, returns null.
+                     */
+                    function getEscapedFirstRawIfNeeded(
+                        firstElement: CharacterClassElement,
+                    ) {
+                        const firstRaw =
+                            firstElement.type === "Character"
+                                ? firstElement.raw
+                                : firstElement.type === "CharacterClassRange"
+                                ? firstElement.min.raw
+                                : null
+                        if (firstRaw == null) {
+                            return null
+                        }
+                        if (characterClassStack.length) {
+                            // Nesting character class
+
+                            // Avoid [A&&[&]] => [A&&&]
+                            if (
+                                REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR.has(
+                                    firstRaw,
+                                ) &&
+                                // The previous character is the same
+                                pattern[ccNode.start - 1] === firstRaw
+                            ) {
+                                return `\\${firstElement.raw}`
+                            }
+                            return null
+                        }
+
+                        // Flat character class
+                        if (
+                            (flags.unicode
+                                ? ESCAPES_OUTSIDE_CHARACTER_CLASS_WITH_U
+                                : ESCAPES_OUTSIDE_CHARACTER_CLASS
+                            ).has(firstRaw)
+                        ) {
+                            return `\\${firstElement.raw}`
+                        }
+                        return null
+                    }
+
+                    /**
+                     * Returns the escaped raw text, if the given last element requires escaping.
+                     * Otherwise, returns null.
+                     */
+                    function getEscapedLatsRawIfNeeded(
+                        lastElement: CharacterClassElement,
+                    ) {
+                        const lastRaw =
+                            lastElement.type === "Character"
+                                ? lastElement.raw
+                                : lastElement.type === "CharacterClassRange"
+                                ? lastElement.max.raw
+                                : null
+                        if (lastRaw == null) {
+                            return null
+                        }
+                        if (characterClassStack.length) {
+                            // Nesting character class
+
+                            // Avoid [A[&]&B] => [A&&B]
+                            if (
+                                REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR.has(
+                                    lastRaw,
+                                ) &&
+                                // The next character is the same
+                                pattern[ccNode.end] === lastRaw
+                            ) {
+                                const prefix = lastElement.raw.slice(
+                                    0,
+                                    -lastRaw.length,
+                                )
+                                return `${prefix}\\${lastRaw}`
+                            }
+                        }
+                        return null
+                    }
                 },
             }
         }

--- a/tests/lib/rules/no-useless-character-class.ts
+++ b/tests/lib/rules/no-useless-character-class.ts
@@ -47,6 +47,7 @@ tester.run("no-useless-character-class", rule as any, {
         String.raw`/\c[A]/`,
         String.raw`/\c[Z]/`,
         String.raw`/\c[m]/`,
+        String.raw`/[\q{abc}]/v`,
     ],
     invalid: [
         {
@@ -166,31 +167,41 @@ tester.run("no-useless-character-class", rule as any, {
         {
             code: String.raw`/[[\^]A]/v`,
             output: String.raw`/[\^A]/v`,
-            options: [{ ignores: [] }],
             errors: 1,
         },
         {
             code: String.raw`/[[A]--[B]]/v`,
             output: String.raw`/[A--B]/v`,
-            options: [{ ignores: [] }],
             errors: 2,
         },
         {
             code: String.raw`/[A[&]&B]/v; /[A&&[&]]/v`,
             output: String.raw`/[A\&&B]/v; /[A&&\&]/v`,
-            options: [{ ignores: [] }],
             errors: 2,
         },
         {
             code: String.raw`/[A[&-&]&B]/v`,
             output: String.raw`/[A\&&B]/v`,
-            options: [{ ignores: [] }],
             errors: 1,
         },
         {
             code: String.raw`/[[&]&&[&]]/v`,
             output: String.raw`/[\&&&\&]/v`,
-            options: [{ ignores: [] }],
+            errors: 2,
+        },
+        {
+            code: String.raw`/[[abc]]/v`,
+            output: String.raw`/[abc]/v`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[[A&&B]]/v`,
+            output: String.raw`/[A&&B]/v`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[[\q{abc}]]/v`,
+            output: String.raw`/[\q{abc}]/v`,
             errors: 2,
         },
     ],

--- a/tests/lib/rules/no-useless-character-class.ts
+++ b/tests/lib/rules/no-useless-character-class.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/no-useless-character-class"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -128,6 +128,12 @@ tester.run("no-useless-character-class", rule as any, {
             errors: 18,
         },
         {
+            code: String.raw`/[.] [*] [+] [?] [\^] [=] [!] [:] [$] [\{] [\}] [\(] [\)] [\|] [\[] [\]] [\/] [\\]/v`,
+            output: String.raw`/\. \* \+ \? \^ = ! : \$ \{ \} \( \) \| \[ \] \/ \\/v`,
+            options: [{ ignores: [] }],
+            errors: 18,
+        },
+        {
             code: String.raw`/[.-.]/u`,
             output: String.raw`/\./u`,
             options: [{ ignores: [] }],
@@ -148,6 +154,42 @@ tester.run("no-useless-character-class", rule as any, {
         {
             code: String.raw`RegExp("[\"]" + '[\']')`,
             output: String.raw`RegExp("\"" + '\'')`,
+            options: [{ ignores: [] }],
+            errors: 2,
+        },
+        {
+            code: String.raw`/[ [.] [*] [+] [?] [\^] [=] [!] [:] [$] [\{] [\}] [\(] [\)] [\|] [\[] [\]] [\/] [\\] ]/v`,
+            output: String.raw`/[ . * + ? \^ = ! : $ \{ \} \( \) \| \[ \] \/ \\ ]/v`,
+            options: [{ ignores: [] }],
+            errors: 18,
+        },
+        {
+            code: String.raw`/[[\^]A]/v`,
+            output: String.raw`/[\^A]/v`,
+            options: [{ ignores: [] }],
+            errors: 1,
+        },
+        {
+            code: String.raw`/[[A]--[B]]/v`,
+            output: String.raw`/[A--B]/v`,
+            options: [{ ignores: [] }],
+            errors: 2,
+        },
+        {
+            code: String.raw`/[A[&]&B]/v; /[A&&[&]]/v`,
+            output: String.raw`/[A\&&B]/v; /[A&&\&]/v`,
+            options: [{ ignores: [] }],
+            errors: 2,
+        },
+        {
+            code: String.raw`/[A[&-&]&B]/v`,
+            output: String.raw`/[A\&&B]/v`,
+            options: [{ ignores: [] }],
+            errors: 1,
+        },
+        {
+            code: String.raw`/[[&]&&[&]]/v`,
+            output: String.raw`/[\&&&\&]/v`,
             options: [{ ignores: [] }],
             errors: 2,
         },

--- a/tests/lib/rules/no-useless-character-class.ts
+++ b/tests/lib/rules/no-useless-character-class.ts
@@ -48,6 +48,10 @@ tester.run("no-useless-character-class", rule as any, {
         String.raw`/\c[Z]/`,
         String.raw`/\c[m]/`,
         String.raw`/[\q{abc}]/v`,
+        // This rule does not support them.
+        String.raw`/[^[abc]]/v`, // -> /[^abc]/v
+        String.raw`/[^[abc]d]/v`, // -> /[^abcd]/v
+        String.raw`/[[abc][def]ghi]/v`, // -> /[abcdefghi]/v
     ],
     invalid: [
         {
@@ -203,6 +207,11 @@ tester.run("no-useless-character-class", rule as any, {
             code: String.raw`/[[\q{abc}]]/v`,
             output: String.raw`/[\q{abc}]/v`,
             errors: 2,
+        },
+        {
+            code: String.raw`/[[^\w&&\d]]/v`,
+            output: String.raw`/[^\w&&\d]/v`,
+            errors: 1,
         },
     ],
 })

--- a/tests/lib/rules/no-useless-character-class.ts
+++ b/tests/lib/rules/no-useless-character-class.ts
@@ -257,5 +257,15 @@ tester.run("no-useless-character-class", rule as any, {
         //     output: String.raw`/[a\-b]/v`,
         //     errors: 1,
         // },
+        {
+            code: String.raw`/[[]^]/v`,
+            output: String.raw`/[\^]/v`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/[&[]&]/v`,
+            output: String.raw`/[&\&]/v`,
+            errors: 1,
+        },
     ],
 })

--- a/tests/lib/rules/no-useless-character-class.ts
+++ b/tests/lib/rules/no-useless-character-class.ts
@@ -209,7 +209,7 @@ tester.run("no-useless-character-class", rule as any, {
             output: String.raw`/[\q{abc}]/v`,
             errors: [
                 "Unexpected character class with one character class. Can remove brackets.",
-                "Unexpected character class with one string alternative. Can remove brackets.",
+                "Unexpected character class with one string literal. Can remove brackets.",
             ],
         },
         {


### PR DESCRIPTION

related to https://github.com/ota-meshi/eslint-plugin-regexp/issues/545