### PR TITLE
chore: remove intl-segmenter-polyfill

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -19,10 +19,6 @@ const theme: Theme = {
     async enhanceApp(ctx) {
         DefaultTheme.enhanceApp(ctx)
 
-        if (typeof Intl.Segmenter === "undefined") {
-            await setupIntlSegmenter()
-        }
-
         const ESLintCodeBlock = await import(
             "./components/eslint-code-block.vue"
         ).then((m) => m.default ?? m)
@@ -34,19 +30,3 @@ const theme: Theme = {
     },
 }
 export default theme
-
-// We can remove this polyfill once Firefox supports Intl.Segmenter.
-async function setupIntlSegmenter() {
-    // For Firefox
-    const [{ createIntlSegmenterPolyfill }, breakIteratorUrl] =
-        await Promise.all([
-            import("intl-segmenter-polyfill"),
-            import(
-                // @ts-expect-error -- polyfill
-                "intl-segmenter-polyfill/dist/break_iterator.wasm?url"
-            ).then((m) => m.default ?? m),
-        ])
-
-    // @ts-expect-error -- polyfill
-    Intl.Segmenter = await createIntlSegmenterPolyfill(fetch(breakIteratorUrl))
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
                 "eslint-plugin-vue": "^9.26.0",
                 "eslint-plugin-yml": "^1.14.0",
                 "eslint-snapshot-rule-tester": "^0.1.0",
-                "intl-segmenter-polyfill": "^0.4.4",
                 "markdownlint-cli": "^0.41.0",
                 "mocha": "^10.0.0",
                 "mocha-chai-jest-snapshot": "^1.1.3",
@@ -6922,12 +6921,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
         },
-        "node_modules/fast-text-encoding": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-            "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
-            "dev": true
-        },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -7697,15 +7690,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/intl-segmenter-polyfill": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/intl-segmenter-polyfill/-/intl-segmenter-polyfill-0.4.4.tgz",
-            "integrity": "sha512-dIOcmvH+Q1WYGkjMqxPfaCgHEwOegH5UPcd/LLeaeY8aguHadC46MzGb40q8C1LrsuyJxJGKeKqoVtIh9ADRXQ==",
-            "dev": true,
-            "dependencies": {
-                "fast-text-encoding": "^1.0.2"
             }
         },
         "node_modules/is-alphabetical": {
@@ -18424,12 +18408,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
         },
-        "fast-text-encoding": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-            "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
-            "dev": true
-        },
         "fastest-levenshtein": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -18985,15 +18963,6 @@
                 "es-errors": "^1.3.0",
                 "hasown": "^2.0.0",
                 "side-channel": "^1.0.4"
-            }
-        },
-        "intl-segmenter-polyfill": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/intl-segmenter-polyfill/-/intl-segmenter-polyfill-0.4.4.tgz",
-            "integrity": "sha512-dIOcmvH+Q1WYGkjMqxPfaCgHEwOegH5UPcd/LLeaeY8aguHadC46MzGb40q8C1LrsuyJxJGKeKqoVtIh9ADRXQ==",
-            "dev": true,
-            "requires": {
-                "fast-text-encoding": "^1.0.2"
             }
         },
         "is-alphabetical": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
         "eslint-plugin-vue": "^9.26.0",
         "eslint-plugin-yml": "^1.14.0",
         "eslint-snapshot-rule-tester": "^0.1.0",
-        "intl-segmenter-polyfill": "^0.4.4",
         "markdownlint-cli": "^0.41.0",
         "mocha": "^10.0.0",
         "mocha-chai-jest-snapshot": "^1.1.3",


### PR DESCRIPTION
This PR removes intl-segmenter-polyfill.
intl-segmenter-polyfill was used on our site. This is because Intl.Segmenter did not work in FireFox.
However, FireFox now supports Intl.Segmenter, so intl-segmenter-polyfill is no longer needed.

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/125