### PR TITLE
Improve detection for `regexp/no-useless-assertion`

### DIFF
--- a/.changeset/odd-oranges-matter.md
+++ b/.changeset/odd-oranges-matter.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Improve detection of useless assertions for `regexp/no-useless-assertion`

--- a/tests/lib/rules/no-useless-assertions.ts
+++ b/tests/lib/rules/no-useless-assertions.ts
@@ -433,5 +433,26 @@ tester.run("no-useless-assertions", rule as any, {
                 "'\\B' will always accept because it is preceded by a non-word character and followed by a non-word character.",
             ],
         },
+
+        {
+            code: String.raw`/(?!$)$/`,
+            errors: ["The negative lookahead '(?!$)' will always reject."],
+        },
+        {
+            code: String.raw`/(?=a|$)a/`,
+            errors: ["The lookahead '(?=a|$)' will always accept."],
+        },
+        {
+            code: String.raw`/(?=(?=[a-f])(?=a|A)[\w%])a/`,
+            errors: [
+                "The lookahead '(?=(?=[a-f])(?=a|A)[\\w%])' will always accept.",
+            ],
+        },
+        {
+            code: String.raw`/(?=(?=[a-f])(?=[aA])\w(?<=[aA])(?<=[a-f]))a/`,
+            errors: [
+                "The lookahead '(?=(?=[a-f])(?=[aA])\\w(?<=[aA])(?<=[a-f]))' will always accept.",
+            ],
+        },
     ],
 })


### PR DESCRIPTION
Fixes #661.

The new condition for always accepting is relatively simple. It's just the previous check, but it accounts for edges properly and allows more assertions. 

The complex part of this PR is the `isSingleCharacterAssertion` function. Implementing this function was surprisingly complex. Since we can't modify the AST, we have to handle some pretty complex cases. But even with those complex cases handled, `isSingleCharacterAssertion` is still not perfect and will return false negatives at times. Fortunately, false negatives aren't a problem for us.