### PR TITLE
Add support for `v` flag to `regexp/use-ignore-case`

### DIFF
--- a/.changeset/cyan-rats-attend.md
+++ b/.changeset/cyan-rats-attend.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Add support for `v` flag to `regexp/use-ignore-case`

--- a/lib/utils/util.ts
+++ b/lib/utils/util.ts
@@ -4,3 +4,22 @@
 export function assertNever(value: never): never {
     throw new Error(`Invalid value: ${value}`)
 }
+
+/**
+ * Returns a cached version of the given function. A `WeakMap` is used internally.
+ *
+ * For the cached function to behave correctly, the given function must be pure.
+ */
+export function cachedFn<K extends object, R>(
+    fn: (key: K) => R,
+): (key: K) => R {
+    const cache = new WeakMap<K, R>()
+    return (key) => {
+        let cached = cache.get(key)
+        if (cached === undefined) {
+            cached = fn(key)
+            cache.set(key, cached)
+        }
+        return cached
+    }
+}

--- a/tests/lib/rules/use-ignore-case.ts
+++ b/tests/lib/rules/use-ignore-case.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/use-ignore-case"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -16,6 +16,22 @@ tester.run("use-ignore-case", rule as any, {
         String.raw`/[aAb]/`,
         String.raw`/[aaaa]/`,
 
+        String.raw`/regexp/u`,
+        String.raw`/[aA]/iu`,
+        String.raw`/[aA]a/u`,
+        String.raw`/[aAb]/u`,
+        String.raw`/[aaaa]/u`,
+        String.raw`/\b[aA]/u`,
+        String.raw`/[a-zA-Z]/u`,
+
+        String.raw`/regexp/v`,
+        String.raw`/[aA]/iv`,
+        String.raw`/[aA]a/v`,
+        String.raw`/[aAb]/v`,
+        String.raw`/[aaaa]/v`,
+        String.raw`/\b[aA]/v`,
+        String.raw`/[a-zA-Z]/v`,
+
         // partial pattern
         String.raw`/[a-zA-Z]/.source`,
     ],
@@ -25,6 +41,27 @@ tester.run("use-ignore-case", rule as any, {
             output: String.raw`/[a-z]/i`,
             errors: [
                 "The character class(es) '[a-zA-Z]' can be simplified using the `i` flag.",
+            ],
+        },
+        {
+            code: String.raw`/[aA][aA][aA][aA][aA]/`,
+            output: String.raw`/[a][a][a][a][a]/i`,
+            errors: [
+                "The character class(es) '[aA]', '[aA]', '[aA]', '[aA]', '[aA]' can be simplified using the `i` flag.",
+            ],
+        },
+        {
+            code: String.raw`/[aA]/u`,
+            output: String.raw`/[a]/iu`,
+            errors: [
+                "The character class(es) '[aA]' can be simplified using the `i` flag.",
+            ],
+        },
+        {
+            code: String.raw`/[aA]/v`,
+            output: String.raw`/[a]/iv`,
+            errors: [
+                "The character class(es) '[aA]' can be simplified using the `i` flag.",
             ],
         },
         {
@@ -39,6 +76,13 @@ tester.run("use-ignore-case", rule as any, {
             output: String.raw`RegExp("[a-z]", "i")`,
             errors: [
                 "The character class(es) '[a-zA-Z]' can be simplified using the `i` flag.",
+            ],
+        },
+        {
+            code: String.raw`/[\q{a|A}]/v`,
+            output: String.raw`/[\q{a}]/iv`,
+            errors: [
+                "The character class(es) '[\\q{a|A}]' can be simplified using the `i` flag.",
             ],
         },
     ],


### PR DESCRIPTION
Related to #545.

Changes:
- The rule (and `isCaseVariant`) now supports the `v` flag.
- I added support for including string alternatives in the analysis.
- Fixed `removeAll`. That function did now work correctly because `pattern = pattern.slice(0, start) + pattern.slice(end)` is only correct for a `{ start, end }` pair.
- The rule will now add the `i` in the correct place. E.g. `u` -> `iu`.
- I added a `cachedFn` util function and used it in 3 places. The function itself is very simple.