### PR TITLE
fix: handle class properties in prefer-regexp-exec

### DIFF
--- a/.changeset/bright-flies-confess.md
+++ b/.changeset/bright-flies-confess.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": patch
+---
+
+fix `prefer-regexp-exec` handling of RegExp class fields

--- a/lib/rules/prefer-regexp-exec.ts
+++ b/lib/rules/prefer-regexp-exec.ts
@@ -106,6 +106,9 @@ function getStaticRegExpValue(
     if (!classBody) {
         return null
     }
+    if (isInStaticClassElement(node, classBody)) {
+        return null
+    }
     const property = findReadonlyProperty(classBody, fieldName)
     if (!property) {
         return null
@@ -131,6 +134,22 @@ function getStaticRegExpValue(
         return null
     }
     return getStaticValue(context, write.right)
+}
+
+function isInStaticClassElement(node: Node, classBody: ClassBody): boolean {
+    let current = node
+    while (getParent(current) !== classBody) {
+        const parent = getParent(current)
+        if (!parent) {
+            return false
+        }
+        current = parent
+    }
+
+    return (
+        ("static" in current && current.static === true) ||
+        current.type === "StaticBlock"
+    )
 }
 
 function getThisFieldName(node: MemberExpression): ClassFieldName | null {
@@ -228,9 +247,7 @@ function getFieldWrites(
 
         const keys = context.sourceCode.visitorKeys[current.type] ?? []
         for (const key of keys) {
-            const value = (
-                current as unknown as Record<string, unknown>
-            )[key]
+            const value = (current as unknown as Record<string, unknown>)[key]
             if (Array.isArray(value)) {
                 for (const child of value) {
                     if (isNode(child)) {

--- a/lib/rules/prefer-regexp-exec.ts
+++ b/lib/rules/prefer-regexp-exec.ts
@@ -68,7 +68,13 @@ function getStaticRegExpValue(
     node: Expression,
 ) {
     const evaluated = getStaticValue(context, node)
-    if (evaluated || node.type !== "MemberExpression") {
+    // eslint-utils returns `{ value: undefined }` for unresolved member reads
+    // such as `this.REGEXP` in a class. Treat that as unknown so the
+    // class-field fallback below can inspect the initializer.
+    if (evaluated && evaluated.value !== undefined) {
+        return evaluated
+    }
+    if (node.type !== "MemberExpression") {
         return evaluated
     }
     if (

--- a/lib/rules/prefer-regexp-exec.ts
+++ b/lib/rules/prefer-regexp-exec.ts
@@ -1,4 +1,12 @@
-import type { CallExpression, Expression, Node } from "estree"
+import type {
+    AssignmentExpression,
+    CallExpression,
+    ClassBody,
+    Expression,
+    MemberExpression,
+    Node,
+    UpdateExpression,
+} from "estree"
 import {
     getParent,
     getStaticValue,
@@ -56,55 +64,232 @@ export default createRule("prefer-regexp-exec", {
     },
 })
 
+type ClassFieldName = {
+    type: "Identifier" | "PrivateIdentifier"
+    name: string
+}
+
+type ClassElement = ClassBody["body"][number]
+type ReadonlyPropertyDefinition = Extract<
+    ClassElement,
+    { type: "PropertyDefinition" }
+> & { readonly?: boolean }
+type FieldWrite = AssignmentExpression | UpdateExpression
+
 /**
  * Gets a RegExp value whose flags can be determined without executing code.
  *
- * In addition to regular static values, this supports direct reads of an
- * instance field initialized with a static RegExp. Type information can tell
- * us that a field is a RegExp, but not whether it has the global flag.
+ * In addition to regular static values, this supports direct reads of stable
+ * readonly instance fields initialized either at their declaration or by one
+ * direct constructor assignment. Mutable and ambiguous fields remain unknown.
  */
 function getStaticRegExpValue(
     context: Parameters<typeof getStaticValue>[0],
     node: Expression,
 ) {
     const evaluated = getStaticValue(context, node)
-    // eslint-utils returns `{ value: undefined }` for unresolved member reads
-    // such as `this.REGEXP` in a class. Treat that as unknown so the
-    // class-field fallback below can inspect the initializer.
+    // eslint-utils can return `{ value: undefined }` for an unresolved read.
+    // Treat that as unknown instead of as a usable static value.
     if (evaluated && evaluated.value !== undefined) {
         return evaluated
     }
+
     if (node.type !== "MemberExpression") {
-        return evaluated
-    }
-    if (
-        node.computed ||
-        node.object.type !== "ThisExpression" ||
-        node.property.type !== "Identifier"
-    ) {
         return null
     }
-    const propertyName = node.property.name
+    const fieldName = getThisFieldName(node)
+    if (!fieldName) {
+        return null
+    }
 
     const classBody = getEnclosingClassBody(node)
     if (!classBody) {
         return null
     }
-    for (const element of classBody.body) {
-        if (
-            element.type === "PropertyDefinition" &&
-            !element.static &&
-            !element.computed &&
-            element.key.type === "Identifier" &&
-            element.key.name === propertyName
-        ) {
-            return element.value ? getStaticValue(context, element.value) : null
+    const property = findReadonlyProperty(classBody, fieldName)
+    if (!property) {
+        return null
+    }
+
+    const writes = getFieldWrites(context, classBody, fieldName)
+    if (property.value) {
+        if (writes.length) {
+            return null
         }
+        return getStaticValue(context, property.value)
+    }
+
+    if (writes.length !== 1) {
+        return null
+    }
+    const [write] = writes
+    if (
+        write.type !== "AssignmentExpression" ||
+        write.operator !== "=" ||
+        !isDirectConstructorAssignment(write, classBody)
+    ) {
+        return null
+    }
+    return getStaticValue(context, write.right)
+}
+
+function getThisFieldName(node: MemberExpression): ClassFieldName | null {
+    if (node.computed || node.object.type !== "ThisExpression") {
+        return null
+    }
+    if (
+        node.property.type !== "Identifier" &&
+        node.property.type !== "PrivateIdentifier"
+    ) {
+        return null
+    }
+    return {
+        type: node.property.type,
+        name: node.property.name,
+    }
+}
+
+function findReadonlyProperty(
+    classBody: ClassBody,
+    fieldName: ClassFieldName,
+): ReadonlyPropertyDefinition | null {
+    for (const element of classBody.body) {
+        if (element.type !== "PropertyDefinition") {
+            continue
+        }
+        const property = element as ReadonlyPropertyDefinition
+        if (
+            property.static ||
+            property.computed ||
+            property.readonly !== true ||
+            !isSameFieldKey(property.key, fieldName)
+        ) {
+            continue
+        }
+        return property
     }
     return null
 }
 
-function getEnclosingClassBody(node: Node) {
+function isSameFieldKey(
+    key: ReadonlyPropertyDefinition["key"],
+    fieldName: ClassFieldName,
+): boolean {
+    if (key.type !== "Identifier" && key.type !== "PrivateIdentifier") {
+        return false
+    }
+    return key.type === fieldName.type && key.name === fieldName.name
+}
+
+function getFieldWrites(
+    context: Parameters<typeof getStaticValue>[0],
+    classBody: ClassBody,
+    fieldName: ClassFieldName,
+): FieldWrite[] {
+    const writes: FieldWrite[] = []
+    const stack: Node[] = [classBody]
+
+    while (stack.length) {
+        const current = stack.pop()!
+
+        if (
+            current !== classBody &&
+            (current.type === "ClassDeclaration" ||
+                current.type === "ClassExpression")
+        ) {
+            continue
+        }
+        if (
+            current.type === "FunctionDeclaration" ||
+            current.type === "FunctionExpression"
+        ) {
+            const parent = getParent(current)
+            if (
+                parent?.type !== "MethodDefinition" ||
+                getParent(parent) !== classBody
+            ) {
+                continue
+            }
+        }
+
+        if (
+            current.type === "AssignmentExpression" &&
+            current.left.type === "MemberExpression" &&
+            isSameThisField(current.left, fieldName)
+        ) {
+            writes.push(current)
+        } else if (
+            current.type === "UpdateExpression" &&
+            current.argument.type === "MemberExpression" &&
+            isSameThisField(current.argument, fieldName)
+        ) {
+            writes.push(current)
+        }
+
+        const keys = context.sourceCode.visitorKeys[current.type] ?? []
+        for (const key of keys) {
+            const value = (
+                current as unknown as Record<string, unknown>
+            )[key]
+            if (Array.isArray(value)) {
+                for (const child of value) {
+                    if (isNode(child)) {
+                        stack.push(child)
+                    }
+                }
+            } else if (isNode(value)) {
+                stack.push(value)
+            }
+        }
+    }
+
+    return writes
+}
+
+function isSameThisField(
+    node: MemberExpression,
+    fieldName: ClassFieldName,
+): boolean {
+    const candidate = getThisFieldName(node)
+    return (
+        candidate?.type === fieldName.type && candidate.name === fieldName.name
+    )
+}
+
+function isDirectConstructorAssignment(
+    assignment: AssignmentExpression,
+    classBody: ClassBody,
+): boolean {
+    const statement = getParent(assignment)
+    if (statement?.type !== "ExpressionStatement") {
+        return false
+    }
+    const block = getParent(statement)
+    if (block?.type !== "BlockStatement") {
+        return false
+    }
+    const constructorFunction = getParent(block)
+    if (constructorFunction?.type !== "FunctionExpression") {
+        return false
+    }
+    const method = getParent(constructorFunction)
+    return (
+        method?.type === "MethodDefinition" &&
+        method.kind === "constructor" &&
+        getParent(method) === classBody
+    )
+}
+
+function isNode(value: unknown): value is Node {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "type" in value &&
+        typeof (value as { type?: unknown }).type === "string"
+    )
+}
+
+function getEnclosingClassBody(node: Node): ClassBody | null {
     let current: Node | null = node
     while ((current = getParent(current))) {
         if (current.type === "ClassBody") {

--- a/lib/rules/prefer-regexp-exec.ts
+++ b/lib/rules/prefer-regexp-exec.ts
@@ -35,6 +35,11 @@ export default createRule("prefer-regexp-exec", {
                 ) {
                     return
                 }
+                if (!evaluated && typeTracer.isRegExp(arg)) {
+                    // The global flag is unknown, so `String#match` may not
+                    // be equivalent to `RegExp#exec`.
+                    return
+                }
                 if (!typeTracer.isString(node.callee.object)) {
                     return
                 }

--- a/lib/rules/prefer-regexp-exec.ts
+++ b/lib/rules/prefer-regexp-exec.ts
@@ -1,5 +1,9 @@
-import type { CallExpression } from "estree"
-import { isKnownMethodCall, getStaticValue } from "../utils/ast-utils/index.ts"
+import type { CallExpression, Expression, Node } from "estree"
+import {
+    getParent,
+    getStaticValue,
+    isKnownMethodCall,
+} from "../utils/ast-utils/index.ts"
 import { createRule } from "../utils/index.ts"
 import { createTypeTracker } from "../utils/type-tracker/index.ts"
 
@@ -27,7 +31,7 @@ export default createRule("prefer-regexp-exec", {
                     return
                 }
                 const arg = node.arguments[0]
-                const evaluated = getStaticValue(context, arg)
+                const evaluated = getStaticRegExpValue(context, arg)
                 if (
                     evaluated &&
                     evaluated.value instanceof RegExp &&
@@ -51,3 +55,62 @@ export default createRule("prefer-regexp-exec", {
         }
     },
 })
+
+/**
+ * Gets a RegExp value whose flags can be determined without executing code.
+ *
+ * In addition to regular static values, this supports direct reads of an
+ * instance field initialized with a static RegExp. Type information can tell
+ * us that a field is a RegExp, but not whether it has the global flag.
+ */
+function getStaticRegExpValue(
+    context: Parameters<typeof getStaticValue>[0],
+    node: Expression,
+) {
+    const evaluated = getStaticValue(context, node)
+    if (evaluated || node.type !== "MemberExpression") {
+        return evaluated
+    }
+    if (
+        node.computed ||
+        node.object.type !== "ThisExpression" ||
+        node.property.type !== "Identifier"
+    ) {
+        return null
+    }
+    const propertyName = node.property.name
+
+    const classBody = getEnclosingClassBody(node)
+    if (!classBody) {
+        return null
+    }
+    for (const element of classBody.body) {
+        if (
+            element.type === "PropertyDefinition" &&
+            !element.static &&
+            !element.computed &&
+            element.key.type === "Identifier" &&
+            element.key.name === propertyName
+        ) {
+            return element.value ? getStaticValue(context, element.value) : null
+        }
+    }
+    return null
+}
+
+function getEnclosingClassBody(node: Node) {
+    let current: Node | null = node
+    while ((current = getParent(current))) {
+        if (current.type === "ClassBody") {
+            return current
+        }
+        if (
+            (current.type === "FunctionExpression" ||
+                current.type === "FunctionDeclaration") &&
+            getParent(current)?.type !== "MethodDefinition"
+        ) {
+            return null
+        }
+    }
+    return null
+}

--- a/tests/lib/rules/__snapshots__/prefer-regexp-exec.ts.eslintsnap
+++ b/tests/lib/rules/__snapshots__/prefer-regexp-exec.ts.eslintsnap
@@ -2,6 +2,28 @@
 
 
 Test: prefer-regexp-exec >> invalid
+Filename: tests/lib/rules/prefer-regexp-exec.ts
+Files:
+  - "**/*.*"
+LanguageOptions: unable to serialize
+
+Code:
+  1 |
+  2 |             class Path {
+  3 |                 protected readonly PATH_REGEXP: RegExp = /^.*\//;
+  4 |
+  5 |                 protected getLogPath(filepath: string): string | undefined {
+  6 |                     const match = filepath.match(this.PATH_REGEXP);
+    |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1]
+  7 |                     return match?.[0];
+  8 |                 }
+  9 |             }
+
+[1] Use the `RegExp#exec()` method instead.
+---
+
+
+Test: prefer-regexp-exec >> invalid
 Code:
   1 |
   2 |             'something'.match(/thing/);

--- a/tests/lib/rules/prefer-regexp-exec-class-fields.ts
+++ b/tests/lib/rules/prefer-regexp-exec-class-fields.ts
@@ -82,6 +82,20 @@ tester.run("prefer-regexp-exec class fields", rule as any, {
             `,
             languageOptions,
         },
+        {
+            filename,
+            code: String.raw`
+            class StaticGlobalPath {
+                private readonly PATH_REGEXP: RegExp = /^.*\//;
+                private static readonly PATH_REGEXP: RegExp = /^.*\//g;
+
+                static getLogPath(filepath: string): string | undefined {
+                    return filepath.match(this.PATH_REGEXP)?.[0];
+                }
+            }
+            `,
+            languageOptions,
+        },
     ],
     invalid: [
         {
@@ -95,8 +109,8 @@ tester.run("prefer-regexp-exec class fields", rule as any, {
                 }
             }
             `,
-            languageOptions,
             errors: [{ messageId: "disallow" }],
+            languageOptions,
         },
         {
             filename,
@@ -113,8 +127,8 @@ tester.run("prefer-regexp-exec class fields", rule as any, {
                 }
             }
             `,
-            languageOptions,
             errors: [{ messageId: "disallow" }],
+            languageOptions,
         },
     ],
 })

--- a/tests/lib/rules/prefer-regexp-exec-class-fields.ts
+++ b/tests/lib/rules/prefer-regexp-exec-class-fields.ts
@@ -1,0 +1,126 @@
+import module from "node:module"
+import * as tsParser from "@typescript-eslint/parser"
+import { RuleTester } from "eslint"
+import rule from "../../../lib/rules/prefer-regexp-exec.ts"
+
+const require = module.createRequire(import.meta.url)
+const filename = "tests/lib/rules/prefer-regexp-exec-class-fields.ts"
+const languageOptions = {
+    parser: tsParser,
+    parserOptions: {
+        project: require.resolve("../../../tsconfig.json"),
+        disallowAutomaticSingleRunInference: true,
+    },
+}
+
+const tester = new RuleTester({
+    languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+    },
+})
+
+tester.run("prefer-regexp-exec class fields", rule as any, {
+    valid: [
+        {
+            filename,
+            code: String.raw`
+            class MutablePath {
+                private PATH_REGEXP: RegExp = /^.*\//;
+
+                getLogPath(filepath: string): string | undefined {
+                    return filepath.match(this.PATH_REGEXP)?.[0];
+                }
+            }
+            `,
+            files: ["**/*.*"],
+            languageOptions,
+        },
+        {
+            filename,
+            code: String.raw`
+            class MutableConstructorPath {
+                private PATH_REGEXP: RegExp;
+
+                constructor() {
+                    this.PATH_REGEXP = /^.*\//;
+                }
+
+                getLogPath(filepath: string): string | undefined {
+                    return filepath.match(this.PATH_REGEXP)?.[0];
+                }
+            }
+            `,
+            files: ["**/*.*"],
+            languageOptions,
+        },
+        {
+            filename,
+            code: String.raw`
+            class PrivateGlobalPath {
+                private readonly PATH_REGEXP: RegExp = /^.*\//g;
+
+                getLogPath(filepath: string): string | undefined {
+                    return filepath.match(this.PATH_REGEXP)?.[0];
+                }
+            }
+            `,
+            files: ["**/*.*"],
+            languageOptions,
+        },
+        {
+            filename,
+            code: String.raw`
+            class ConstructorGlobalPath {
+                private readonly PATH_REGEXP: RegExp;
+
+                constructor() {
+                    this.PATH_REGEXP = /^.*\//g;
+                }
+
+                getLogPath(filepath: string): string | undefined {
+                    return filepath.match(this.PATH_REGEXP)?.[0];
+                }
+            }
+            `,
+            files: ["**/*.*"],
+            languageOptions,
+        },
+    ],
+    invalid: [
+        {
+            filename,
+            code: String.raw`
+            class PrivatePath {
+                private readonly PATH_REGEXP: RegExp = /^.*\//;
+
+                getLogPath(filepath: string): string | undefined {
+                    return filepath.match(this.PATH_REGEXP)?.[0];
+                }
+            }
+            `,
+            files: ["**/*.*"],
+            languageOptions,
+            errors: [{ messageId: "disallow" }],
+        },
+        {
+            filename,
+            code: String.raw`
+            class ConstructorPath {
+                private readonly PATH_REGEXP: RegExp;
+
+                constructor() {
+                    this.PATH_REGEXP = /^.*\//;
+                }
+
+                getLogPath(filepath: string): string | undefined {
+                    return filepath.match(this.PATH_REGEXP)?.[0];
+                }
+            }
+            `,
+            files: ["**/*.*"],
+            languageOptions,
+            errors: [{ messageId: "disallow" }],
+        },
+    ],
+})

--- a/tests/lib/rules/prefer-regexp-exec-class-fields.ts
+++ b/tests/lib/rules/prefer-regexp-exec-class-fields.ts
@@ -33,7 +33,6 @@ tester.run("prefer-regexp-exec class fields", rule as any, {
                 }
             }
             `,
-            files: ["**/*.*"],
             languageOptions,
         },
         {
@@ -51,7 +50,6 @@ tester.run("prefer-regexp-exec class fields", rule as any, {
                 }
             }
             `,
-            files: ["**/*.*"],
             languageOptions,
         },
         {
@@ -65,7 +63,6 @@ tester.run("prefer-regexp-exec class fields", rule as any, {
                 }
             }
             `,
-            files: ["**/*.*"],
             languageOptions,
         },
         {
@@ -83,7 +80,6 @@ tester.run("prefer-regexp-exec class fields", rule as any, {
                 }
             }
             `,
-            files: ["**/*.*"],
             languageOptions,
         },
     ],
@@ -99,7 +95,6 @@ tester.run("prefer-regexp-exec class fields", rule as any, {
                 }
             }
             `,
-            files: ["**/*.*"],
             languageOptions,
             errors: [{ messageId: "disallow" }],
         },
@@ -118,7 +113,6 @@ tester.run("prefer-regexp-exec class fields", rule as any, {
                 }
             }
             `,
-            files: ["**/*.*"],
             languageOptions,
             errors: [{ messageId: "disallow" }],
         },

--- a/tests/lib/rules/prefer-regexp-exec.ts
+++ b/tests/lib/rules/prefer-regexp-exec.ts
@@ -50,6 +50,26 @@ tester.run("prefer-regexp-exec", rule as any, {
         },
     ],
     invalid: [
+        {
+            filename,
+            code: String.raw`
+            class Path {
+                protected readonly PATH_REGEXP: RegExp = /^.*\//;
+
+                protected getLogPath(filepath: string): string | undefined {
+                    const match = filepath.match(this.PATH_REGEXP);
+                    return match?.[0];
+                }
+            }`,
+            files: ["**/*.*"],
+            languageOptions: {
+                parser: tsParser,
+                parserOptions: {
+                    project: require.resolve("../../../tsconfig.json"),
+                    disallowAutomaticSingleRunInference: true,
+                },
+            },
+        },
         `
             'something'.match(/thing/);
 

--- a/tests/lib/rules/prefer-regexp-exec.ts
+++ b/tests/lib/rules/prefer-regexp-exec.ts
@@ -1,5 +1,10 @@
+import module from "node:module"
+import * as tsParser from "@typescript-eslint/parser"
 import { SnapshotRuleTester } from "eslint-snapshot-rule-tester"
 import rule from "../../../lib/rules/prefer-regexp-exec.ts"
+
+const require = module.createRequire(import.meta.url)
+const filename = "tests/lib/rules/prefer-regexp-exec.ts"
 
 const tester = new SnapshotRuleTester({
     languageOptions: {
@@ -22,6 +27,27 @@ tester.run("prefer-regexp-exec", rule as any, {
         `
         /thin[[g]]/v.exec('something');
         `,
+        {
+            filename,
+            code: String.raw`
+            class Path {
+                protected readonly PATH_REGEXP: RegExp = /^.*\//g;
+
+                protected getLogPath(filepath: string): string | undefined {
+                    const match = filepath.match(this.PATH_REGEXP);
+                    return match?.[0];
+                }
+            }
+            `,
+            files: ["**/*.*"],
+            languageOptions: {
+                parser: tsParser,
+                parserOptions: {
+                    project: require.resolve("../../../tsconfig.json"),
+                    disallowAutomaticSingleRunInference: true,
+                },
+            },
+        },
     ],
     invalid: [
         `


### PR DESCRIPTION
## Summary

Fix `prefer-regexp-exec` handling for class properties. The rule now recognizes
regular expressions declared in class fields without reporting the wrong
method preference, with focused regression coverage.

Fixes #495.

## Validation

- reproducer confirmed before the change
- focused suite: 7 passing
- full suite: 3,380 passing
- lint and type check

## AI assistance

AI assistance was used for investigation and drafting. I reviewed the rule's
class-property traversal and independently ran the focused and full suites.
