### PR TITLE
Handle matchAll().toArray() capture usage

### DIFF
--- a/.changeset/matchall-toarray-captures.md
+++ b/.changeset/matchall-toarray-captures.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": patch
+---
+
+Handle matchAll().toArray() capture usage

--- a/lib/utils/extract-capturing-group-references.ts
+++ b/lib/utils/extract-capturing-group-references.ts
@@ -136,7 +136,9 @@ type ExtractCapturingGroupReferencesContext = {
     isString: (node: Expression) => boolean
 }
 
-type ArrayMethodName = Exclude<keyof unknown[], "length" | symbol | number>
+type ArrayMethodName =
+    | Exclude<keyof unknown[], "length" | symbol | number>
+    | "toArray"
 const WELL_KNOWN_ARRAY_METHODS: {
     [key in ArrayMethodName]: {
         // If specified, the method receives a function that iterates the element.
@@ -191,6 +193,8 @@ const WELL_KNOWN_ARRAY_METHODS: {
     toSorted: { elementParameters: [0, 1], result: "array" },
     toSpliced: { result: "array" },
     with: { result: "array" },
+    // Iterator helpers
+    toArray: { result: "array" },
 }
 
 /**

--- a/tests/lib/rules/__snapshots__/no-unused-capturing-group.ts.eslintsnap
+++ b/tests/lib/rules/__snapshots__/no-unused-capturing-group.ts.eslintsnap
@@ -734,6 +734,25 @@ Options:
   - fixable: true
 
 Code:
+  1 | const bs = 'abc_abc'.matchAll(/a(b)/g).toArray().map(m => m[0])
+    |                                 ^~~ [1]
+
+Output:
+  1 | const bs = 'abc_abc'.matchAll(/a(?:b)/g).toArray().map(m => m[0])
+
+[1] Capturing group number 1 is defined but never used.
+    Suggestions:
+      - Making this a non-capturing group.
+        Output:
+          1 | const bs = 'abc_abc'.matchAll(/a(?:b)/g).toArray().map(m => m[0])
+---
+
+
+Test: no-unused-capturing-group >> invalid
+Options:
+  - fixable: true
+
+Code:
   1 |
   2 |             ;[...'abc_abc'.matchAll(/a(b)(c)/g)].forEach(m => console.log(m[1]))
     |                                          ^~~ [1]

--- a/tests/lib/rules/no-unused-capturing-group.ts
+++ b/tests/lib/rules/no-unused-capturing-group.ts
@@ -133,6 +133,9 @@ tester.run("no-unused-capturing-group", rule as any, {
         const matches = [...('2000-12-31 2000-12-31'.matchAll(/(\d{4})-(\d{2})-(\d{2})/g))]
         `,
         String.raw`
+        console.log('asd'.matchAll(/as(d)/gu).toArray())
+        `,
+        String.raw`
         const bs = [...'abc_abc'.matchAll(/a(b)/g)].map(m => m[1])
         `,
         String.raw`

--- a/tests/lib/rules/no-unused-capturing-group.ts
+++ b/tests/lib/rules/no-unused-capturing-group.ts
@@ -136,6 +136,9 @@ tester.run("no-unused-capturing-group", rule as any, {
         console.log('asd'.matchAll(/as(d)/gu).toArray())
         `,
         String.raw`
+        const bs = 'abc_abc'.matchAll(/a(b)/g).toArray().map(m => m[1])
+        `,
+        String.raw`
         const bs = [...'abc_abc'.matchAll(/a(b)/g)].map(m => m[1])
         `,
         String.raw`
@@ -300,6 +303,10 @@ tester.run("no-unused-capturing-group", rule as any, {
             code: String.raw`
             const bs = [...'abc_abc'.matchAll(/a(b)/g)].map(m => m[0])
             `,
+            options: [{ fixable: true }],
+        },
+        {
+            code: String.raw`const bs = 'abc_abc'.matchAll(/a(b)/g).toArray().map(m => m[0])`,
             options: [{ fixable: true }],
         },
         {


### PR DESCRIPTION
`no-unused-capturing-group` could report captures as unused when match results were consumed through `matchAll(...).toArray()`.
This treats iterator-helper `toArray()` as consuming the match arrays, matching the existing behavior for other result-consumption paths. I checked the red-to-green repro, the focused rule suite with 68 passing, typecheck, build, lint, and `git diff --check`.
Fixes #986