### PR TITLE
Add support for v flag to `regexp/no-non-standard-flag` rule

### DIFF
--- a/.changeset/brown-dragons-dance.md
+++ b/.changeset/brown-dragons-dance.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Add support for v flag to `regexp/no-non-standard-flag` rule

--- a/lib/rules/no-non-standard-flag.ts
+++ b/lib/rules/no-non-standard-flag.ts
@@ -1,7 +1,7 @@
 import type { RegExpContext, UnparsableRegExpContext } from "../utils"
 import { createRule, defineRegexpVisitor } from "../utils"
 
-const STANDARD_FLAGS = "dgimsuy"
+const STANDARD_FLAGS = "dgimsuvy"
 
 export default createRule("no-non-standard-flag", {
     meta: {

--- a/tests/lib/rules/no-non-standard-flag.ts
+++ b/tests/lib/rules/no-non-standard-flag.ts
@@ -3,14 +3,14 @@ import rule from "../../../lib/rules/no-non-standard-flag"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
     parser: require.resolve("@typescript-eslint/parser"),
 })
 
 tester.run("no-non-standard-flag", rule as any, {
-    valid: [`/foo/gimsuy`],
+    valid: [`/foo/gimsuy`, `/foo/v`],
     invalid: [
         {
             code: `/fo*o*/l`,


### PR DESCRIPTION
related to https://github.com/ota-meshi/eslint-plugin-regexp/issues/545