### PR TITLE
Add support for `v` flag to `regexp/prefer-character-class`

### DIFF
--- a/.changeset/clean-kids-mate.md
+++ b/.changeset/clean-kids-mate.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Add support for `v` flag to `regexp/prefer-character-class`

--- a/lib/rules/no-useless-character-class.ts
+++ b/lib/rules/no-useless-character-class.ts
@@ -7,17 +7,13 @@ import type {
     ExpressionCharacterClass,
     UnicodeSetsCharacterClass,
 } from "@eslint-community/regexpp/ast"
+import { RESERVED_DOUBLE_PUNCTUATOR_CHARS } from "../utils/unicode-set"
 
 const ESCAPES_OUTSIDE_CHARACTER_CLASS = new Set("$()*+./?[{|")
 const ESCAPES_OUTSIDE_CHARACTER_CLASS_WITH_U = new Set([
     ...ESCAPES_OUTSIDE_CHARACTER_CLASS,
     "}",
 ])
-// A single character set of ClassSetReservedDoublePunctuator.
-// && !! ## $$ %% ** ++ ,, .. :: ;; << == >> ?? @@ ^^ `` ~~ are ClassSetReservedDoublePunctuator
-const REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR = new Set(
-    "!#$%&*+,.:;<=>?@^`~",
-)
 
 export default createRule("no-useless-character-class", {
     meta: {
@@ -217,9 +213,7 @@ export default createRule("no-useless-character-class", {
 
                             // Avoid [A&&[&]] => [A&&&]
                             if (
-                                REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR.has(
-                                    char,
-                                ) &&
+                                RESERVED_DOUBLE_PUNCTUATOR_CHARS.has(char) &&
                                 // The previous character is the same
                                 pattern[ccNode.start - 1] === char
                             ) {
@@ -263,9 +257,7 @@ export default createRule("no-useless-character-class", {
 
                             // Avoid [A[&]&B] => [A&&B]
                             return (
-                                REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR.has(
-                                    char,
-                                ) &&
+                                RESERVED_DOUBLE_PUNCTUATOR_CHARS.has(char) &&
                                 // The next character is the same
                                 pattern[ccNode.end] === char
                             )

--- a/lib/rules/no-useless-escape.ts
+++ b/lib/rules/no-useless-escape.ts
@@ -25,20 +25,8 @@ import {
     CP_PIPE,
     CP_MINUS,
     canUnwrapped,
-    CP_HASH,
-    CP_PERCENT,
-    CP_BAN,
-    CP_AMP,
-    CP_COMMA,
-    CP_COLON,
-    CP_SEMI,
-    CP_LT,
-    CP_EQ,
-    CP_GT,
-    CP_AT,
-    CP_TILDE,
-    CP_BACKTICK,
 } from "../utils"
+import { RESERVED_DOUBLE_PUNCTUATOR_CP } from "../utils/unicode-set"
 
 const REGEX_CHAR_CLASS_ESCAPES = new Set([
     CP_BACK_SLASH, // \\
@@ -79,29 +67,6 @@ const POTENTIAL_ESCAPE_SEQUENCE = new Set("uxkpP")
 const POTENTIAL_ESCAPE_SEQUENCE_FOR_CHAR_CLASS = new Set([
     ...POTENTIAL_ESCAPE_SEQUENCE,
     "q",
-])
-// A single character set of ClassSetReservedDoublePunctuator.
-// && !! ## $$ %% ** ++ ,, .. :: ;; << == >> ?? @@ ^^ `` ~~ are ClassSetReservedDoublePunctuator
-const REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR = new Set([
-    CP_BAN, // !
-    CP_HASH, // #
-    CP_DOLLAR, // $
-    CP_PERCENT, // %
-    CP_AMP, // &
-    CP_STAR, // *
-    CP_PLUS, // +
-    CP_COMMA, // ,
-    CP_DOT, // .
-    CP_COLON, // :
-    CP_SEMI, // ;
-    CP_LT, // <
-    CP_EQ, // =
-    CP_GT, // >
-    CP_QUESTION, // ?
-    CP_AT, // @
-    CP_CARET, // ^
-    CP_BACKTICK, // `
-    CP_TILDE, // ~
 ])
 
 export default createRule("no-useless-escape", {
@@ -186,7 +151,7 @@ export default createRule("no-useless-escape", {
                                 }
                                 if (flags.unicodeSets) {
                                     if (
-                                        REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR.has(
+                                        RESERVED_DOUBLE_PUNCTUATOR_CP.has(
                                             cNode.value,
                                         )
                                     ) {

--- a/lib/rules/require-unicode-sets-regexp.ts
+++ b/lib/rules/require-unicode-sets-regexp.ts
@@ -3,29 +3,7 @@ import type { RegExpContext } from "../utils"
 import { createRule, defineRegexpVisitor } from "../utils"
 import { RegExpParser, visitRegExpAST } from "@eslint-community/regexpp"
 import { toUnicodeSet } from "regexp-ast-analysis"
-
-const CLASS_SET_RESERVED_DOUBLE_PUNCTUATORS = [
-    "&&",
-    "!!",
-    "##",
-    "$$",
-    "%%",
-    "**",
-    "++",
-    ",,",
-    "..",
-    "::",
-    ";;",
-    "<<",
-    "==",
-    ">>",
-    "??",
-    "@@",
-    "^^",
-    "``",
-    "~~",
-    "--",
-]
+import { RESERVED_DOUBLE_PUNCTUATOR_PATTERN } from "../utils/unicode-set"
 
 /**
  * Returns whether the regex would keep its behavior if the v flag were to be
@@ -48,11 +26,7 @@ function isCompatible(regexpContext: RegExpContext): boolean {
                 if (!us.equals(vus)) {
                     throw INCOMPATIBLE
                 }
-                if (
-                    CLASS_SET_RESERVED_DOUBLE_PUNCTUATORS.some((punctuator) =>
-                        node.raw.includes(punctuator),
-                    )
-                ) {
+                if (RESERVED_DOUBLE_PUNCTUATOR_PATTERN.test(node.raw)) {
                     throw INCOMPATIBLE
                 }
             },

--- a/lib/utils/unicode-set.ts
+++ b/lib/utils/unicode-set.ts
@@ -1,0 +1,18 @@
+/**
+ * A single character set of ClassSetReservedDoublePunctuator.
+ *
+ * `&& !! ## $$ %% ** ++ ,, .. :: ;; << == >> ?? @@ ^^ `` ~~ --` are ClassSetReservedDoublePunctuator
+ */
+export const RESERVED_DOUBLE_PUNCTUATOR_CHARS: ReadonlySet<string> = new Set(
+    "&!#$%*+,.:;<=>?@^`~-",
+)
+
+/**
+ * Same as {@link RESERVED_DOUBLE_PUNCTUATOR_CHARS} but as code points.
+ */
+export const RESERVED_DOUBLE_PUNCTUATOR_CP: ReadonlySet<number> = new Set(
+    [...RESERVED_DOUBLE_PUNCTUATOR_CHARS].map((c) => c.codePointAt(0)!),
+)
+
+export const RESERVED_DOUBLE_PUNCTUATOR_PATTERN =
+    /&&|!!|##|\$\$|%%|\*\*|\+\+|,,|\.\.|::|;;|<<|==|>>|\?\?|@@|\^\^|``|~~|--/u

--- a/tests/lib/rules/prefer-character-class.ts
+++ b/tests/lib/rules/prefer-character-class.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/prefer-character-class"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -133,7 +133,7 @@ tester.run("prefer-character-class", rule as any, {
 
         { code: String.raw`/a|b|c/`, output: String.raw`/[abc]/`, errors: 1 },
         { code: String.raw`/]|a|b/`, output: String.raw`/[\]ab]/`, errors: 1 },
-        { code: String.raw`/-|a|c/`, output: String.raw`/[-ac]/`, errors: 1 },
+        { code: String.raw`/-|a|c/`, output: String.raw`/[\-ac]/`, errors: 1 },
         { code: String.raw`/a|-|c/`, output: String.raw`/[a\-c]/`, errors: 1 },
         {
             code: String.raw`/a|[-]|c/`,
@@ -268,6 +268,22 @@ tester.run("prefer-character-class", rule as any, {
         {
             code: String.raw`/--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&|\|\|?|\?|\*|\/|~|\^|%/`,
             output: String.raw`/--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&|\|\|?|[\?\*\/~\^%]/`,
+            errors: 1,
+        },
+
+        {
+            code: String.raw`/1|2|3|[\w--\d]/v`,
+            output: String.raw`/[123[\w--\d]]/v`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/1|&|&|[\w--\d]/v`,
+            output: String.raw`/[1\&&[\w--\d]]/v`,
+            errors: 1,
+        },
+        {
+            code: String.raw`/1|~|~|[\w--\d]|[\q{abc}]/v`,
+            output: String.raw`/[1\~~[\w--\d]]|[\q{abc}]/v`,
             errors: 1,
         },
 


### PR DESCRIPTION
Related to #545

Changes:
- What the title says.
- Added `unicode-set.ts` util file for reserved punctuators.
- Changed `no-useless-character-class`, `no-useless-escape`, and `require-unicode-sets-regexp` to use the new util file.

Some details about how I changed `prefer-character-class`:
- This rule assumes that character elements are exactly one character long. So it's hard to add support for e.g. `\q{abc}`. So I restricted it to character elements that don't contain strings. So the rule won't combine e.g. `[abc]|[\q{abc}]` -> `[abc\q{abc}]`. I think support for this can be added in a follow-up PR.
- Since the parsing with the `v` flag is stricter, I had to change `elementsToCharacterClass` (the function that creates the combined character class) to make more escapes. Those additional escapes apply to all regexes regardless of flags.