### PR TITLE
Add support for `v` flag to `regexp/no-contradiction-with-assertion`

### DIFF
--- a/.changeset/neat-rats-sneeze.md
+++ b/.changeset/neat-rats-sneeze.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": patch
+---
+
+Add support for `v` flag to `regexp/no-contradiction-with-assertion`

--- a/lib/rules/no-contradiction-with-assertion.ts
+++ b/lib/rules/no-contradiction-with-assertion.ts
@@ -89,7 +89,11 @@ function* getNextElements(
 
         if (
             parent.type === "CharacterClass" ||
-            parent.type === "CharacterClassRange"
+            parent.type === "CharacterClassRange" ||
+            parent.type === "ExpressionCharacterClass" ||
+            parent.type === "ClassIntersection" ||
+            parent.type === "ClassSubtraction" ||
+            parent.type === "StringAlternative"
         ) {
             return
         }
@@ -103,10 +107,8 @@ function* getNextElements(
             }
         }
 
-        // FIXME: TS Error
-        // @ts-expect-error -- FIXME
         const elements = parent.elements
-        const index = elements.indexOf(element) as number
+        const index = elements.indexOf(element)
         const inc = dir === "ltr" ? 1 : -1
         for (let i = index + inc; i >= 0 && i < elements.length; i += inc) {
             const e = elements[i]

--- a/tests/lib/rules/no-contradiction-with-assertion.ts
+++ b/tests/lib/rules/no-contradiction-with-assertion.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/no-contradiction-with-assertion"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -15,10 +15,12 @@ tester.run("no-contradiction-with-assertion", rule as any, {
         String.raw`/(?!)a/`,
         String.raw`/(?=)a/`,
         String.raw`/$a/`,
+        String.raw`/$a/v`,
 
         // Other valid regexes
         String.raw`/(^|[\s\S])\bfoo/`,
         String.raw`/(?:aa|a\b)-?a/`,
+        String.raw`/(?:aa|a\b)-?a/v`,
     ],
     invalid: [
         {
@@ -45,6 +47,15 @@ tester.run("no-contradiction-with-assertion", rule as any, {
                 {
                     messageId: "cannotEnterQuantifier",
                     suggestions: [{ output: String.raw`/a\b-/` }],
+                },
+            ],
+        },
+        {
+            code: String.raw`/a\b[a\q{foo|bar}]*-/v`,
+            errors: [
+                {
+                    messageId: "cannotEnterQuantifier",
+                    suggestions: [{ output: String.raw`/a\b-/v` }],
                 },
             ],
         },


### PR DESCRIPTION
related to https://github.com/ota-meshi/eslint-plugin-regexp/issues/545