### PR TITLE
Generate string literal types for configs

### DIFF
--- a/.changeset/grumpy-waves-warn.md
+++ b/.changeset/grumpy-waves-warn.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+Improved compatibility of type information with typescript-eslint in config.

--- a/lib/configs/rules/all.ts
+++ b/lib/configs/rules/all.ts
@@ -1,7 +1,8 @@
 import { rules as ruleLint } from "../../all-rules"
+import type { SeverityString } from "../../types"
 import { rules as recommendedRules } from "./recommended"
 
-const all: Record<string, string> = {}
+const all: Record<string, SeverityString> = {}
 for (const rule of ruleLint) {
     all[rule.meta.docs.ruleId] = "error"
 }

--- a/lib/configs/rules/recommended.ts
+++ b/lib/configs/rules/recommended.ts
@@ -1,4 +1,6 @@
-export const rules = {
+import type { SeverityString } from "../../types"
+
+export const rules: Record<string, SeverityString> = {
     // ESLint core rules
     "no-control-regex": "error",
     "no-misleading-character-class": "error",
@@ -70,4 +72,4 @@ export const rules = {
     "regexp/sort-flags": "error",
     "regexp/strict": "error",
     "regexp/use-ignore-case": "error",
-} as const
+}

--- a/lib/configs/rules/recommended.ts
+++ b/lib/configs/rules/recommended.ts
@@ -70,4 +70,4 @@ export const rules = {
     "regexp/sort-flags": "error",
     "regexp/strict": "error",
     "regexp/use-ignore-case": "error",
-}
+} as const

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,8 @@ export type RuleCategory =
     | "Best Practices"
     | "Stylistic Issues"
 
+export type SeverityString = "error" | "warn" | "off"
+
 export interface RuleMetaData {
     docs: {
         description: string
@@ -21,7 +23,7 @@ export interface RuleMetaData {
         url: string
         ruleId: string
         ruleName: string
-        default?: "error" | "warn"
+        default?: Exclude<SeverityString, "off">
     }
     messages: { [messageId: string]: string }
     fixable?: "code" | "whitespace"
@@ -42,7 +44,7 @@ export interface PartialRuleMetaData {
         description: string
         category: RuleCategory
         recommended: boolean
-        default?: "error" | "warn"
+        default?: Exclude<SeverityString, "off">
     }
     messages: { [messageId: string]: string }
     fixable?: "code" | "whitespace"

--- a/tools/update-rulesets.ts
+++ b/tools/update-rulesets.ts
@@ -14,7 +14,9 @@ const coreRules = [
     // "require-unicode-regexp", // modern
 ]
 
-const content = `export const rules = {
+const content = `import type { SeverityString } from "../../types"
+
+export const rules: Record<string, SeverityString> = {
     // ESLint core rules
     ${coreRules.map((ruleName) => `"${ruleName}": "error"`).join(",\n    ")},
     // The ESLint rule will report fewer cases than our rule


### PR DESCRIPTION
Hi there, first of all thanks for this ESLint plugin, great to learn about regular expression antipatterns!

Using the `tseslint.config()` config helper function from [`typescript-eslint`](https://typescript-eslint.io/) leads to an error:

```ts
import tseslint from 'typescript-eslint';

const config = tseslint.config(
  regexp.configs['flat/recommended'] // 💥 Argument of type 'typeof import("/Users/k/p/project/node_modules/eslint-plugin-regexp/dist/configs/flat/recommended")' is not assignable to parameter of type 'ConfigWithExtends'.
                                     // (see more below)
)
```

Error message:

```
Argument of type 'typeof import("/Users/k/p/project/node_modules/eslint-plugin-regexp/dist/configs/flat/recommended")' is not assignable to parameter of type 'ConfigWithExtends'.
  Types of property 'rules' are incompatible.
    Type '{ "no-control-regex": string; "no-misleading-character-class": string; "no-regex-spaces": string; "prefer-regex-literals": string; "no-invalid-regexp": string; "no-useless-backreference": string; ... 60 more ...; "regexp/use-ignore-case": string; }' is not assignable to type 'Partial<Record<string, RuleEntry>>'.
      Property '"no-control-regex"' is incompatible with index signature.
        Type 'string' is not assignable to type 'RuleEntry | undefined'.ts(2345)
```

This is because [the types for `typescript-eslint` require a string of `'error'`,  `'off'` or `'warn'`](https://github.com/typescript-eslint/typescript-eslint/blob/8d92ba8533e65360877de1af12979c42b6c836e2/packages/utils/src/ts-eslint/Config.ts#L11)

To avoid the type mismatch when using `typescript-eslint`, this PR aims to generate string literal config property values instead of [the current property values of `string`](https://unpkg.com/browse/eslint-plugin-regexp@2.5.0/dist/configs/rules/recommended.d.ts)