### PR TITLE
Publish type declarations

### DIFF
--- a/.changeset/mean-peas-give.md
+++ b/.changeset/mean-peas-give.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": patch
+---
+
+Publish type declarations

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "node": "^18 || >=20"
     },
     "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "files": [
         "dist"
     ],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "exclude": ["tests/**/*", "tools/**/*", "typings/**/*", "docs/**/*"],
     "compilerOptions": {
-        "removeComments": true /* Do not emit comments to output. */
+        "removeComments": true /* Do not emit comments to output. */,
+        "declaration": true /* Generates corresponding '.d.ts' file. */
     }
 }


### PR DESCRIPTION
Fixes #723

This PR makes our build process emit type declarations (`.d.ts` files). Since we publish the entire `dist/` folder, they will be included when publishing without any further config changes. In my tests, types declarations were correctly imported, so this seems to work.

One thing to note is that this PR publishes a lot more `.d.ts` files than necessary. All files in `lib/rules` and `lib/utils` will have their type declarations published as well. I don't think there are any real downsides that come from this, but I think it's something we should be aware of.