### PR TITLE
docs: explain escape-case compatibility

### DIFF
--- a/docs/rules/letter-case.md
+++ b/docs/rules/letter-case.md
@@ -60,6 +60,23 @@ var foo = /\ca/
   - `hexadecimalEscape` ... Specifies the letter case when the hexadecimal escapes. Default is `"lowercase"`.
   - `controlEscape` ... Specifies the letter case when the control escapes (e.g. `\cX`). Default is `"uppercase"`.
 
+### Compatibility with `unicorn/escape-case`
+
+The default `"lowercase"` values for `unicodeEscape` and `hexadecimalEscape`
+conflict with the default `"uppercase"` style of
+[`unicorn/escape-case`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/escape-case.md).
+To use both rules with Unicorn's default, configure both properties as `"uppercase"`:
+
+```json5
+{
+  "unicorn/escape-case": "error",
+  "regexp/letter-case": ["error", {
+    "unicodeEscape": "uppercase",
+    "hexadecimalEscape": "uppercase",
+  }],
+}
+```
+
 ## :rocket: Version
 
 This rule was introduced in eslint-plugin-regexp v0.3.0


### PR DESCRIPTION
## Summary

Documents the default conflict between `regexp/letter-case` and `unicorn/escape-case`.

The new compatibility note shows how to align both Unicode and hexadecimal escape handling with Unicorn's default uppercase style. Configuring both properties is necessary to avoid circular autofixes for `\u` and `\x` escapes.

Closes #743.

## Validation

- `npm run build`
- `npm run update`
- `npm run lint:docs`
- `npm run docs:build`
- Verified the documented configuration against Unicode, hexadecimal, and control escapes
- `git diff --check`
