### PR TITLE
docs: replaces 🏳️‍🌈 emoji with 🏴‍☠️ emoji

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,8 +15,8 @@
     "css.validate": false,
     "typescript.tsdk": "./node_modules/typescript/lib",
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true,
-        "source.fixAll.stylelint": true
+        "source.fixAll.eslint": "explicit",
+        "source.fixAll.stylelint": "explicit"
     },
     "stylelint.validate": [
         "css",

--- a/docs/rules/no-misleading-unicode-character.md
+++ b/docs/rules/no-misleading-unicode-character.md
@@ -19,10 +19,10 @@ since: "v1.2.0"
 
 This rule reports misleading Unicode characters.
 
-Some Unicode characters like '❇️', '🏳️‍🌈', and '👨‍👩‍👦' consist of multiple code points. This causes problems in character classes and around quantifiers. E.g.
+Some Unicode characters like '❇️', '🏴‍☠️', and '👨‍👩‍👦' consist of multiple code points. This causes problems in character classes and around quantifiers. E.g.
 
 ```js
-> /^[❇️🏳️‍🌈]$/.test("🏳️‍🌈")
+> /^[❇️🏴‍☠️]$/.test("🏴‍☠️")
 false
 > /^👨‍👩‍👦{2,4}$/.test("👨‍👩‍👦👨‍👩‍👦")
 false
@@ -41,7 +41,7 @@ var foo = /👨‍👩‍👦/;
 
 /* ✗ BAD */
 var foo = /👍+/;
-var foo = /[❇️🏳️‍🌈👨‍👩‍👦]❤️/;
+var foo = /[❇️🏴‍☠️👨‍👩‍👦]❤️/;
 ```
 
 </eslint-code-block>


### PR DESCRIPTION
I received the following message from GitHub:

> The below code is promoting the idea that families from the LGBT community should not be seen well which we found  to be in violation of our Acceptable Use Policies. 
> 
> ```
> /* ✗ BAD */
> ❇️🏳️‍🌈👨‍👩‍👦]
> ```

I know we don't intend such a discriminatory meaning, but for some people to think it's discriminatory, that's not what I mean either, so I fixes the documentation.

For the record, I would like to strongly emphasize that this pull request to replace the flag is not intended to exclude LGBT people.