### PR TITLE
refctor: replace indexOf with strict equality

### DIFF
--- a/.changeset/serious-plants-decide.md
+++ b/.changeset/serious-plants-decide.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": minor
+---
+
+refctor: replace `indexOf()` with strict equality

--- a/lib/rules/sort-character-class-elements.ts
+++ b/lib/rules/sort-character-class-elements.ts
@@ -296,17 +296,17 @@ function escapeRaw(node: CharacterClassElement, target: CharacterClassElement) {
         ) {
             raw = `\\${raw}`
         }
-    } else if (raw[0] === "^") {
+    } else if (raw.startsWith("^")) {
         const parent = target.parent as CharacterClass
         const elements: (
             | UnicodeSetsCharacterClassElement
             | ClassRangesCharacterClassElement
         )[] = parent.elements
-        if (elements.indexOf(target) === 0) {
+        if (elements[0] === target) {
             raw = `\\${raw}`
         }
     }
-    if (target.raw[0] === "-") {
+    if (target.raw.startsWith("-")) {
         if (node.type === "Character" || node.type === "CharacterSet") {
             raw = `${raw}\\`
         }

--- a/lib/rules/sort-character-class-elements.ts
+++ b/lib/rules/sort-character-class-elements.ts
@@ -302,7 +302,7 @@ function escapeRaw(node: CharacterClassElement, target: CharacterClassElement) {
             | UnicodeSetsCharacterClassElement
             | ClassRangesCharacterClassElement
         )[] = parent.elements
-        if (elements[0] === target) {
+        if (elements.indexOf(target) === 0) {
             raw = `\\${raw}`
         }
     }

--- a/lib/rules/sort-character-class-elements.ts
+++ b/lib/rules/sort-character-class-elements.ts
@@ -296,17 +296,17 @@ function escapeRaw(node: CharacterClassElement, target: CharacterClassElement) {
         ) {
             raw = `\\${raw}`
         }
-    } else if (raw.startsWith("^")) {
+    } else if (raw[0] === "^") {
         const parent = target.parent as CharacterClass
         const elements: (
             | UnicodeSetsCharacterClassElement
             | ClassRangesCharacterClassElement
         )[] = parent.elements
-        if (elements.indexOf(target) === 0) {
+        if (elements[0] === target) {
             raw = `\\${raw}`
         }
     }
-    if (target.raw.startsWith("-")) {
+    if (target.raw[0] === "-") {
         if (node.type === "Character" || node.type === "CharacterSet") {
             raw = `${raw}\\`
         }


### PR DESCRIPTION
When determining the value of the first letter of a string, using strict equality is more efficient than startsWith. refer to [link](https://perf.link/#eyJpZCI6InpyZjd5OHg5Mm13IiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMCkua2V5cygpXS5tYXAoKCkgPT4gTWF0aC5yYW5kb20oKS50b1N0cmluZygxNikpIiwidGVzdHMiOlt7Im5hbWUiOiJGaW5kIGl0ZW0gMTAwIiwiY29kZSI6ImRhdGEuZmluZCh4ID0%2BIHguc3RhcnRzV2l0aCgnLicpKSIsInJ1bnMiOls2MDAwMCw1NTAwMCw1NzAwMCw3MjAwMCwyNzAwMCw5MzAwMCw5NjAwMCw4MTAwMCwxMTEwMDAsMzAwMCwyODAwMCwxMzAwMDAsMTUwMDAsMjEwMDAsMTU0MDAwLDEwMDAsNTYwMDAsODkwMDAsMzkwMDAsMzMwMDAsMTIwMDAsMzAwMCwyNDAwMCw0MDAwMCwxMjAwMCwxMjAwMCwzNjAwMCwxNTYwMDAsMTA3MDAwLDIwMDAwLDE3MjAwMCwzMzAwMCwyNTAwMCw3MDAwLDEzMDAwLDEyNTAwMCwxNTYwMDAsMTMwMDAsNTgwMDAsMTY5MDAwLDEyMDAwLDIwMDAsMTkwMDAsNDYwMDAsMzAwMCw3NTAwMCwzNDAwMCwxOTAwMCw4NTAwMCwxMzkwMDAsMTY3MDAwLDM4MDAwLDQzMDAwLDQ1MDAwLDM3MDAwLDMzMDAwLDg4MDAwLDE4MDAwLDM3MDAwLDI5MDAwLDQwMDAwLDM0MDAwLDYwMDAwLDQ1MDAwLDEyMzAwMCwyMDAwMCwxMDAwMCw3NjAwMCwxNDAwMCw1NDAwMCw0MzAwMCw3NzAwMCw1MDAwLDU2MDAwLDIwMDAsNDkwMDAsNDMwMDAsNDUwMDAsNDcwMDAsNzQwMDAsMzEwMDAsMjkwMDAsMzkwMDAsMzQwMDAsNDgwMDAsNTIwMDAsMTIwMDAsMjIwMDAsMjAwMCwyMDAwLDIwMDAwLDE1MDAwLDU0MDAwLDQ1MDAwLDkwMDAsMjAwMDAsMTQwMDAsNzAwMCw1NDAwMCw0MTAwMF0sIm9wcyI6NDg1MDB9LHsibmFtZSI6IkZpbmQgaXRlbSAyMDAiLCJjb2RlIjoiZGF0YS5maW5kKHggPT4geFswXSA9PT0gJy4nKSIsInJ1bnMiOls4NTAwMCw3NzAwMCw4NzAwMCw5MjAwMCwyOTAwMCwxMTMwMDAsMTE5MDAwLDExMDAwMCwxMzUwMDAsMTAwMCwzMjAwMCwxNTUwMDAsMjMwMDAsMzMwMDAsMTEzMDAwLDE2NTAwMCw3NDAwMCwxMTQwMDAsMjMwMDAsNDIwMDAsMTAwMDAsMTM4MDAwLDQyMDAwLDU2MDAwLDE3MDAwLDE4MDAwMCw0NjAwMCwxNzcwMDAsMTM1MDAwLDIxMDAwLDE2NzAwMCwzNDAwMCwxOTAwMCw4MDAwLDQwMDAsMTU0MDAwLDE3ODAwMCwxOTYwMDAsODQwMDAsMTg3MDAwLDE2MDAwLDExMDAwLDI0MDAwLDQ3MDAwLDE4NDAwMCw5MzAwMCw0NzAwMCwxOTYwMDAsOTAwMDAsMTY2MDAwLDE4MTAwMCw1MDAwMCwzOTAwMCw1NDAwMCw1NjAwMCwzODAwMCwxMTIwMDAsMjQwMDAsNTEwMDAsNDQwMDAsMzMwMDAsNDUwMDAsNzUwMDAsMjUwMDAsMTQyMDAwLDExMDAwLDE4MzAwMCw5NjAwMCwxMDAwLDUxMDAwLDU3MDAwLDk5MDAwLDE5NjAwMCw3MTAwMCwyMDAwLDY5MDAwLDY2MDAwLDYxMDAwLDY1MDAwLDEwMzAwMCwzNTAwMCwyMTAwMCw1MjAwMCw1OTAwMCwyMzAwMCw0NTAwMCwxMzgwMDAsMzMwMDAsMjAwMCwyMDAwLDI4MDAwLDExMDAwLDU4MDAwLDYyMDAwLDYwMDAsMzAwMDAsMTMwMDAsMjAwMCw3MTAwMCw2NDAwMF0sIm9wcyI6NzIwNDB9XSwidXBkYXRlZCI6IjIwMjUtMDgtMDdUMTQ6MTI6NTUuNDEwWiJ9)