### PR TITLE
Fix Changesets v2 workflow inputs

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -40,10 +40,10 @@ jobs:
               uses: changesets/action@v2.0.0
               with:
                   # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
-                  version: npm run version:ci
+                  version-script: npm run version:ci
                   # This expects you to have a script called release which does a build for your packages and calls changeset publish
-                  publish: npm run release
-                  commit: "chore: release eslint-plugin-regexp"
-                  title: "chore: release eslint-plugin-regexp"
+                  publish-script: npm run release
+                  commit-message: "chore: release eslint-plugin-regexp"
+                  pr-title: "chore: release eslint-plugin-regexp"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow still passed the Changesets v1 input names after #1025 upgraded `changesets/action` to v2. The action rejected those inputs before it could create a release pull request or publish a package.

Use the v2 names for the version and publish scripts, commit message, and pull request title while preserving their existing values.
