### PR TITLE
Use `assertNever`

### DIFF
--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -1335,7 +1335,7 @@ export default createRule("no-dupe-disjunctions", {
                         break
 
                     default:
-                        return assertNever(result)
+                        throw assertNever(result)
                 }
             }
 

--- a/lib/rules/no-dupe-disjunctions.ts
+++ b/lib/rules/no-dupe-disjunctions.ts
@@ -41,6 +41,7 @@ import type { NestedAlternative } from "../utils/partial-parser"
 import { PartialParser } from "../utils/partial-parser"
 import type { Rule } from "eslint"
 import { getAllowedCharRanges, inRange } from "../utils/char-ranges"
+import { assertNever } from "../utils/util"
 
 type ParentNode = Group | CapturingGroup | Pattern | LookaroundAssertion
 
@@ -393,7 +394,7 @@ function getPartialSubsetRelation(
                 return SubsetRelation.leftSupersetOfRight
 
             default:
-                throw new Error(relation)
+                return assertNever(relation)
         }
     }
     if (rightIsPartial && !leftIsPartial) {
@@ -406,7 +407,7 @@ function getPartialSubsetRelation(
                 return SubsetRelation.none
 
             default:
-                throw new Error(relation)
+                return assertNever(relation)
         }
     }
 
@@ -696,7 +697,7 @@ function* findDuplicationNfa(
                 }
 
                 default:
-                    throw new Error(relation)
+                    throw assertNever(relation)
             }
         }
 
@@ -821,10 +822,6 @@ function deduplicateResults(
 
         return false
     })
-}
-
-function assertNever(value: never): never {
-    throw new Error(`Invalid value: ${value}`)
 }
 
 function mentionNested(nested: NestedAlternative): string {
@@ -1338,7 +1335,7 @@ export default createRule("no-dupe-disjunctions", {
                         break
 
                     default:
-                        throw new Error(result)
+                        return assertNever(result)
                 }
             }
 

--- a/lib/rules/no-misleading-capturing-group.ts
+++ b/lib/rules/no-misleading-capturing-group.ts
@@ -25,11 +25,8 @@ import { canSimplifyQuantifier } from "../utils/regexp-ast/simplify-quantifier"
 import { fixSimplifyQuantifier } from "../utils/fix-simplify-quantifier"
 import { joinEnglishList, mention } from "../utils/mention"
 import { getParser } from "../utils/regexp-ast"
+import { assertNever } from "../utils/util"
 import { CharSet } from "refa"
-
-function assertNever(value: never): never {
-    throw new Error(`Invalid value: ${value}`)
-}
 
 /**
  * Returns an iterator that goes through all elements in the given array in

--- a/lib/rules/no-useless-assertions.ts
+++ b/lib/rules/no-useless-assertions.ts
@@ -25,6 +25,7 @@ import {
     FirstConsumedChars,
 } from "regexp-ast-analysis"
 import { mention } from "../utils/mention"
+import { assertNever } from "../utils/util"
 
 /**
  * Combines 2 look chars such that the result is equivalent to 2 adjacent
@@ -414,6 +415,7 @@ export default createRule("no-useless-assertions", {
                         verifyLookaround(assertion, getFirstCharAfterFn)
                         break
                     default:
+                        throw assertNever(assertion)
                 }
             }
 

--- a/lib/rules/optimal-quantifier-concatenation.ts
+++ b/lib/rules/optimal-quantifier-concatenation.ts
@@ -26,6 +26,7 @@ import type { CharSet } from "refa"
 import { joinEnglishList, mention } from "../utils/mention"
 import { canSimplifyQuantifier } from "../utils/regexp-ast/simplify-quantifier"
 import { fixSimplifyQuantifier } from "../utils/fix-simplify-quantifier"
+import { assertNever } from "../utils/util"
 
 /**
  * Returns whether the given node is or contains a capturing group.
@@ -75,6 +76,7 @@ function getSingleConsumedChar(
         case "Character":
         case "CharacterSet":
         case "CharacterClass":
+        case "ExpressionCharacterClass":
             return {
                 // FIXME: TS Error
                 // @ts-expect-error -- FIXME
@@ -94,8 +96,13 @@ function getSingleConsumedChar(
             }
         }
 
-        default:
+        case "Assertion":
+        case "Backreference":
+        case "Quantifier":
             return empty
+
+        default:
+            return assertNever(element)
     }
 }
 
@@ -140,9 +147,14 @@ function isGroupOrCharacter(element: Element): element is GroupOrCharacter {
         case "Character":
         case "CharacterClass":
         case "CharacterSet":
+        case "ExpressionCharacterClass":
             return true
-        default:
+        case "Assertion":
+        case "Backreference":
+        case "Quantifier":
             return false
+        default:
+            return assertNever(element)
     }
 }
 

--- a/lib/rules/prefer-character-class.ts
+++ b/lib/rules/prefer-character-class.ts
@@ -22,6 +22,7 @@ import {
     getMatchingDirection,
 } from "regexp-ast-analysis"
 import type { Position, SourceLocation } from "estree"
+import { assertNever } from "../utils/util"
 
 /**
  * Find the first index of an element that satisfies the given condition.
@@ -126,7 +127,7 @@ function elementsToCharacterClass(elements: CharElementArray): string {
             default:
                 // FIXME: TS Error
                 // @ts-expect-error -- FIXME
-                throw new Error(e)
+                throw assertNever(e)
         }
     })
 
@@ -397,7 +398,7 @@ function getParentPrefixAndSuffix(
             return ["", ""]
 
         default:
-            throw new Error(parent)
+            return assertNever(parent)
     }
 }
 

--- a/lib/utils/partial-parser.ts
+++ b/lib/utils/partial-parser.ts
@@ -7,12 +7,9 @@ import type {
 } from "refa"
 import { JS } from "refa"
 import type { AST } from "@eslint-community/regexpp"
+import { assertNever } from "./util"
 
 export type NestedAlternative = AST.Alternative | AST.CharacterClassElement
-
-function assertNever(value: never): never {
-    throw new Error(`Invalid value: ${value}`)
-}
 
 class Context {
     public readonly ancestors: ReadonlySet<AST.Node>

--- a/lib/utils/regexp-ast/case-variation.ts
+++ b/lib/utils/regexp-ast/case-variation.ts
@@ -15,6 +15,7 @@ import type {
     Element,
     Pattern,
 } from "@eslint-community/regexpp/ast"
+import { assertNever } from "../util"
 
 const ignoreCaseFlagsCache = new WeakMap<ReadonlyFlags, ReadonlyFlags>()
 const caseSensitiveFlagsCache = new WeakMap<ReadonlyFlags, ReadonlyFlags>()
@@ -103,7 +104,7 @@ export function isCaseVariant(
                 }
 
             default:
-                throw new Error(`Unknown type: ${e}`)
+                return assertNever(e)
         }
     }
 

--- a/lib/utils/regexp-ast/simplify-quantifier.ts
+++ b/lib/utils/regexp-ast/simplify-quantifier.ts
@@ -16,6 +16,7 @@ import type {
     QuantifiableElement,
     Quantifier,
 } from "@eslint-community/regexpp/ast"
+import { assertNever } from "../util"
 
 /**
  * Wraps the given function to be cached by a `WeakMap`.
@@ -337,10 +338,6 @@ function removeTargetQuantifier(
     }
 
     return result
-}
-
-function assertNever(value: never): never {
-    throw new Error(`Invalid value: ${value}`)
 }
 
 /**

--- a/lib/utils/util.ts
+++ b/lib/utils/util.ts
@@ -1,0 +1,6 @@
+/**
+ * Throws if the function is called. This is useful for ensuring that a switch statement is exhaustive.
+ */
+export function assertNever(value: never): never {
+    throw new Error(`Invalid value: ${value}`)
+}


### PR DESCRIPTION
I moved `assertNever` into its own util file. 

The file is called `util.ts`, because I intend to move other general utility function into it (= function and constants that generally just fill holes in the language). Here's an example of this file in 2 other projects I work on: [Navi](https://github.com/chaiNNer-org/Navi/blob/main/src/util.ts), [refa](https://github.com/RunDevelopment/refa/blob/master/src/util.ts). This file will never have any imports, because it only depends on JavaScript itself.

I also used `assertNever` in a few places where it wasn't before.