### PR TITLE
Handle matchAll().take() and .drop() capture usage

### DIFF
--- a/.changeset/matchall-take-drop-captures.md
+++ b/.changeset/matchall-take-drop-captures.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-regexp": patch
+---
+
+Handle matchAll().take()/.drop() capture usage

--- a/.changeset/matchall-take-drop-captures.md
+++ b/.changeset/matchall-take-drop-captures.md
@@ -1,5 +1,5 @@
 ---
-"eslint-plugin-regexp": patch
+"eslint-plugin-regexp": minor
 ---
 
 Handle matchAll().take()/.drop() capture usage

--- a/lib/utils/extract-capturing-group-references.ts
+++ b/lib/utils/extract-capturing-group-references.ts
@@ -137,7 +137,10 @@ type ExtractCapturingGroupReferencesContext = {
 }
 
 type ArrayMethodName =
-    Exclude<keyof unknown[], "length" | symbol | number> | "toArray"
+    | Exclude<keyof unknown[], "length" | symbol | number>
+    | "toArray"
+    | "take"
+    | "drop"
 const WELL_KNOWN_ARRAY_METHODS: {
     [key in ArrayMethodName]: {
         // If specified, the method receives a function that iterates the element.
@@ -194,6 +197,8 @@ const WELL_KNOWN_ARRAY_METHODS: {
     with: { result: "array" },
     // Iterator helpers
     toArray: { result: "array" },
+    take: { result: "iterator" },
+    drop: { result: "iterator" },
 }
 
 /**

--- a/tests/lib/rules/__snapshots__/no-unused-capturing-group.ts.eslintsnap
+++ b/tests/lib/rules/__snapshots__/no-unused-capturing-group.ts.eslintsnap
@@ -753,6 +753,25 @@ Options:
   - fixable: true
 
 Code:
+  1 | const bs = 'abc_abc'.matchAll(/a(b)/g).take(2).map(m => m[0])
+    |                                 ^~~ [1]
+
+Output:
+  1 | const bs = 'abc_abc'.matchAll(/a(?:b)/g).take(2).map(m => m[0])
+
+[1] Capturing group number 1 is defined but never used.
+    Suggestions:
+      - Making this a non-capturing group.
+        Output:
+          1 | const bs = 'abc_abc'.matchAll(/a(?:b)/g).take(2).map(m => m[0])
+---
+
+
+Test: no-unused-capturing-group >> invalid
+Options:
+  - fixable: true
+
+Code:
   1 |
   2 |             ;[...'abc_abc'.matchAll(/a(b)(c)/g)].forEach(m => console.log(m[1]))
     |                                          ^~~ [1]

--- a/tests/lib/rules/no-unused-capturing-group.ts
+++ b/tests/lib/rules/no-unused-capturing-group.ts
@@ -139,6 +139,12 @@ tester.run("no-unused-capturing-group", rule, {
         const bs = 'abc_abc'.matchAll(/a(b)/g).toArray().map(m => m[1])
         `,
         `
+        for (const m of 'abc_abc'.matchAll(/a(b)(c)/g).take(2)) console.log(m[1], m[2])
+        `,
+        `
+        'abc_abc'.matchAll(/a(b)(c)/g).drop(1).toArray().forEach(m => console.log(m[1], m[2]))
+        `,
+        `
         const bs = [...'abc_abc'.matchAll(/a(b)/g)].map(m => m[1])
         `,
         `
@@ -307,6 +313,10 @@ tester.run("no-unused-capturing-group", rule, {
         },
         {
             code: "const bs = 'abc_abc'.matchAll(/a(b)/g).toArray().map(m => m[0])",
+            options: [{ fixable: true }],
+        },
+        {
+            code: "const bs = 'abc_abc'.matchAll(/a(b)/g).take(2).map(m => m[0])",
             options: [{ fixable: true }],
         },
         {


### PR DESCRIPTION
`no-unused-capturing-group` reports group 1 on this, and the suggestion it offers rewrites the regex to `/as(?:d)/gu`, which breaks the `m[1]` sat under it:

```js
for (const m of 'asd'.matchAll(/as(d)/gu).take(2)) console.log(m[1])
```

The same line with `.toArray()` instead is quiet, so its just the name. `take` and `drop` are the other two iterator helpers with no `Array.prototype` twin, which is why they cant arrive through `keyof unknown[]` like most of that table does, and #992 added `toArray` on its own. I've put a negative control in the tests as well, because `.take(2).map(m => m[0])` should still report, and it does.

Small change, so feel free to close it if you'd rather leave the table as it is.

---

One I've left alone. Any unrecognised method on a matchAll result reads as unused, not just these two, so `'asd'.matchAll(/as(d)/gu).foo()` reports exactly the same. That's a behaviour change rather than a missing name though, and it seemed like your call and not mine.
