### PR TITLE
Add support for v flag to `regexp/no-empty-character-class`

### DIFF
--- a/.changeset/purple-suns-carry.md
+++ b/.changeset/purple-suns-carry.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Add support for v flag to `regexp/no-empty-character-class`

--- a/lib/rules/no-empty-character-class.ts
+++ b/lib/rules/no-empty-character-class.ts
@@ -35,6 +35,15 @@ export default createRule("no-empty-character-class", {
                         })
                     }
                 },
+                onExpressionCharacterClassEnter(ccNode) {
+                    if (matchesNoCharacters(ccNode, flags)) {
+                        context.report({
+                            node,
+                            loc: getRegexpLocation(ccNode),
+                            messageId: "cannotMatchAny",
+                        })
+                    }
+                },
             }
         }
 

--- a/tests/lib/rules/no-empty-character-class.ts
+++ b/tests/lib/rules/no-empty-character-class.ts
@@ -3,7 +3,7 @@ import rule from "../../../lib/rules/no-empty-character-class"
 
 const tester = new RuleTester({
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
 })
@@ -21,6 +21,8 @@ tester.run("no-empty-character-class", rule as any, {
         `/[ ]/`,
         String.raw`/[\s\S]/`,
         String.raw`/[\da-zA-Z_\W]/`,
+        String.raw`/a[[[ab]&&b]]/v`,
+        String.raw`/a[[ab]&&b]/v`,
     ],
     invalid: [
         {
@@ -74,6 +76,34 @@ tester.run("no-empty-character-class", rule as any, {
         {
             code: String.raw`/[^\da-zA-Z_\W]/`,
             errors: ["This character class cannot match any characters."],
+        },
+        {
+            code: String.raw`/a[[a&&b]]/v`,
+            errors: [
+                {
+                    message:
+                        "This character class cannot match any characters.",
+                    line: 1,
+                    column: 3,
+                },
+                {
+                    message:
+                        "This character class cannot match any characters.",
+                    line: 1,
+                    column: 4,
+                },
+            ],
+        },
+        {
+            code: String.raw`/a[a&&b]/v`,
+            errors: [
+                {
+                    message:
+                        "This character class cannot match any characters.",
+                    line: 1,
+                    column: 3,
+                },
+            ],
         },
     ],
 })


### PR DESCRIPTION
related to https://github.com/ota-meshi/eslint-plugin-regexp/issues/545