### PR TITLE
feat: support explicit comparisons to null for prefer-regexp-test

### DIFF
--- a/.changeset/polite-berries-kiss.md
+++ b/.changeset/polite-berries-kiss.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+feat: support explicit comparisons to null for prefer-regexp-test

--- a/lib/utils/ast-utils/utils.ts
+++ b/lib/utils/ast-utils/utils.ts
@@ -222,6 +222,7 @@ export function findFunction(
 export type KnownMethodCall = CallExpression & {
     callee: MemberExpression & { object: Expression; property: Identifier }
     arguments: Expression[]
+    parent: Node
 }
 /**
  * Checks whether given node is expected method call

--- a/tests/lib/rules/__snapshots__/prefer-regexp-test.ts.eslintsnap
+++ b/tests/lib/rules/__snapshots__/prefer-regexp-test.ts.eslintsnap
@@ -202,3 +202,67 @@ Output:
 [1] Use the `RegExp#test()` method instead of `RegExp#exec`, if you need a boolean.
 [2] Use the `RegExp#test()` method instead of `String#match`, if you need a boolean.
 ---
+
+
+Test: prefer-regexp-test >> invalid
+Code:
+  1 |
+  2 |         const text = 'something';
+  3 |         const pattern = /thing/;
+  4 |         const a = pattern.exec(test) === null;
+    |                           ^~~~ [1]
+  5 |         const b = pattern.exec(test) !== null;
+    |                           ^~~~ [2]
+  6 |         const c = text.match(pattern) === null;
+    |                   ^~~~~~~~~~~~~~~~~~~ [3]
+  7 |         const d = text.match(pattern) !== null;
+    |                   ^~~~~~~~~~~~~~~~~~~ [4]
+  8 |             
+
+Output:
+  1 |
+  2 |         const text = 'something';
+  3 |         const pattern = /thing/;
+  4 |         const a = !pattern.test(test);
+  5 |         const b = pattern.test(test);
+  6 |         const c = !pattern.test(text);
+  7 |         const d = pattern.test(text);
+  8 |             
+
+[1] Use the `RegExp#test()` method instead of `RegExp#exec`, if you need a boolean.
+[2] Use the `RegExp#test()` method instead of `RegExp#exec`, if you need a boolean.
+[3] Use the `RegExp#test()` method instead of `String#match`, if you need a boolean.
+[4] Use the `RegExp#test()` method instead of `String#match`, if you need a boolean.
+---
+
+
+Test: prefer-regexp-test >> invalid
+Code:
+  1 |
+  2 |         const text = 'something';
+  3 |         const pattern = /thing/;
+  4 |         const a = pattern.exec(test)=== null;
+    |                           ^~~~ [1]
+  5 |         const b = pattern.exec(test) /* Comment */ !== null;
+    |                           ^~~~ [2]
+  6 |         const c = text.match(pattern) === /** Comment */ null;
+    |                   ^~~~~~~~~~~~~~~~~~~ [3]
+  7 |         const d = (text.match(pattern)) !== null;
+    |                    ^~~~~~~~~~~~~~~~~~~ [4]
+  8 |             
+
+Output:
+  1 |
+  2 |         const text = 'something';
+  3 |         const pattern = /thing/;
+  4 |         const a = !pattern.test(test);
+  5 |         const b = pattern.test(test) /* Comment */;
+  6 |         const c = !pattern.test(text);
+  7 |         const d = (pattern.test(text));
+  8 |             
+
+[1] Use the `RegExp#test()` method instead of `RegExp#exec`, if you need a boolean.
+[2] Use the `RegExp#test()` method instead of `RegExp#exec`, if you need a boolean.
+[3] Use the `RegExp#test()` method instead of `String#match`, if you need a boolean.
+[4] Use the `RegExp#test()` method instead of `String#match`, if you need a boolean.
+---

--- a/tests/lib/rules/prefer-regexp-test.ts
+++ b/tests/lib/rules/prefer-regexp-test.ts
@@ -38,6 +38,14 @@ tester.run("prefer-regexp-test", rule as any, {
         const pattern = /thin[[g]]/v;
         if (pattern.test(text)) {}
         `,
+        `
+        const text = 'something';
+        const pattern = /thing/;
+        const a = pattern.exec(test) instanceof null;
+        const b = pattern.exec(test) === maybeNull; 
+        const c = pattern.exec(test).groups !== undefined;
+        const d = text.match(pattern) != null;
+        `,
     ],
     invalid: [
         `
@@ -97,6 +105,22 @@ tester.run("prefer-regexp-test", rule as any, {
             const pattern = /thin[[g]]/v;
             if (pattern.exec(text)) {}
             if (text.match(pattern)) {}
+            `,
+        `
+        const text = 'something';
+        const pattern = /thing/;
+        const a = pattern.exec(test) === null;
+        const b = pattern.exec(test) !== null;
+        const c = text.match(pattern) === null;
+        const d = text.match(pattern) !== null;
+            `,
+        `
+        const text = 'something';
+        const pattern = /thing/;
+        const a = pattern.exec(test)=== null;
+        const b = pattern.exec(test) /* Comment */ !== null;
+        const c = text.match(pattern) === /** Comment */ null;
+        const d = (text.match(pattern)) !== null;
             `,
     ],
 })


### PR DESCRIPTION
Add support for explicit comparisons in the `prefer-regexp-test` rule:
```javascript
pattern.exec(string) !== null
// is fixed to
pattern.test(string)
```
Adding the additional check for `!== null` was straightforward but adding the fix was not.
But I hope, the code is still understandable.
Fixes #838