### PR TITLE
Add support for `v` flag to `regexp/match-any`

### DIFF
--- a/.changeset/lemon-goats-look.md
+++ b/.changeset/lemon-goats-look.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Add support for `v` flag to `regexp/match-any`

--- a/tests/lib/rules/match-any.ts
+++ b/tests/lib/rules/match-any.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/match-any"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -41,6 +41,7 @@ tester.run("match-any", rule as any, {
         "/[^\\p{ASCII}\\P{ASCII}]/u",
         "/[^\\P{ASCII}\\p{ASCII}]/u",
         "/[^\\s\\S\\0-\\uFFFF]/",
+        String.raw`/[\S\s\q{abc}]/v`,
     ],
     invalid: [
         {
@@ -53,6 +54,25 @@ tester.run("match-any", rule as any, {
                     column: 2,
                     endColumn: 8,
                 },
+            ],
+        },
+        {
+            code: String.raw`/[\S\s]/v`,
+            output: String.raw`/[\s\S]/v`,
+            errors: ["Unexpected using '[\\S\\s]' to match any character."],
+        },
+        {
+            code: String.raw`/[\S\s\q{a|b|c}]/v`,
+            output: String.raw`/[\s\S]/v`,
+            errors: [
+                "Unexpected using '[\\S\\s\\q{a|b|c}]' to match any character.",
+            ],
+        },
+        {
+            code: String.raw`/[[\S\s\q{abc}]--\q{abc}]/v`,
+            output: String.raw`/[\s\S]/v`,
+            errors: [
+                "Unexpected using '[[\\S\\s\\q{abc}]--\\q{abc}]' to match any character.",
             ],
         },
         {


### PR DESCRIPTION
Changes:
- Fixed that character classes with strings were lost their strings after fixing. E.g. `[\q{abc}\s\S]` -> `[\s\S]`.
- Check expression character classes as well.