### PR TITLE
Fixed minor mistake in message of `no-misleading-unicode-character`

### DIFF
--- a/.changeset/nine-pets-tan.md
+++ b/.changeset/nine-pets-tan.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": patch
+---
+
+Fixed minor mistake in message of `no-misleading-unicode-character`

--- a/lib/rules/no-misleading-unicode-character.ts
+++ b/lib/rules/no-misleading-unicode-character.ts
@@ -276,7 +276,10 @@ export default createRule("no-misleading-unicode-character", {
                         messageId: "characterClass",
                         data: {
                             graphemes,
-                            unit: flags.unicode ? "code points" : "char codes",
+                            unit:
+                                flags.unicode || flags.unicodeSets
+                                    ? "code points"
+                                    : "char codes",
                             uFlag: uFlag ? " Use the `u` flag." : "",
                         },
                         ...makeFix(

--- a/tests/lib/rules/no-misleading-unicode-character.ts
+++ b/tests/lib/rules/no-misleading-unicode-character.ts
@@ -293,6 +293,14 @@ tester.run("no-misleading-unicode-character", rule as any, {
             errors: [{ messageId: "characterClass" }],
         },
         {
+            code: String.raw`/[👶🏻👨‍👩‍👦]/v`,
+            output: String.raw`/[\q{👶🏻|👨‍👩‍👦}]/v`,
+            options: [{ fixable: true }],
+            errors: [
+                "The character(s) '👶🏻', '👨‍👩‍👦' are all represented using multiple code points.",
+            ],
+        },
+        {
             code: String.raw`/[👶🏻&👨‍👩‍👦]/v`,
             output: String.raw`/[\q{👶🏻|👨‍👩‍👦}&]/v`,
             options: [{ fixable: true }],


### PR DESCRIPTION
In the error message, a grapheme with multiple code points was said to have "multiple char codes". A very minor mistake.