### PR TITLE
Fix typos in docs 

### DIFF
--- a/docs/rules/control-character-escape.md
+++ b/docs/rules/control-character-escape.md
@@ -17,7 +17,7 @@ since: "v0.9.0"
 
 ## :book: Rule Details
 
-This rule reports control characters that were not escaped using a control escape (`\0`, `t`, `\n`, `\v`, `f`, `\r`).
+This rule reports control characters that were not escaped using a control escape (`\0`, `\t`, `\n`, `\v`, `\f`, `\r`).
 
 <eslint-code-block fix>
 

--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -39,7 +39,7 @@ RegExp('=' + space + '+(\\w+)', 'u')
 
 ### Differences to ESLint's `no-invalid-regexp` rule
 
-This rule is almost functionally equivalent to ESLint's [no-invalid-regexp] rule. The only difference is that this rule doesn't valid flags (see [no-non-standard-flag](./no-non-standard-flag.html)).
+This rule is almost functionally equivalent to ESLint's [no-invalid-regexp] rule. The only difference is that this rule doesn't validate flags (see [no-non-standard-flag](./no-non-standard-flag.html)).
 
 There are two reasons we provide this rule:
 


### PR DESCRIPTION
I've noticed two minor errors in the documentation. This simply addresses them.