### PR TITLE
fix: `no-unused-capturing-group` rule match error

### DIFF
--- a/docs/rules/no-unused-capturing-group.md
+++ b/docs/rules/no-unused-capturing-group.md
@@ -26,6 +26,7 @@ This rule reports unused capturing groups.
 
 /* ✓ GOOD */
 var replaced = '2000-12-31'.replace(/(\d{4})-(\d{2})-(\d{2})/, '$1/$2/$3') // "2000/12/31"
+var replaced = '2000-12-31'.replace(/(\d{4})-(\d{2})-(\d{2})/, '$3') // "31"
 var replaced = '2000-12-31'.replace(/(?<y>\d{4})-(?<m>\d{2})-(?<d>\d{2})/u, '$<y>/$<m>/$<d>') // "2000/12/31"
 var replaced = '2000-12-31'.replace(/(\d{4})-(\d{2})-(\d{2})/, (_, y, m, d) => `${y}/${m}/${d}`) // "2000/12/31"
 

--- a/lib/rules/no-unused-capturing-group.ts
+++ b/lib/rules/no-unused-capturing-group.ts
@@ -140,11 +140,21 @@ export default createRule("no-unused-capturing-group", {
             }
 
             return {
-                unusedIndexRef(index: number): boolean {
+                unusedIndexRef(index: number, groupTotal: number): boolean {
                     if (hasSplit) {
                         return false
                     }
-                    return !indexRefs.includes(index)
+                    if (!indexRefs.length) {
+                        return true
+                    }
+                    if (indexRefs.includes(index)) {
+                        return false
+                    }
+                    const _indexRefs = indexRefs.filter((i) => i <= groupTotal)
+                    if (!indexRefs.length) {
+                        return true
+                    }
+                    return _indexRefs.every((i) => i < index)
                 },
                 unusedNamedRef(name: string): boolean {
                     if (hasUnknownName) {
@@ -169,7 +179,10 @@ export default createRule("no-unused-capturing-group", {
                 const cgNode = allCapturingGroups[index]
                 if (
                     cgNode.references.length ||
-                    !references.unusedIndexRef(index + 1)
+                    !references.unusedIndexRef(
+                        index + 1,
+                        allCapturingGroups.length,
+                    )
                 ) {
                     continue
                 }


### PR DESCRIPTION
When the regular expression of the following group is used in the match, the previous group should also be considered to be used.