### PR TITLE
use eslint-plugin-eslint-rule-tester

### DIFF
--- a/.eslintrc-editor-only.js
+++ b/.eslintrc-editor-only.js
@@ -1,0 +1,11 @@
+"use strict"
+
+module.exports = {
+    extends: [require.resolve('./.eslintrc.js')],
+    overrides: [
+        {
+            files: ["tests/lib/rules/*"],
+            extends: ['plugin:eslint-rule-tester/recommended-legacy']
+        },
+    ],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
         "jsonc",
         "yaml"
     ],
+    "eslint.options": {
+        "overrideConfigFile": "./.eslintrc-editor-only.js"
+    },
     "typescript.validate.enable": true,
     "javascript.validate.enable": false,
     "vetur.validation.script": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "eslint-doc-generator": "^1.7.0",
                 "eslint-plugin-eslint-comments": "^3.2.0",
                 "eslint-plugin-eslint-plugin": "^5.2.1",
+                "eslint-plugin-eslint-rule-tester": "^0.1.1",
                 "eslint-plugin-json-schema-validator": "^4.6.1",
                 "eslint-plugin-jsonc": "^2.0.0",
                 "eslint-plugin-n": "^16.0.0",
@@ -66,6 +67,20 @@
             },
             "peerDependencies": {
                 "eslint": ">=8.44.0"
+            }
+        },
+        "eslint-plugin-internal": {
+            "version": "0.0.0",
+            "extraneous": true,
+            "peerDependencies": {
+                "@eslint-community/eslint-utils": "*",
+                "eslint": "*",
+                "ts-node": "*"
+            },
+            "peerDependenciesMeta": {
+                "ts-node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -5440,6 +5455,24 @@
             },
             "peerDependencies": {
                 "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-eslint-rule-tester": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-rule-tester/-/eslint-plugin-eslint-rule-tester-0.1.1.tgz",
+            "integrity": "sha512-mG3CvpTH72T5KWUZMbNeP3UQZIKFN0iHnYWCsVtEX7rDorAywBAmPZ9IIuLwWuYaEFTCPaiXcSxyzvJ3g3LQUQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            },
+            "peerDependencies": {
+                "eslint": "^8.0.0 || ^9.0.0-0"
             }
         },
         "node_modules/eslint-plugin-json-schema-validator": {
@@ -15293,6 +15326,15 @@
             "requires": {
                 "eslint-utils": "^3.0.0",
                 "estraverse": "^5.3.0"
+            }
+        },
+        "eslint-plugin-eslint-rule-tester": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-rule-tester/-/eslint-plugin-eslint-rule-tester-0.1.1.tgz",
+            "integrity": "sha512-mG3CvpTH72T5KWUZMbNeP3UQZIKFN0iHnYWCsVtEX7rDorAywBAmPZ9IIuLwWuYaEFTCPaiXcSxyzvJ3g3LQUQ==",
+            "dev": true,
+            "requires": {
+                "@eslint-community/eslint-utils": "^4.4.0"
             }
         },
         "eslint-plugin-json-schema-validator": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "eslint-doc-generator": "^1.7.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-eslint-plugin": "^5.2.1",
+        "eslint-plugin-eslint-rule-tester": "^0.1.1",
         "eslint-plugin-json-schema-validator": "^4.6.1",
         "eslint-plugin-jsonc": "^2.0.0",
         "eslint-plugin-n": "^16.0.0",


### PR DESCRIPTION
I'm not sure if this will work yet, but I think merging this PR will allow test case expectations to update automatically if you're using VSCode. Related to https://github.com/ota-meshi/eslint-plugin-regexp/pull/703#issuecomment-1987047177

See https://github.com/ota-meshi/eslint-plugin-eslint-rule-tester.