### PR TITLE
Fixed incorrect default of `ignoreSticky` option in `regexp/no-super-linear-move`

### DIFF
--- a/.changeset/dry-horses-punch.md
+++ b/.changeset/dry-horses-punch.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": patch
+---
+
+Fixed incorrect default of `ignoreSticky` option in `regexp/no-super-linear-move`

--- a/lib/rules/no-super-linear-move.ts
+++ b/lib/rules/no-super-linear-move.ts
@@ -146,7 +146,7 @@ export default createRule("no-super-linear-move", {
     create(context) {
         const reportUncertain =
             (context.options[0]?.report ?? "certain") === "potential"
-        const ignoreSticky = context.options[0]?.ignoreSticky ?? false
+        const ignoreSticky = context.options[0]?.ignoreSticky ?? true
         const ignorePartial = context.options[0]?.ignorePartial ?? true
 
         function getScslreReports(


### PR DESCRIPTION
Fixes #629